### PR TITLE
Improve caching, and allow caching for ACD build

### DIFF
--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -101,6 +101,13 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     common_parser.add_argument('--dest-dir', default='.',
                                help='Directory to write the output to')
 
+    cache_parser = argparse.ArgumentParser(add_help=False)
+    cache_parser.add_argument('--collection-cache', default=None,
+                              help='Directory of cached collection tarballs.  Will be'
+                              ' used if a collection tarball to be downloaded exists'
+                              ' in here, and will be populated when downloading new'
+                              ' tarballs.')
+
     build_parser = argparse.ArgumentParser(add_help=False)
     build_parser.add_argument('--build-file', default=None,
                               help='File containing the list of collections with version ranges.'
@@ -130,7 +137,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                             ' place $BASENAME_OF_PIECES_FILE-X.Y.build into --dest-dir')
 
     build_single_parser = subparsers.add_parser('build-single',
-                                                parents=[common_parser, build_parser],
+                                                parents=[common_parser, cache_parser, build_parser],
                                                 description='Build a single-file ACD')
 
     build_single_parser.add_argument('--debian', action='store_true',
@@ -138,7 +145,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                      ' the resulting output directory')
 
     subparsers.add_parser('build-multiple',
-                          parents=[common_parser, build_parser],
+                          parents=[common_parser, cache_parser, build_parser],
                           description='Build a multi-file ACD')
 
     collection_parser = subparsers.add_parser('build-collection',

--- a/antsibull/galaxy.py
+++ b/antsibull/galaxy.py
@@ -183,17 +183,6 @@ class CollectionDownloader(GalaxyClient):
         :arg version: Version of the collection to download.
         :returns: The full path to the downloaded collection.
         """
-        # First check cache to avoid any network access
-        if self.collection_cache:
-            cache_filename = f"${collection.replace('.', '-')}-${version}.tar.gz"
-            if cache_filename in os.listdir(self.collection_cache):
-                # TODO: PY3.8: We can use t.Final in __init__ instead of cast here.
-                cached_copy = os.path.join(t.cast(str, self.collection_cache),
-                                           cache_filename)
-                download_filename = os.path.join(self.download_dir, cache_filename)
-                shutil.copyfile(cached_copy, download_filename)
-                return download_filename
-
         collection = collection.replace('.', '/')
         release_info = await self.get_release_info(collection, version)
         release_url = release_info['download_url']

--- a/antsibull/galaxy.py
+++ b/antsibull/galaxy.py
@@ -183,6 +183,17 @@ class CollectionDownloader(GalaxyClient):
         :arg version: Version of the collection to download.
         :returns: The full path to the downloaded collection.
         """
+        # First check cache to avoid any network access
+        if self.collection_cache:
+            cache_filename = f"${collection.replace('.', '-')}-${version}.tar.gz"
+            if cache_filename in os.listdir(self.collection_cache):
+                # TODO: PY3.8: We can use t.Final in __init__ instead of cast here.
+                cached_copy = os.path.join(t.cast(str, self.collection_cache),
+                                           cache_filename)
+                download_filename = os.path.join(self.download_dir, cache_filename)
+                shutil.copyfile(cached_copy, download_filename)
+                return download_filename
+
         collection = collection.replace('.', '/')
         release_info = await self.get_release_info(collection, version)
         release_url = release_info['download_url']

--- a/antsibull/galaxy.py
+++ b/antsibull/galaxy.py
@@ -215,6 +215,13 @@ class CollectionDownloader(GalaxyClient):
             raise DownloadFailure(f'{release_url} failed to download correctly.'
                                   f' Expected checksum: {sha256sum}')
 
+        # Copy downloaded collection into cache
+        if self.collection_cache:
+            # TODO: PY3.8: We can use t.Final in __init__ instead of cast here.
+            cached_copy = os.path.join(t.cast(str, self.collection_cache),
+                                       release_info['artifact']['filename'])
+            shutil.copyfile(download_filename, cached_copy)
+
         return download_filename
 
     async def _get_latest_matching_version(self, collection: str,


### PR DESCRIPTION
Yesterday I probably downloaded most collection tarballs a dozen times since Galaxy returned at least one error during almost every run. This enables the collection tarball cache also for the ACD build (adds option `--collection-cache`), and improves the caching behavior in `CollectionDownloader` by actually storing downloaded tarballs in the caching directory after downloading, and by even avoiding the initial Galaxy `get_release_info` call (which was the one failing so often for me) when a candidate filename is found in the cache.