### PR TITLE
Use thread and process worker limits to keep open file count down.

### DIFF
--- a/antsibull/docs_parsing/ansible_doc.py
+++ b/antsibull/docs_parsing/ansible_doc.py
@@ -106,6 +106,8 @@ async def _get_plugin_info(plugin_type: str, ansible_doc: 'sh.Command') -> Dict[
             sys.stderr.write('\n'.join(err_msg))
             continue
 
+        stdout = ansible_doc_results.stdout.decode("utf-8", errors="surrogateescape")
+
         # ansible-doc returns plugins shipped with ansible-base using no namespace and collection.
         # For now, we fix these entries to use the ansible.builtin collection here.  The reason we
         # do it here instead of as part of a general normalization step is that other plugins


### PR DESCRIPTION
On MacOS, the default open file limit per process is 256.  If we let
antsibull process the full set of collections in parallel we can exceed
this limit.  So we can constrain the number of worker threads so we
dont't hit that limit

Also fix for the error message fix in aafad85ee51eb5273c8a403a83c2404426e94894
which missed that stdout is used in the non-error path
