### PR TITLE
Allow to build docs for current state

### DIFF
--- a/antsibull/cli/doc_commands/current.py
+++ b/antsibull/cli/doc_commands/current.py
@@ -1,0 +1,257 @@
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2020
+"""Entrypoint to the antsibull-docs script."""
+
+import asyncio
+import os
+import os.path
+import tempfile
+import typing as t
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor
+
+import aiohttp
+from pydantic import ValidationError
+
+from ...ansible_base import get_ansible_base
+from ...collections import install_together
+from ...compat import asyncio_run, best_get_loop
+from ...dependency_files import DepsFile
+from ...docs_parsing.ansible_doc import get_ansible_plugin_info
+from ...docs_parsing.fqcn import get_fqcn_parts
+from ...galaxy import CollectionDownloader
+from ...logging import log
+from ...schemas.docs import DOCS_SCHEMAS
+from ...venv import VenvRunner, FakeVenvRunner
+from ...write_docs import output_indexes, output_all_plugin_rst
+
+if t.TYPE_CHECKING:
+    import argparse
+    import semantic_version as semver
+
+
+mlog = log.fields(mod=__name__)
+
+#: Mapping of plugins to nonfatal errors.  This is the type to use when returning the mapping.
+PluginErrorsRT = t.DefaultDict[str, t.DefaultDict[str, t.List[str]]]
+
+
+async def retrieve(ansible_base_version: str,
+                   collections: t.Mapping[str, str],
+                   tmp_dir: str) -> t.Dict[str, 'semver.Version']:
+    """
+    Download ansible-base and the collections.
+
+    :arg ansible_base_version: Version of ansible-base to download.
+    :arg collections: Map of collection names to collection versions to download.
+    :arg tmp_dir: The directory to download into
+    :returns: Map of collection name to directory it is in.  ansible-base will
+        use the special key, `_ansible_base`.
+    """
+    collection_dir = os.path.join(tmp_dir, 'collections')
+    os.mkdir(collection_dir, mode=0o700)
+
+    requestors = {}
+    async with aiohttp.ClientSession() as aio_session:
+        requestors['_ansible_base'] = asyncio.create_task(get_ansible_base(aio_session,
+                                                                           ansible_base_version,
+                                                                           tmp_dir))
+        downloader = CollectionDownloader(aio_session, collection_dir)
+        for collection, version in collections.items():
+            requestors[collection] = asyncio.create_task(downloader.download(collection, version))
+
+        responses = await asyncio.gather(*requestors.values())
+
+    # Note: Python dicts have always had a stable order as long as you don't modify the dict.
+    # So requestors (implicitly, the keys) and responses have a matching order here.
+    return dict(zip(requestors, responses))
+
+
+def normalize_plugin_info(plugin_type: str,
+                          plugin_info: t.Mapping[str, t.Any]
+                          ) -> t.Tuple[t.Dict[str, t.Any], t.List[str]]:
+    """
+    Normalize and validate all of the plugin docs.
+
+    :arg plugin_type: The type of plugins that we're getting docs for.
+    :arg plugin_info: Mapping of plugin_info.  The toplevel keys are plugin names.
+        See the schema in :mod:`antsibull.schemas` for what the data should look like and just how
+        much conversion we can perform on it.
+    :returns: A tuple containing a "copy" of plugin_info with all of the data normalized and a list
+        of nonfatal errors.  The plugin_info dict will follow the structure expressed in the schemas
+        in :mod:`antsibull.schemas`.  The nonfatal errors are strings representing the problems
+        encountered.
+    """
+    new_info = {}
+    errors = []
+    # Note: loop through "doc" before any other keys.
+    for field in ('doc', 'examples', 'return'):
+        try:
+            new_info.update(DOCS_SCHEMAS[plugin_type][field](**{field: plugin_info[field]}).dict())
+        except ValidationError as e:
+            if field == 'doc':
+                # We can't recover if there's not a doc field
+                raise
+            # But we can use the default value (some variant of "empty") for everything else
+            # Note: We looped through doc first and raised an exception if doc did not normalize
+            # so we're able to use it in the error message here.
+            errors.append(f'Unable to normalize {new_info["doc"]["name"]}: {field}'
+                          f' due to: {str(e)}')
+            new_info.update(DOCS_SCHEMAS[plugin_type][field].parse_obj({}))
+
+    return (new_info, errors)
+
+
+async def normalize_all_plugin_info(plugin_info: t.Mapping[str, t.Mapping[str, t.Any]]
+                                    ) -> t.Tuple[t.Dict[str, t.Dict[str, t.Any]], PluginErrorsRT]:
+    """
+    Normalize the data in plugin_info so that it is ready to be passed to the templates.
+
+    :arg plugin_info: Mapping of information about plugins.  This contains information about all of
+        the plugins that are to be documented. See the schema in :mod:`antsibull.schemas` for the
+        structure of the information.
+    :returns: A tuple of plugin_info (this is a "copy" of the input plugin_info with all of the
+        data normalized) and a mapping of errors.  The plugin_info may have less records than the
+        input plugin_info if there were plugin records which failed to validate.  The mapping of
+        errors takes the form of:
+
+        .. code-block:: yaml
+
+            plugin_type:
+                plugin_name:
+                    - error string
+                    - error string
+    """
+    loop = best_get_loop()
+
+    # Normalize each plugin in a subprocess since normalization is CPU bound
+    normalizers = {}
+    for plugin_type, plugin_list_for_type in plugin_info.items():
+        for plugin_name, plugin_record in plugin_list_for_type.items():
+            normalizers[(plugin_type, plugin_name)] = loop.run_in_executor(
+                ProcessPoolExecutor(), normalize_plugin_info, plugin_type, plugin_record)
+
+    results = await asyncio.gather(*normalizers.values(), return_exceptions=True)
+
+    new_plugin_info = defaultdict(dict)
+    nonfatal_errors = defaultdict(lambda: defaultdict(list))
+    for (plugin_type, plugin_name), plugin_record in zip(normalizers, results):
+        # Errors which broke doc parsing (and therefore we won't have enough info to
+        # build a docs page)
+        if isinstance(plugin_record, Exception):
+            nonfatal_errors[plugin_type][plugin_name].append(str(plugin_record))
+            # An exception means there is no usable documentation for this plugin
+            new_plugin_info[plugin_type][plugin_name] = {}
+            continue
+
+        # Errors where we have at least docs.  We can still create a docs page for these with some
+        # information left out
+        if plugin_record[1]:
+            nonfatal_errors[plugin_type][plugin_name].extend(results[1])
+
+        new_plugin_info[plugin_type][plugin_name] = plugin_record[0]
+
+    return new_plugin_info, nonfatal_errors
+
+
+def get_collection_contents(plugin_info: t.Mapping[str, t.Mapping[str, t.Any]],
+                            nonfatal_errors: PluginErrorsRT
+                            ) -> t.DefaultDict[str, t.DefaultDict[str, t.Dict[str, str]]]:
+    """
+    Return the contents plugins which are in each collection.
+
+    :arg plugin_info: Mapping of plugin type to a mapping of plugin name to plugin record.
+        The plugin_type, plugin_name, and short_description from plugin_records are used.
+    :arg nonfatal_errors: mapping of plugin type to plugin name to list of error messages.
+        The plugin_type and plugin_name are used.
+    :returns: A Mapping of collection name to a mapping of plugin type to a mapping of plugin names
+        to short_descriptions.
+    collection:
+        plugin_type:
+            - plugin_short_name: short_description
+    """
+    collection_plugins = defaultdict(lambda: defaultdict(dict))
+    for plugin_type, plugin_list in plugin_info.items():
+        for plugin_name, plugin_desc in plugin_list.items():
+            namespace, collection, short_name = get_fqcn_parts(plugin_name)
+            collection_plugins['.'.join((namespace, collection))][plugin_type][short_name] = (
+                plugin_desc)
+
+    # Some plugins won't have an entry in the plugin_info because documentation failed to parse.
+    # Those should be documented in the nonfatal_errors information.
+    for plugin_type, plugin_list in nonfatal_errors.items():
+        for plugin_name, dummy_ in plugin_list.items():
+            namespace, collection, short_name = get_fqcn_parts(plugin_name)
+            collection_plugins['.'.join((namespace, collection))][plugin_type][short_name] = ''
+
+    return collection_plugins
+
+
+def generate_docs(args: 'argparse.Namespace') -> int:
+    """
+    Create documentation for the current subcommand.
+
+    Current documentation creates documentation for the currently installed version of Ansible,
+    as well as the currently installed collections.
+
+    :arg args: The parsed comand line args.
+    :returns: A return code for the program.  See :func:`antsibull.cli.antsibull_docs.main` for
+        details on what each code means.
+    """
+    flog = mlog.fields(func='generate_docs')
+    flog.debug('Begin processing docs')
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        venv = FakeVenvRunner()
+
+        # Get the list of plugins
+        plugin_info = asyncio_run(get_ansible_plugin_info(venv, args.collection_dir))
+        flog.debug('Finished parsing info from plugins')
+
+        """
+        # Turn these into some sort of decorator that will load choose to dump or load the values
+        # if a command line arg is specified.
+        with open('dump_raw_plugin_info.json', 'w') as f:
+            import json
+            json.dump(plugin_info, f)
+        flog.debug('Finished dumping raw plugin_info')
+        """
+
+        plugin_info, nonfatal_errors = asyncio_run(normalize_all_plugin_info(plugin_info))
+        flog.debug('Finished normalizing data')
+        # calculate_additional_info(plugin_info) (full_path)
+
+        """
+        with open('dump_normalized_plugin_info.json', 'w') as f:
+            json.dump(plugin_info, f)
+        flog.debug('Finished dumping normalized data')
+
+        with open('dump_errors.json', 'w') as f:
+            json.dump(nonfatal_errors, f)
+        flog.debug('Finished dump errors')
+
+        with open('dump_normalized_plugin_info.json', 'r') as f:
+            import json
+            plugin_info = json.load(f)
+        flog.debug('Finished loading normalized data')
+
+        with open('dump_errors.json', 'r') as f:
+            from collections import defaultdict
+            nonfatal_errors = json.load(f)
+            nonfatal_errors = defaultdict(lambda: defaultdict(list), nonfatal_errors)
+            for key, value in nonfatal_errors.items():
+                nonfatal_errors[key] = defaultdict(list, value)
+        flog.debug('Finished loading errors')
+        """
+
+        asyncio_run(output_all_plugin_rst(plugin_info, nonfatal_errors, args.dest_dir))
+        flog.debug('Finished writing plugin docs')
+
+        collection_info = get_collection_contents(plugin_info, nonfatal_errors)
+        flog.debug('Finished writing collection data')
+
+        asyncio_run(output_indexes(collection_info, args.dest_dir))
+        flog.debug('Finished writing indexes')
+
+    return 0

