### PR TITLE
Implement a cli option for specifying an ansible-base cache

### DIFF
--- a/antsibull/ansible_base.py
+++ b/antsibull/ansible_base.py
@@ -3,9 +3,11 @@
 # License: GPLv3+
 # Copyright: Ansible Project, 2020
 """Functions for working with the ansible-base package."""
+import ast
 import os
+import re
+import typing as t
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, List, Union
 from urllib.parse import urljoin
 
 import aiofiles
@@ -13,8 +15,9 @@ import packaging.version as pypiver
 import sh
 
 from .compat import best_get_loop
+from .constants import CHUNKSIZE
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     import aiohttp.client
 
 
@@ -22,28 +25,10 @@ if TYPE_CHECKING:
 ANSIBLE_BASE_URL = 'https://github.com/ansible/ansible'
 #: URL to pypi.
 PYPI_SERVER_URL = 'https://test.pypi.org/'
-#: Number of bytes to read or write in one chunk
-CHUNKSIZE = 4096
 
 
 class UnknownVersion(Exception):
     """Raised when a requested version does not exist."""
-
-
-@lru_cache
-async def checkout_from_git(download_dir: str, repo_url: str = ANSIBLE_BASE_URL) -> str:
-    """
-    Checkout the ansible-base git repo.
-
-    :arg download_dir: Directory to checkout into.
-    :kwarg: repo_url: The url to the git repo.
-    :return: The directory that ansible-base has been checked out to.
-    """
-    loop = best_get_loop()
-    ansible_base_dir = os.path.join(download_dir, 'ansible-base')
-    await loop.run_in_executor(None, sh.git, 'clone', repo_url, ansible_base_dir)
-
-    return ansible_base_dir
 
 
 class AnsibleBasePyPiClient:
@@ -61,7 +46,7 @@ class AnsibleBasePyPiClient:
         self.pypi_server_url = pypi_server_url
 
     @lru_cache
-    async def get_info(self) -> Dict[str, Any]:
+    async def get_info(self) -> t.Dict[str, t.Any]:
         """
         Retrieve information about the ansible-base package from pypi.
 
@@ -76,7 +61,7 @@ class AnsibleBasePyPiClient:
             pkg_info = await response.json()
         return pkg_info
 
-    async def get_versions(self) -> List[pypiver.Version]:
+    async def get_versions(self) -> t.List[pypiver.Version]:
         """
         Get the versions of the ansible-base package on pypi.
 
@@ -98,7 +83,7 @@ class AnsibleBasePyPiClient:
         versions = await self.get_versions()
         return versions[0]
 
