### PR TITLE
Allow prereleases

### DIFF
--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -9,7 +9,7 @@ import os.path
 import sys
 from typing import List
 
-import packaging.version as pypiver
+from packaging.version import Version as PypiVer
 
 from ..new_acd import new_acd_command
 from ..build_collection import build_collection_command
@@ -96,7 +96,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     :raises InvalidArgumentError: Whenever there's something wrong with the arguments.
     """
     common_parser = argparse.ArgumentParser(add_help=False)
-    common_parser.add_argument('acd_version', type=pypiver.Version,
+    common_parser.add_argument('acd_version', type=PypiVer,
                                help='The X.Y.Z version of ACD that this will be for')
     common_parser.add_argument('--dest-dir', default='.',
                                help='Directory to write the output to')

--- a/antsibull/data/acd-setup_py.j2
+++ b/antsibull/data/acd-setup_py.j2
@@ -27,7 +27,7 @@ setup(
     packages=['ansible_collections'],
     include_package_data=True,
     install_requires=[
-        'ansible-base>={{ version }},<{{ version.major }}.{{ version.minor + 1 }}',{{ collection_deps }}
+        'ansible-base>={{ ansible_base_version }},<{{ ansible_base_version.major }}.{{ ansible_base_version.minor + 1 }}',{{ collection_deps }}
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/antsibull/dependency_files.py
+++ b/antsibull/dependency_files.py
@@ -16,8 +16,8 @@ We don't want to install backwards incompatible collections until the next major
 from typing import TYPE_CHECKING, Dict, List, Mapping, NamedTuple, Optional
 
 if TYPE_CHECKING:
-    from packaging.version import Version as PyPiVersion
-    from semantic_version import Version as SemVersion
+    from packaging.version import Version as PypiVer
+    from semantic_version import Version as SemVer
 
 
 class DependencyFileData(NamedTuple):
@@ -136,8 +136,8 @@ class BuildFile:
         """Parse the build from a dependency file."""
         return _parse_name_version_spec_file(self.filename)
 
-    def write(self, acd_version: 'PyPiVersion', ansible_base_version: str,
-              dependencies: Mapping[str, 'SemVersion']) -> None:
+    def write(self, acd_version: 'PypiVer', ansible_base_version: str,
+              dependencies: Mapping[str, 'SemVer']) -> None:
         """
         Write a build dependency file.
 

--- a/antsibull/new_acd.py
+++ b/antsibull/new_acd.py
@@ -26,7 +26,7 @@ async def get_version_info(collections):
 
     requestors = {}
     async with aiohttp.ClientSession() as aio_session:
-        async with asyncio_pool.AioPool(max_workers=THREAD_MAX) as pool:
+        async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
             pypi_client = AnsibleBasePyPiClient(aio_session)
             requestors['_ansible_base'] = await pool.spawn(pypi_client.get_versions())
             galaxy_client = GalaxyClient(aio_session)


### PR DESCRIPTION
Depend on prerelease versions of ansible as well.

If we have an ansible-base pre-release like ansible-base-2.10.0beta1
as the latest version on pypi, we need to depend on that.

Also:

* Normalize the imports of packaging.version.Version
* Fix calling AioPool with the wrong parameter name to limit the number of workers.