--- a/antsibull/cli/doc_commands/current.py
+++ b/antsibull/cli/doc_commands/current.py
@@ -3,31 +3,19 @@
 # Copyright: Ansible Project, 2020
 """Entrypoint to the antsibull-docs script."""
 
-import asyncio
 import os
-import os.path
-import tempfile
 import typing as t
-from collections import defaultdict
-from concurrent.futures import ProcessPoolExecutor
-
-import aiohttp
-from pydantic import ValidationError
 
 from ...ansible_base import get_ansible_base
-from ...compat import asyncio_run, best_get_loop
+from ...compat import asyncio_run
 from ...docs_parsing.ansible_doc import get_ansible_plugin_info
-from ...docs_parsing.fqcn import get_fqcn_parts
-from ...galaxy import CollectionDownloader
 from ...logging import log
-from ...schemas.docs import DOCS_SCHEMAS
 from ...venv import FakeVenvRunner
 from ...write_docs import output_indexes, output_all_plugin_rst
 from .stable import normalize_all_plugin_info, get_collection_contents
 
 if t.TYPE_CHECKING:
     import argparse
-    import semantic_version as semver
 
 
 mlog = log.fields(mod=__name__)

--- a/antsibull/cli/doc_commands/current.py
+++ b/antsibull/cli/doc_commands/current.py
@@ -15,16 +15,15 @@ import aiohttp
 from pydantic import ValidationError
 
 from ...ansible_base import get_ansible_base
