### PR TITLE
Change references to the master branch to the main branch

### DIFF
--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -6,9 +6,9 @@ name: Python linting
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -6,9 +6,9 @@ name: Python testing
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
         # paths:
         #   - "src"
         branches:
-          - master
+          - main
         if_not_found: success
         if_ci_failed: error
         informational: true


### PR DESCRIPTION
Some config for testing needs to know the default branch name.