### PR TITLE
Changelog generator: try to process multi-line list items correctly

### DIFF
--- a/antsibull/changelog/changelog_generator.py
+++ b/antsibull/changelog/changelog_generator.py
@@ -239,7 +239,7 @@ class ChangelogGenerator:
 
         if isinstance(content, list):
             for rst in sorted(content):
-                builder.add_raw_rst('- %s' % rst)
+                builder.add_list_item(rst)
         else:
             builder.add_raw_rst(content)
 

--- a/antsibull/changelog/rst.py
+++ b/antsibull/changelog/rst.py
@@ -50,6 +50,17 @@ class RstBuilder:
         """
         self.lines.append(content)
 
+    def add_list_item(self, content: str) -> None:
+        """
+        Add a list item. Content can be multi-lined.
+        """
+        lines = content.splitlines()
+        for no, line in enumerate(lines):
+            if no > 0 and not line:
+                self.lines.append('')
+                continue
+            self.lines.append('%s %s' % (' ' if no else '-', line))
+
     def generate(self) -> str:
         """
         Generate RST content.


### PR DESCRIPTION
Test fragment: https://github.com/felixfontein/ansible-versioning_test_collection/blob/8e3bba34c8c687ce02f86aa7f3f9e98142cb75df/changelogs/fragments/something-long.yml

Before PR: https://github.com/felixfontein/ansible-versioning_test_collection/blob/93c76092e36d2ad0354f864075c40cade9823587/changelogs/CHANGELOG-v2.rst#minor-changes

After first commit: https://github.com/felixfontein/ansible-versioning_test_collection/blob/8600b8dd2114d63332cb00221674c887ba0a00c9/changelogs/CHANGELOG-v2.rst#minor-changes