-from ...collections import install_together
 from ...compat import asyncio_run, best_get_loop
-from ...dependency_files import DepsFile
 from ...docs_parsing.ansible_doc import get_ansible_plugin_info
 from ...docs_parsing.fqcn import get_fqcn_parts
 from ...galaxy import CollectionDownloader
 from ...logging import log
 from ...schemas.docs import DOCS_SCHEMAS
-from ...venv import VenvRunner, FakeVenvRunner
+from ...venv import FakeVenvRunner
 from ...write_docs import output_indexes, output_all_plugin_rst
+from .stable import normalize_all_plugin_info, get_collection_contents
 
 if t.TYPE_CHECKING:
     import argparse
@@ -32,160 +31,6 @@ if t.TYPE_CHECKING:
 
 
 mlog = log.fields(mod=__name__)
-
-#: Mapping of plugins to nonfatal errors.  This is the type to use when returning the mapping.
-PluginErrorsRT = t.DefaultDict[str, t.DefaultDict[str, t.List[str]]]
-
-
-async def retrieve(ansible_base_version: str,
-                   collections: t.Mapping[str, str],
-                   tmp_dir: str) -> t.Dict[str, 'semver.Version']:
-    """
-    Download ansible-base and the collections.
-
-    :arg ansible_base_version: Version of ansible-base to download.
-    :arg collections: Map of collection names to collection versions to download.
-    :arg tmp_dir: The directory to download into
-    :returns: Map of collection name to directory it is in.  ansible-base will
-        use the special key, `_ansible_base`.
-    """
-    collection_dir = os.path.join(tmp_dir, 'collections')
-    os.mkdir(collection_dir, mode=0o700)
-
-    requestors = {}
-    async with aiohttp.ClientSession() as aio_session:
-        requestors['_ansible_base'] = asyncio.create_task(get_ansible_base(aio_session,
-                                                                           ansible_base_version,
-                                                                           tmp_dir))
-        downloader = CollectionDownloader(aio_session, collection_dir)
-        for collection, version in collections.items():
-            requestors[collection] = asyncio.create_task(downloader.download(collection, version))
-
-        responses = await asyncio.gather(*requestors.values())
-
-    # Note: Python dicts have always had a stable order as long as you don't modify the dict.
-    # So requestors (implicitly, the keys) and responses have a matching order here.
-    return dict(zip(requestors, responses))
-
-
-def normalize_plugin_info(plugin_type: str,
-                          plugin_info: t.Mapping[str, t.Any]
-                          ) -> t.Tuple[t.Dict[str, t.Any], t.List[str]]:
-    """
-    Normalize and validate all of the plugin docs.
-
-    :arg plugin_type: The type of plugins that we're getting docs for.
-    :arg plugin_info: Mapping of plugin_info.  The toplevel keys are plugin names.
-        See the schema in :mod:`antsibull.schemas` for what the data should look like and just how
-        much conversion we can perform on it.
-    :returns: A tuple containing a "copy" of plugin_info with all of the data normalized and a list
-        of nonfatal errors.  The plugin_info dict will follow the structure expressed in the schemas
-        in :mod:`antsibull.schemas`.  The nonfatal errors are strings representing the problems
-        encountered.
-    """
-    new_info = {}
-    errors = []
-    # Note: loop through "doc" before any other keys.
-    for field in ('doc', 'examples', 'return'):
-        try:
-            new_info.update(DOCS_SCHEMAS[plugin_type][field](**{field: plugin_info[field]}).dict())
-        except ValidationError as e:
-            if field == 'doc':
-                # We can't recover if there's not a doc field
-                raise
-            # But we can use the default value (some variant of "empty") for everything else
-            # Note: We looped through doc first and raised an exception if doc did not normalize
-            # so we're able to use it in the error message here.
-            errors.append(f'Unable to normalize {new_info["doc"]["name"]}: {field}'
-                          f' due to: {str(e)}')
-            new_info.update(DOCS_SCHEMAS[plugin_type][field].parse_obj({}))
-
-    return (new_info, errors)
-
-
-async def normalize_all_plugin_info(plugin_info: t.Mapping[str, t.Mapping[str, t.Any]]
-                                    ) -> t.Tuple[t.Dict[str, t.Dict[str, t.Any]], PluginErrorsRT]:
-    """
-    Normalize the data in plugin_info so that it is ready to be passed to the templates.
-
-    :arg plugin_info: Mapping of information about plugins.  This contains information about all of
-        the plugins that are to be documented. See the schema in :mod:`antsibull.schemas` for the
-        structure of the information.
-    :returns: A tuple of plugin_info (this is a "copy" of the input plugin_info with all of the
-        data normalized) and a mapping of errors.  The plugin_info may have less records than the
-        input plugin_info if there were plugin records which failed to validate.  The mapping of
-        errors takes the form of:
-
-        .. code-block:: yaml
-
-            plugin_type:
-                plugin_name:
-                    - error string
-                    - error string
-    """
-    loop = best_get_loop()
-
-    # Normalize each plugin in a subprocess since normalization is CPU bound
-    normalizers = {}
-    for plugin_type, plugin_list_for_type in plugin_info.items():
-        for plugin_name, plugin_record in plugin_list_for_type.items():
-            normalizers[(plugin_type, plugin_name)] = loop.run_in_executor(
-                ProcessPoolExecutor(), normalize_plugin_info, plugin_type, plugin_record)
-
-    results = await asyncio.gather(*normalizers.values(), return_exceptions=True)
-
-    new_plugin_info = defaultdict(dict)
-    nonfatal_errors = defaultdict(lambda: defaultdict(list))
-    for (plugin_type, plugin_name), plugin_record in zip(normalizers, results):
-        # Errors which broke doc parsing (and therefore we won't have enough info to
-        # build a docs page)
-        if isinstance(plugin_record, Exception):
-            nonfatal_errors[plugin_type][plugin_name].append(str(plugin_record))
-            # An exception means there is no usable documentation for this plugin
-            new_plugin_info[plugin_type][plugin_name] = {}
-            continue
-
-        # Errors where we have at least docs.  We can still create a docs page for these with some
-        # information left out
-        if plugin_record[1]:
-            nonfatal_errors[plugin_type][plugin_name].extend(results[1])
-
-        new_plugin_info[plugin_type][plugin_name] = plugin_record[0]
-
-    return new_plugin_info, nonfatal_errors
-
-
-def get_collection_contents(plugin_info: t.Mapping[str, t.Mapping[str, t.Any]],
-                            nonfatal_errors: PluginErrorsRT
-                            ) -> t.DefaultDict[str, t.DefaultDict[str, t.Dict[str, str]]]:
-    """
-    Return the contents plugins which are in each collection.
-
-    :arg plugin_info: Mapping of plugin type to a mapping of plugin name to plugin record.
-        The plugin_type, plugin_name, and short_description from plugin_records are used.
-    :arg nonfatal_errors: mapping of plugin type to plugin name to list of error messages.
-        The plugin_type and plugin_name are used.
-    :returns: A Mapping of collection name to a mapping of plugin type to a mapping of plugin names
-        to short_descriptions.
-    collection:
-        plugin_type:
-            - plugin_short_name: short_description
-    """
-    collection_plugins = defaultdict(lambda: defaultdict(dict))
-    for plugin_type, plugin_list in plugin_info.items():
-        for plugin_name, plugin_desc in plugin_list.items():
-            namespace, collection, short_name = get_fqcn_parts(plugin_name)
-            collection_plugins['.'.join((namespace, collection))][plugin_type][short_name] = (
-                plugin_desc)
-
-    # Some plugins won't have an entry in the plugin_info because documentation failed to parse.
-    # Those should be documented in the nonfatal_errors information.
-    for plugin_type, plugin_list in nonfatal_errors.items():
-        for plugin_name, dummy_ in plugin_list.items():
-            namespace, collection, short_name = get_fqcn_parts(plugin_name)
-            collection_plugins['.'.join((namespace, collection))][plugin_type][short_name] = ''
-
-    return collection_plugins
 
 
 def generate_docs(args: 'argparse.Namespace') -> int:
@@ -202,56 +47,55 @@ def generate_docs(args: 'argparse.Namespace') -> int:
     flog = mlog.fields(func='generate_docs')
     flog.debug('Begin processing docs')
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        venv = FakeVenvRunner()
+    venv = FakeVenvRunner()
 
-        # Get the list of plugins
-        plugin_info = asyncio_run(get_ansible_plugin_info(venv, args.collection_dir))
-        flog.debug('Finished parsing info from plugins')
+    # Get the list of plugins
+    plugin_info = asyncio_run(get_ansible_plugin_info(venv, args.collection_dir))
+    flog.debug('Finished parsing info from plugins')
 
-        """
-        # Turn these into some sort of decorator that will load choose to dump or load the values
-        # if a command line arg is specified.
-        with open('dump_raw_plugin_info.json', 'w') as f:
-            import json
-            json.dump(plugin_info, f)
-        flog.debug('Finished dumping raw plugin_info')
-        """
+    """
+    # Turn these into some sort of decorator that will load choose to dump or load the values
+    # if a command line arg is specified.
+    with open('dump_raw_plugin_info.json', 'w') as f:
+        import json
+        json.dump(plugin_info, f)
+    flog.debug('Finished dumping raw plugin_info')
+    """
 
-        plugin_info, nonfatal_errors = asyncio_run(normalize_all_plugin_info(plugin_info))
-        flog.debug('Finished normalizing data')
-        # calculate_additional_info(plugin_info) (full_path)
+    plugin_info, nonfatal_errors = asyncio_run(normalize_all_plugin_info(plugin_info))
+    flog.debug('Finished normalizing data')
+    # calculate_additional_info(plugin_info) (full_path)
 
