### PR TITLE
Elements should only be rendered for lists

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -149,7 +149,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">@{ value['type'] | documented_type }@</span>
-                        / <span style="color: purple">elements=@{ value['elements'] | documented_type }@</span>
+                        {% if value['type'] == 'list' and value['elements'] is not none %} / <span style="color: purple">elements=@{ value['elements'] | documented_type }@</span>{% endif %}
                         {% if value['required'] %} / <span style="color: red">required</span>{% endif %}
                     </div>
                     {% if value['version_added'] is still_relevant %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value['version_added']}@</div>{% endif %}
@@ -378,7 +378,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value"></a>
                     <div style="font-size: small">
                       <span style="color: purple">@{ value['type'] | documented_type }@</span>
-                      {% if value['elements'] %} / <span style="color: purple">elements=@{ value['elements'] | documented_type }@</span>{% endif %}
+                      {% if value['type'] == 'list' and value['elements'] is not none %} / <span style="color: purple">elements=@{ value['elements'] | documented_type }@</span>{% endif %}
                     </div>
                     {% if value['version_added'] is still_relevant %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value['version_added']}@</div>{% endif %}
                 </td>


### PR DESCRIPTION
Elements only makes sense for container types (list and dict).  Of
those, dict is usually heterogeneous so the types of dict values should
be identified by suboptions.  So we really only want to display elements
for lists.

Potential fix for #73