-    async def retrieve(self, ansible_base_version: Union[str, pypiver.Version],
+    async def retrieve(self, ansible_base_version: t.Union[str, pypiver.Version],
                        download_dir: str) -> str:
         """
         Get the release from pypi.
@@ -131,14 +116,99 @@ class AnsibleBasePyPiClient:
         return tar_filename
 
 
-async def create_sdist(dist_dir):
-    # TODO: Should we move code that does this into here?
-    pass
+def _get_cache_version(ansible_base_cache: str) -> pypiver.Version:
+    with open(os.path.join(ansible_base_cache, 'lib', 'ansible', 'release.py')) as f:
+        root = ast.parse(f.read())
+
+    # Find the version of the cache
+    cache_version = None
+    # Iterate backwards in case __version__ is assigned to multiple times
+    for node in reversed(root.body):
+        if isinstance(node, ast.Assign):
+            for name in node.targets:
+                # These attributes are dynamic so pyre cannot check them
+                if name.id == '__version__':  # pyre-ignore[16]
+                    cache_version = node.value.s  # pyre-ignore[16]
+                    break
+
+        if cache_version:
+            break
+
+    if not cache_version:
+        raise ValueError('Version was not found')
+
+    return pypiver.Version(cache_version)
+
+
+def cache_is_devel(ansible_base_cache: t.Optional[str]) -> bool:
+    """
+    :arg ansible_base_cache: A path to an Ansible-base checkout or expanded sdist or None.
+        This will be used instead of downloading an ansible-base package if the version matches
+        with ``ansible_base_version``.
+    :returns: True if the cache looks like it is for the devel branch.
+    """
+    if ansible_base_cache is None:
+        return False
+
+    try:
+        cache_version = _get_cache_version(ansible_base_cache)
+    except Exception:
+        return False
+
+    dev_version = re.compile('[.]dev[0-9]+$')
+    if dev_version.match(cache_version.public):
+        return True
+
+    return False
+
+
+def cache_is_correct_version(ansible_base_cache: t.Optional[str],
+                             ansible_base_version: pypiver.Version) -> bool:
+    """
+    :arg ansible_base_cache: A path to an Ansible-base checkout or expanded sdist or None.
+        This will be used instead of downloading an ansible-base package if the version matches
+        with ``ansible_base_version``.
+    :arg ansible_base_version: Version of ansible-base to retrieve.
+    :returns: True if the cache is for a compatible version at or newer than the requested version
+    """
+    if ansible_base_cache is None:
+        return False
+
+    try:
+        cache_version = _get_cache_version(ansible_base_cache)
+    except Exception:
+        return False
+
+    # If the cache is a compatible version of ansible-base and it is the same or more recent than
+    # the requested version then allow this.
+    if (cache_version.major == ansible_base_version.major
+            and cache_version.minor == ansible_base_version.minor
+            and cache_version.micro >= ansible_base_version.micro):
+        return True
+
+    return False
+
+
+@lru_cache
+async def checkout_from_git(download_dir: str, repo_url: str = ANSIBLE_BASE_URL) -> str:
+    """
+    Checkout the ansible-base git repo.
+
+    :arg download_dir: Directory to checkout into.
+    :kwarg: repo_url: The url to the git repo.
+    :return: The directory that ansible-base has been checked out to.
+    """
+    loop = best_get_loop()
+    ansible_base_dir = os.path.join(download_dir, 'ansible-base')
+    await loop.run_in_executor(None, sh.git, 'clone', repo_url, ansible_base_dir)
+
+    return ansible_base_dir
 
 
 async def get_ansible_base(aio_session: 'aiohttp.client.ClientSession',
                            ansible_base_version: str,
-                           tmpdir: str) -> str:
+                           tmpdir: str,
+                           ansible_base_cache: t.Optional[str] = None) -> str:
     """
     Create an ansible-base directory of the requested version.
 
@@ -146,14 +216,29 @@ async def get_ansible_base(aio_session: 'aiohttp.client.ClientSession',
     :arg ansible_base_version: Version of ansible-base to retrieve.
     :arg tmpdir: Temporary directory use as a scratch area for downloading to and the place that the
         ansible-base directory should be placed in.
+    :kwarg ansible_base_cache: If given, a path to an Ansible-base checkout or expanded sdist.
+        This will be used instead of downloading an ansible-base package if the version matches
+        with ``ansible_base_version``.
     """
     if ansible_base_version == '@devel':
-        install_dir = await checkout_from_git(tmpdir)
-        install_file = await create_sdist(install_dir)
+        # is the cache usable?
+        if cache_is_devel(ansible_base_cache):
+            assert ansible_base_cache is not None
+            return ansible_base_cache
+
+        install_file = await checkout_from_git(tmpdir)
     else:
         pypi_client = AnsibleBasePyPiClient(aio_session)
         if ansible_base_version == '@latest':
             ansible_base_version: pypiver.Version = await pypi_client.get_latest_version()
+        else:
+            ansible_base_version: pypiver.Version = pypiver.Version(ansible_base_version)
+
+        # is the cache the asked for version?
+        if cache_is_correct_version(ansible_base_cache, ansible_base_version):
+            assert ansible_base_cache is not None
+            return ansible_base_cache
+
         install_file = await pypi_client.retrieve(ansible_base_version, tmpdir)
 
     return install_file

--- a/antsibull/ansible_base.py
+++ b/antsibull/ansible_base.py
@@ -45,7 +45,7 @@ class AnsibleBasePyPiClient:
         self.aio_session = aio_session
         self.pypi_server_url = pypi_server_url
 
-    @lru_cache
+    @lru_cache(None)
     async def get_info(self) -> t.Dict[str, t.Any]:
         """
         Retrieve information about the ansible-base package from pypi.
@@ -189,7 +189,7 @@ def cache_is_correct_version(ansible_base_cache: t.Optional[str],
     return False
 
 
-@lru_cache
+@lru_cache(None)
 async def checkout_from_git(download_dir: str, repo_url: str = ANSIBLE_BASE_URL) -> str:
     """
     Checkout the ansible-base git repo.

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -100,12 +100,25 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     :raises InvalidArgumentError: Whenever there's something wrong with the arguments.
     """
     # TODO: Need a function to return a parser with options that all antsibull
-    # scripts use. Then we can add it as a parent to the common_parser.
+    # scripts use. Then we can add it as a parent to the common_parser.  First use case:
+    # config file.
     # antsibull_parser =
 
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument('--dest-dir', default='.',
                                help='Directory to write the output to')
+
+    cache_parser = argparse.ArgumentParser(add_help=False)
+    cache_parser.add_argument('--ansible-base-cache', default=None,
+                              help='Checkout or expanded tarball of the ansible-base package.  If'
+                              ' this is a git checkout it must be the HEAD of the cache branch.'
+                              ' If it is an expanded tarball, the __version__ will be checked to'
+                              ' make sure it is compatible with and the same or later version than'
+                              ' requested by the depcs file.')
+    cache_parser.add_argument('--collection-cache', default=None,
+                              help='Directory of collection tarballs.  These will be used instead'
+                              ' of downloading fresh versions provided that they meet the criteria'
+                              ' (Latest version of the collections known to galaxy).')
 
     parser = argparse.ArgumentParser(prog=program_name,
                                      description='Script to manage generated documentation for'
@@ -114,14 +127,14 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                        help='for help use  SUBCOMMANDS -h')
 
     # Document the next version of ansible
-    devel_parser = subparsers.add_parser('devel', parents=[common_parser],
+    devel_parser = subparsers.add_parser('devel', parents=[common_parser, cache_parser],
                                          description='Generate documentation for the next major'
                                          ' release of Ansible')
     devel_parser.add_argument('--pieces-file', default=DEFAULT_PIECES_FILE,
                               help='File containing a list of collections to include')
 
     stable_parser = subparsers.add_parser('stable',
-                                          parents=[common_parser],
+                                          parents=[common_parser, cache_parser],
                                           description='Generate documentation for a current'
                                           ' version of ansible')
     stable_parser.add_argument('--deps-file', required=True,

--- a/antsibull/constants.py
+++ b/antsibull/constants.py
@@ -7,6 +7,9 @@
 from typing import FrozenSet
 
 
+#: Number of bytes to read or write in one chunk
+CHUNKSIZE = 4096
+
 #: All the types of ansible plugins
 PLUGIN_TYPES: FrozenSet[str] = frozenset(('become', 'cache', 'callback', 'cliconf', 'connection',
                                           'httpapi', 'inventory', 'lookup', 'shell', 'strategy',

--- a/antsibull/hashing.py
+++ b/antsibull/hashing.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2020
+"""Functions to help with hashing."""
+
+import hashlib
+
+import aiofiles
+
+from .constants import CHUNKSIZE
+
+
+async def verify_hash(filename: str, hash: str, algorithm: str = 'sha256') -> bool:
+    """
+    Verify whether a file has a given sha256sum.
+
+    :arg filename: The file to verify the sha256sum of.
+    :arg hash: The hash that is expected.
+    :kwarg algorithm: The hash algorithm to use.  This must be present in hashlib on this
+        system.  The default is 'sha256'
+    :returns: True if the hash matches, otherwise False.
+    """
+    hasher = getattr(hashlib, algorithm)()
+    async with aiofiles.open(filename, 'rb') as f:
+        # TODO: PY3.8: while chunk := await f.read(CHUNKSIZE):
+        chunk = await f.read(CHUNKSIZE)
+        while chunk:
+            hasher.update(chunk)
+            chunk = await f.read(CHUNKSIZE)
+    if hasher.hexdigest() != hash:
+        return False
+
+    return True

--- a/antsibull/venv.py
+++ b/antsibull/venv.py
@@ -43,12 +43,21 @@ class VenvRunner:
         """
         return sh.Command(os.path.join(self.venv_dir, 'bin', executable_name))
 
-    def install_package(self, package_name: str) -> sh.RunningCommand:
+    def install_package(self, package_name: str, from_project_path=False) -> sh.RunningCommand:
         """
         Install a python package into the venv.
 
         :arg package_name: This can be a bare package name or a path to a file.  It's passed
             directly to :command:`pip install`.
-            :returns: An :sh:obj:`sh.RunningCommand` for the pip output.
+        :arg from_project_path: Instead of a package name or file, package_name is a path to a
+            project.  ie: an expanded sdist or a checkout of a source repo.  At the moment,
+            pip -e is used to install these sorts of packages but this is an implementation
+            detail.
+        :returns: An :sh:obj:`sh.RunningCommand` for the pip output.
         """
-        return self._python('-m', 'pip', 'install', package_name)
+        if from_project_path:
+            package_args = ('-e', package_name)
+        else:
+            package_args = (package_name,)
+
+        return self._python('-m', 'pip', 'install', *package_args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "antsibull"
-version = "0.4.0"
+version = "0.5.0"
 description = "Tools for building the Ansible Distribution"
 authors = ["Toshio Kuratomi <a.badger@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Add two new command line options, --ansible-base-cache and
--collections-cache which specify directories where a cached copy of
ansible-base or the collection tarballs live.  If you use these,
antsibull-docs will check whether the cached copy is compatible with and
greater than or equal to the desired version.  If so, it will use the
cached copy instead of downloading its own version.

Fixes #43