-        """
-        with open('dump_normalized_plugin_info.json', 'w') as f:
-            json.dump(plugin_info, f)
-        flog.debug('Finished dumping normalized data')
+    """
+    with open('dump_normalized_plugin_info.json', 'w') as f:
+        json.dump(plugin_info, f)
+    flog.debug('Finished dumping normalized data')
 
-        with open('dump_errors.json', 'w') as f:
-            json.dump(nonfatal_errors, f)
-        flog.debug('Finished dump errors')
+    with open('dump_errors.json', 'w') as f:
+        json.dump(nonfatal_errors, f)
+    flog.debug('Finished dump errors')
 
-        with open('dump_normalized_plugin_info.json', 'r') as f:
-            import json
-            plugin_info = json.load(f)
-        flog.debug('Finished loading normalized data')
+    with open('dump_normalized_plugin_info.json', 'r') as f:
+        import json
+        plugin_info = json.load(f)
+    flog.debug('Finished loading normalized data')
 
-        with open('dump_errors.json', 'r') as f:
-            from collections import defaultdict
-            nonfatal_errors = json.load(f)
-            nonfatal_errors = defaultdict(lambda: defaultdict(list), nonfatal_errors)
-            for key, value in nonfatal_errors.items():
-                nonfatal_errors[key] = defaultdict(list, value)
-        flog.debug('Finished loading errors')
-        """
+    with open('dump_errors.json', 'r') as f:
+        from collections import defaultdict
+        nonfatal_errors = json.load(f)
+        nonfatal_errors = defaultdict(lambda: defaultdict(list), nonfatal_errors)
+        for key, value in nonfatal_errors.items():
+            nonfatal_errors[key] = defaultdict(list, value)
+    flog.debug('Finished loading errors')
+    """
 
-        asyncio_run(output_all_plugin_rst(plugin_info, nonfatal_errors, args.dest_dir))
-        flog.debug('Finished writing plugin docs')
+    asyncio_run(output_all_plugin_rst(plugin_info, nonfatal_errors, args.dest_dir))
+    flog.debug('Finished writing plugin docs')
 
-        collection_info = get_collection_contents(plugin_info, nonfatal_errors)
-        flog.debug('Finished writing collection data')
+    collection_info = get_collection_contents(plugin_info, nonfatal_errors)
+    flog.debug('Finished writing collection data')
 
-        asyncio_run(output_indexes(collection_info, args.dest_dir))
-        flog.debug('Finished writing indexes')
+    asyncio_run(output_indexes(collection_info, args.dest_dir))
+    flog.debug('Finished writing indexes')
 
     return 0

--- a/antsibull/cli/doc_commands/current.py
+++ b/antsibull/cli/doc_commands/current.py
@@ -3,10 +3,8 @@
 # Copyright: Ansible Project, 2020
 """Entrypoint to the antsibull-docs script."""
 
-import os
 import typing as t
 
-from ...ansible_base import get_ansible_base
 from ...compat import asyncio_run
 from ...docs_parsing.ansible_doc import get_ansible_plugin_info
 from ...logging import log

--- a/antsibull/docs_parsing/ansible_doc.py
+++ b/antsibull/docs_parsing/ansible_doc.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 import sh
 
@@ -18,7 +18,7 @@ from ..constants import DOCUMENTABLE_PLUGINS
 from ..vendored.json_utils import _filter_non_json_lines
 
 if TYPE_CHECKING:
-    from ..venv import VenvRunner
+    from ..venv import VenvRunner, FakeVenvRunner
 
 
 #: Clear Ansible environment variables that set paths where plugins could be found.
@@ -123,7 +123,7 @@ async def _get_plugin_info(plugin_type: str, ansible_doc: 'sh.Command') -> Dict[
     return results
 
 
-async def get_ansible_plugin_info(venv: 'VenvRunner',
+async def get_ansible_plugin_info(venv: Union['VenvRunner', 'FakeVenvRunner'],
                                   collection_dir: str) -> Dict[str, Dict[str, Any]]:
     """
     Retrieve information about all of the Ansible Plugins.

--- a/antsibull/venv.py
+++ b/antsibull/venv.py
@@ -61,3 +61,36 @@ class VenvRunner:
             package_args = (package_name,)
 
         return self._python('-m', 'pip', 'install', *package_args)
+
+
+class FakeVenvRunner:
+    """
+    Simply runs commands.
+
+    .. seealso::
+        * `sh <https://amoffat.github.io/sh/>`_
+        * :python:mod:`venv`
+    """
+
+    def get_command(self, executable_name) -> sh.Command:
+        """
+        Return an :sh:obj:`sh.Command` for the given program installed within the venv.
+
+        :arg executable_name: Program to return a command for.
+        :returns: An :obj:`sh.Command` that will invoke the program.
+        """
+        return sh.Command(executable_name)
+
+    def install_package(self, package_name: str, from_project_path=False) -> sh.RunningCommand:
+        """
+        Install a python package into the venv.
+
+        :arg package_name: This can be a bare package name or a path to a file.  It's passed
+            directly to :command:`pip install`.
+        :arg from_project_path: Instead of a package name or file, package_name is a path to a
+            project.  ie: an expanded sdist or a checkout of a source repo.  At the moment,
+            pip -e is used to install these sorts of packages but this is an implementation
+            detail.
+        :returns: An :sh:obj:`sh.RunningCommand` for the pip output.
+        """
+        raise Exception('Not implemented')


### PR DESCRIPTION
Adds a subcommand `current` to `antsibull-docs` which uses the currently installed Ansible and all currently installed collections inside the directory specified by `--collection-dir`.