### PR TITLE
ACD changelog generator

### DIFF
--- a/antsibull/build_acd_commands.py
+++ b/antsibull/build_acd_commands.py
@@ -213,7 +213,7 @@ def build_single_command():
         # Write build scripts and files
         write_build_script(app_ctx.extra['acd_version'], ansible_base_version, package_dir)
         write_python_build_files(app_ctx.extra['acd_version'], ansible_base_version, '',
-                                 package_dir, app_ctx.extra['debian'])
+                                 package_dir, release_notes, app_ctx.extra['debian'])
         if app_ctx.extra['debian']:
             write_debian_directory(app_ctx.extra['acd_version'], package_dir)
         make_dist(package_dir, app_ctx.extra['dest_dir'])

--- a/antsibull/build_acd_commands.py
+++ b/antsibull/build_acd_commands.py
@@ -208,7 +208,11 @@ def build_single_command():
 
         # Compose and write release notes
         release_notes = ReleaseNotes.build(changelog)
-        release_notes.write_to(package_dir)
+        release_notes.write_changelog_to(package_dir)
+        # TODO: include porting guide after discussion in DaWG meeting about its relation
+        #       to the ansible-base porting guide, and where things will be placed and
+        #       structured.
+        # release_notes.write_porting_guide_to(package_dir)
 
         # Write build scripts and files
         write_build_script(app_ctx.extra['acd_version'], ansible_base_version, package_dir)

--- a/antsibull/build_acd_commands.py
+++ b/antsibull/build_acd_commands.py
@@ -175,17 +175,18 @@ def build_single_command():
                                                              app_ctx.extra['collection_cache']))
 
         new_dependencies = DependencyFileData(
-            str(args.acd_version),
+            str(app_ctx.extra["acd_version"]),
             str(ansible_base_version),
             {collection: str(version) for collection, version in included_versions.items()})
 
         # Get changelog and porting guide data
-        deps_dir = os.path.dirname(os.path.join(args.dest_dir, args.deps_file))
+        deps_dir = os.path.dirname(
+            os.path.join(app_ctx.extra["dest_dir"], app_ctx.extra["deps_file"]))
         changelog = get_changelog(
-            args.acd_version,
+            app_ctx.extra["acd_version"],
             deps_dir=deps_dir,
             deps_data=[new_dependencies],
-            collection_cache=args.collection_cache)
+            collection_cache=app_ctx.extra["collection_cache"])
 
         # Create package and collections directories
         package_dir = os.path.join(tmp_dir, f'ansible-{app_ctx.extra["acd_version"]}')

--- a/antsibull/build_acd_commands.py
+++ b/antsibull/build_acd_commands.py
@@ -10,6 +10,7 @@ import os.path
 import pkgutil
 import shutil
 import tempfile
+import typing as t
 from functools import partial
 
 import aiofiles
@@ -20,6 +21,8 @@ from jinja2 import Template
 from packaging.version import Version as PypiVer
 
 from . import app_context
+from .build_changelog import ReleaseNotes
+from .changelog import get_changelog
 from .collections import install_separately, install_together
 from .dependency_files import BuildFile, DependencyFileData, DepsFile
 from .galaxy import CollectionDownloader
@@ -68,12 +71,16 @@ def copy_boilerplate_files(package_dir):
         f.write(readme)
 
 
-def write_manifest(package_dir, debian=False):
+def write_manifest(package_dir, release_notes: t.Optional[ReleaseNotes] = None,
+                   debian: bool = False):
     manifest_file = os.path.join(package_dir, 'MANIFEST.in')
     with open(manifest_file, 'w') as f:
         f.write('include COPYING\n')
         f.write('include README\n')
         f.write('include build-ansible.sh\n')
+        if release_notes:
+            f.write('include {0}\n'.format(release_notes.changelog_filename))
+            f.write('include {0}\n'.format(release_notes.porting_guide_filename))
         if debian:
             f.write('include debian/*\n')
         f.write('recursive-include ansible_collections/ **\n')
@@ -92,9 +99,9 @@ def write_setup(acd_version, ansible_base_version, collection_deps, package_dir)
 
 
 def write_python_build_files(acd_version, ansible_base_version, collection_deps, package_dir,
-                             debian=False):
+                             release_notes: t.Optional[ReleaseNotes] = None, debian: bool = False):
     copy_boilerplate_files(package_dir)
-    write_manifest(package_dir, debian)
+    write_manifest(package_dir, release_notes, debian)
     write_setup(acd_version, ansible_base_version, collection_deps, package_dir)
 
 
@@ -162,30 +169,31 @@ def build_single_command():
         download_dir = os.path.join(tmp_dir, 'collections')
         os.mkdir(download_dir, mode=0o700)
 
-<<<<<<< HEAD
+        # Download included collections
         included_versions = asyncio.run(download_collections(deps, app_ctx.galaxy_url,
                                                              download_dir,
                                                              app_ctx.extra['collection_cache']))
-
-        package_dir = os.path.join(tmp_dir, f'ansible-{app_ctx.extra["acd_version"]}')
-=======
-        # Download included collections
-        included_versions = asyncio.run(
-            download_collections(deps, download_dir, args.collection_cache))
 
         new_dependencies = DependencyFileData(
             str(args.acd_version),
             str(ansible_base_version),
             {collection: str(version) for collection, version in included_versions.items()})
 
+        # Get changelog and porting guide data
+        deps_dir = os.path.dirname(os.path.join(args.dest_dir, args.deps_file))
+        changelog = get_changelog(
+            args.acd_version,
+            deps_dir=deps_dir,
+            deps_data=[new_dependencies],
+            collection_cache=args.collection_cache)
+
         # Create package and collections directories
-        package_dir = os.path.join(tmp_dir, f'ansible-{args.acd_version}')
->>>>>>> 7a0a573... Improve comments, fix type bugs that pyre missed.
+        package_dir = os.path.join(tmp_dir, f'ansible-{app_ctx.extra["acd_version"]}')
         os.mkdir(package_dir, mode=0o700)
         ansible_collections_dir = os.path.join(package_dir, 'ansible_collections')
         os.mkdir(ansible_collections_dir, mode=0o700)
 
-<<<<<<< HEAD
+        # Install collections
         # TODO: PY3.8:
         # collections_to_install = [p for f in os.listdir(download_dir)
         #                           if os.path.isfile(p := os.path.join(download_dir, f))]
@@ -196,6 +204,12 @@ def build_single_command():
                 collections_to_install.append(path)
 
         asyncio.run(install_together(collections_to_install, ansible_collections_dir))
+
+        # Compose and write release notes
+        release_notes = ReleaseNotes.build(changelog)
+        release_notes.write_to(package_dir)
+
+        # Write build scripts and files
         write_build_script(app_ctx.extra['acd_version'], ansible_base_version, package_dir)
         write_python_build_files(app_ctx.extra['acd_version'], ansible_base_version, '',
                                  package_dir, app_ctx.extra['debian'])
@@ -205,28 +219,10 @@ def build_single_command():
 
     deps_filename = os.path.join(app_ctx.extra['dest_dir'], app_ctx.extra['deps_file'])
     deps_file = DepsFile(deps_filename)
-    deps_file.write(app_ctx.extra['acd_version'], ansible_base_version, included_versions)
-=======
-        # Install collections
-        collections_to_install = [p for f in os.listdir(download_dir)
-                                  if os.path.isfile(p := os.path.join(download_dir, f))]
-        asyncio.run(install_together(collections_to_install, ansible_collections_dir))
-
-        # Write build scripts and files
-        write_build_script(args.acd_version, ansible_base_version, package_dir)
-        write_python_build_files(args.acd_version, ansible_base_version, '',
-                                 package_dir, args.debian)
-        if args.debian:
-            write_debian_directory(args.acd_version, package_dir)
-        make_dist(package_dir, args.dest_dir)
-
-    deps_filename = os.path.join(args.dest_dir, args.deps_file)
-    deps_file = DepsFile(deps_filename)
     deps_file.write(
         new_dependencies.ansible_version,
         new_dependencies.ansible_base_version,
         new_dependencies.deps)
->>>>>>> 7a0a573... Improve comments, fix type bugs that pyre missed.
 
     return 0
 

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -237,7 +237,8 @@ def add_plugins(builder: RstBuilder,
             for plugin_type, plugin_datas in release_entry.plugins.items():
                 for plugin_data in plugin_datas:
                     plugins.append((
-                        ['New Plugins', plugin_type.title(), name],
+                        # ['New Plugins', plugin_type.title(), name],
+                        ['New Plugins', plugin_type.title()],
                         prefix + plugin_data['name'],
                         plugin_data['description']))
     dump_plugins(builder, plugins)

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -22,7 +22,7 @@ from .changelog import (
 )
 
 
-def append_ansible_base_changelog(builder: RstBuilder, changelog_entry: ChangelogEntry):
+def append_ansible_base_changelog(builder: RstBuilder, changelog_entry: ChangelogEntry) -> None:
     builder.add_section('Ansible Base', 1)
 
     builder.add_raw_rst(f"Ansible {changelog_entry.version} contains Ansible-base "
@@ -52,7 +52,7 @@ def append_ansible_base_changelog(builder: RstBuilder, changelog_entry: Changelo
 
 def append_collection_changelog(builder: RstBuilder, changelog_entry: ChangelogEntry,
                                 collector: CollectionChangelogCollector,
-                                collection_version: str, prev_collection_version: t.Optional[str]):
+                                collection_version: str, prev_collection_version: t.Optional[str]) -> None:
     if collector in changelog_entry.added_collections:
         builder.add_section(f"{collector.collection} (New)", 1)
         builder.add_raw_rst(f"The collection {collector.collection} was "
@@ -95,7 +95,7 @@ def append_collection_changelog(builder: RstBuilder, changelog_entry: ChangelogE
             builder, release, start_level=1, add_version=False)
 
 
-def append_changelog(builder: RstBuilder, changelog_entry: ChangelogEntry):
+def append_changelog(builder: RstBuilder, changelog_entry: ChangelogEntry) -> None:
     builder.add_section('v{0}'.format(changelog_entry.version_str), 0)
 
     if changelog_entry.removed_collections:
@@ -139,7 +139,7 @@ def append_porting_guide_section(builder: RstBuilder, changelog_entry: Changelog
             name: str,
             collector: t.Union[AnsibleBaseChangelogCollector, CollectionChangelogCollector],
             version: str,
-            prev_version: t.Optional[str]):
+            prev_version: t.Optional[str]) -> None:
         changelog = collector.changelog
         generator = collector.changelog_generator
         if not changelog or not generator:
@@ -166,8 +166,8 @@ def append_porting_guide_section(builder: RstBuilder, changelog_entry: Changelog
             collector.collection, collector, collection_version, prev_collection_version)
 
 
-def append_porting_guide(builder: RstBuilder, changelog_entry: ChangelogEntry):
-    def add_title():
+def append_porting_guide(builder: RstBuilder, changelog_entry: ChangelogEntry) -> None:
+    def add_title() -> None:
         builder.add_section('Porting Guide for v{0}'.format(changelog_entry.version_str), 0)
         while True:
             yield
@@ -189,7 +189,7 @@ def append_porting_guide(builder: RstBuilder, changelog_entry: ChangelogEntry):
         append_porting_guide_section(builder, changelog_entry, maybe_add_title, section)
 
 
-def insert_after_heading(lines: t.List[str], content: str):
+def insert_after_heading(lines: t.List[str], content: str) -> None:
     has_heading = False
     for index, line in enumerate(lines):
         if line.startswith('***') and line == '*' * len(line):

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -469,11 +469,12 @@ class ReleaseNotes:
             ReleaseNotes._get_porting_guide_bytes(changelog),
         )
 
-    def write_to(self, dest_dir: str) -> None:
+    def write_changelog_to(self, dest_dir: str) -> None:
         path = os.path.join(dest_dir, self.changelog_filename)
         with open(path, 'wb') as changelog_fd:
             changelog_fd.write(self.changelog_bytes)
 
+    def write_porting_guide_to(self, dest_dir: str) -> None:
         path = os.path.join(dest_dir, self.porting_guide_filename)
         with open(path, 'wb') as porting_guide_fd:
             porting_guide_fd.write(self.porting_guide_bytes)
@@ -490,7 +491,9 @@ def build_changelog() -> int:
 
     changelog = get_changelog(acd_version, deps_dir=deps_dir, collection_cache=collection_cache)
 
-    ReleaseNotes.build(changelog).write_to(dest_dir)
+    release_notes = ReleaseNotes.build(changelog)
+    release_notes.write_changelog_to(dest_dir)
+    release_notes.write_porting_guide_to(dest_dir)
 
     missing_changelogs = []
     for collector in changelog.collection_collectors:

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -6,6 +6,7 @@
 
 import asyncio
 from collections import defaultdict
+from functools import partial
 import glob
 import os
 import os.path
@@ -24,6 +25,7 @@ from antsibull_changelog.changes import ChangesData
 from antsibull_changelog.changelog_generator import ChangelogGenerator
 from antsibull_changelog.rst import RstBuilder
 
+from .ansible_base import get_ansible_base
 from .constants import THREAD_MAX
 from .dependency_files import DepsFile, DependencyFileData
 from .galaxy import CollectionDownloader
@@ -51,10 +53,14 @@ async def download_collections(deps, download_dir, collection_cache=None):
     return included_versions
 
 
-def read_changelog_file(tarball_path: str) -> t.Optional[bytes]:
+def read_changelog_file(tarball_path: str, is_ansible_base=False) -> t.Optional[bytes]:
     with tarfile.open(tarball_path, "r:gz") as tar:
         for file in tar:
-            if file.name in ('changelogs/changelog.yaml', 'changelog.yaml'):
+            if is_ansible_base:
+                found = file.name.endswith('changelogs/changelog.yaml')
+            else:
+                found = file.name in ('changelogs/changelog.yaml', 'changelog.yaml')
+            if found:
                 with tar.extractfile(file) as file_p:
                     return file_p.read()
     return None
@@ -117,38 +123,123 @@ class CollectionChangelogCollector:
         self.changelog = ChangesData.concatenate(changelogs)
 
 
+class AnsibleBaseChangelogCollector:
+    versions: t.List[PypiVer]
+    earliest: PypiVer
+    latest: PypiVer
+
+    changelog: t.Optional[ChangesData]
+
+    def __init__(self, versions: t.List[str]):
+        self.versions = sorted(PypiVer(version) for version in versions)
+        self.earliest = self.versions[0]
+        self.latest = self.versions[-1]
+
+        paths = PathsConfig.force_ansible('')
+        collection_details = CollectionDetails(paths)
+        self.config = ChangelogConfig.default(paths, collection_details)
+
+        self.changelog_data = None
+        self.changelog = None
+
+    async def _get_changelog(self, version: PypiVer,
+                             base_downloader: t.Callable[[str], str]
+                             ) -> t.Optional[ChangesData]:
+        path = await base_downloader(str(version))
+        if os.path.isdir(path):
+            for root, _, files in os.walk(path):
+                if 'changelog.yaml' in files:
+                    with open(os.path.join(root, 'changelog.yaml'), 'rb') as f:
+                        changelog = f.read()
+                    changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
+                    return ChangesData(self.config, '/', changelog_data)
+        if os.path.isfile(path) and path.endswith('.tar.gz'):
+            changelog = read_changelog_file(path, x=True)
+            if changelog is None:
+                return None
+            changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
+            return ChangesData(self.config, '/', changelog_data)
+        return None
+
+    async def download(self, base_downloader: t.Callable[[str], str]):
+        changelog = await self._get_changelog(self.latest, base_downloader)
+        if changelog is None:
+            return
+
+        changelog.prune_versions(versions_after=None, versions_until=str(self.latest))
+
+        changelogs = [changelog]
+        ancestor = changelog.ancestor
+        while ancestor is not None:
+            ancestor_ver = PypiVer(ancestor)
+            if ancestor_ver < self.earliest:
+                break
+            changelog = await self._get_changelog(ancestor_ver, base_downloader)
+            if changelog is None:
+                break
+            changelog.prune_versions(versions_after=None, versions_until=ancestor)
+            changelogs.append(changelog)
+            ancestor = changelog.ancestor
+
+        self.changelog = ChangesData.concatenate(changelogs)
+
+    async def download_github(self, aio_session: 'aiohttp.client.ClientSession'):
+        query_url = (f"https://raw.githubusercontent.com/ansible/ansible/"
+                     f"stable-{self.latest.major}.{self.latest.minor}/changelogs/changelog.yaml")
+        async with aio_session.get(query_url) as response:
+            changelog = await response.read()
+        changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
+        self.changelog = ChangesData(self.config, '/', changelog_data)
+
+
 async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
+                             base_collector: AnsibleBaseChangelogCollector,
                              collection_cache: t.Optional[str]):
     with tempfile.TemporaryDirectory() as tmp_dir:
         async with aiohttp.ClientSession() as aio_session:
             async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
                 downloader = CollectionDownloader(aio_session, tmp_dir,
                                                   collection_cache=collection_cache)
+                base_downloader = partial(get_ansible_base, aio_session, tmpdir=tmp_dir)
 
-                requestors = {}
-                for collector in collectors:
-                    requestors[collector.collection] = await pool.spawn(
-                        collector.download(downloader))
-
-                await asyncio.gather(*requestors.values())
+                requestors = [
+                    await pool.spawn(collector.download(downloader)) for collector in collectors
+                ]
+                if False:  # TODO: make this depend on version or something else...
+                    requestors.append(
+                        await pool.spawn(base_collector.download(base_downloader)))
+                else:
+                    requestors.append(
+                        await pool.spawn(base_collector.download_github(aio_session)))
+                await asyncio.gather(*requestors)
 
 
 def append_changelog(builder: RstBuilder, version: PypiVer, version_str: str,
                      prev_version: t.Optional[PypiVer],
+                     base_versions: t.Dict[PypiVer, str],
                      versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]],
+                     base_collector: AnsibleBaseChangelogCollector,
                      collectors: t.List[CollectionChangelogCollector],
                      ):
     builder.add_section('v{0}'.format(version_str), 0)
 
-    # builder.add_section('Ansible Base', 1)
-    # builder.add_raw_rst('.. contents::')
-    # builder.add_raw_rst('  :local:')
-    # builder.add_raw_rst('  :depth: 5\n')
+    if base_collector.changelog:
+        builder.add_section('Ansible Base', 1)
+        builder.add_raw_rst('.. contents::')
+        builder.add_raw_rst('  :local:')
+        builder.add_raw_rst('  :depth: 5\n')
 
-    # generator = ChangelogGenerator(
-    #     ansible_config, ansible_changes, plugins=None, fragments=None, flatmap=True)
-    # generator.generate_to(
-    #     builder, 1, squash=True, after_version=previous_version, until_version=version)
+        base_version: str = base_versions[version]
+
+        prev_base_version = base_versions.get(prev_version)
+
+        generator = ChangelogGenerator(
+            base_collector.config, base_collector.changelog,
+            plugins=None, fragments=None, flatmap=True)
+        generator.generate_to(
+            builder, 1, squash=True,
+            after_version=prev_base_version,
+            until_version=base_version)
 
     for collector in collectors:
         if version not in versions_per_collection[collector.collection]:
@@ -220,6 +311,7 @@ def build_changelog(args):
     versions: t.List[t.Tuple[str, PypiVer, DependencyFileData]] = []
 
     acd_version = args.acd_version
+    base_versions: t.Dict[PypiVer, str] = dict()
     versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]] = defaultdict(dict)
     for path in glob.glob(os.path.join(args.deps_dir, '*.deps'), recursive=False):
         deps_file = DepsFile(path)
@@ -228,16 +320,18 @@ def build_changelog(args):
         if version > acd_version:
             print(f"Ignoring {path}, since {deps.ansible_version} is newer than {acd_version}")
         versions.append((deps.ansible_version, version, deps))
+        base_versions[version] = deps.ansible_base_version
         for collection_name, collection_version in deps.deps.items():
             versions_per_collection[collection_name][version] = collection_version
 
     versions.sort(key=lambda tuple: tuple[1])
 
+    base_collector = AnsibleBaseChangelogCollector(base_versions.values())
     collectors = [
         CollectionChangelogCollector(collection, versions_per_collection[collection].values())
         for collection in sorted(versions_per_collection.keys())
     ]
-    asyncio.run(collect_changelogs(collectors, args.collection_cache))
+    asyncio.run(collect_changelogs(collectors, base_collector, args.collection_cache))
 
     builder = RstBuilder()
     builder.set_title(f"Ansible {acd_version.major}.{acd_version.minor} Release Notes")
@@ -250,7 +344,9 @@ def build_changelog(args):
             prev_version = None
 
         append_changelog(
-            builder, version, version_str, prev_version, versions_per_collection, collectors)
+            builder, version, version_str, prev_version,
+            base_versions, versions_per_collection,
+            base_collector, collectors)
 
     path = os.path.join(args.dest_dir, f"CHANGELOG-v{acd_version.major}.{acd_version.minor}.rst")
     with open(path, 'wb') as changelog_fd:

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -54,11 +54,11 @@ def append_collection_changelog(builder: RstBuilder, changelog_entry: ChangelogE
                                 collector: CollectionChangelogCollector,
                                 collection_version: str, prev_collection_version: t.Optional[str]):
     if collector in changelog_entry.added_collections:
-        builder.add_section(f"{collector.collection.title()} (New)", 1)
+        builder.add_section(f"{collector.collection} (New)", 1)
         builder.add_raw_rst(f"The collection {collector.collection} was "
                             f"added in Ansible {changelog_entry.version}.\n")
     else:
-        builder.add_section(collector.collection.title(), 1)
+        builder.add_section(collector.collection, 1)
         builder.add_raw_rst(f"Ansible {changelog_entry.version} contains "
                             f"{collector.collection} version {collection_version}.")
         if changelog_entry.prev_version:

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -244,7 +244,7 @@ def build_changelog(args):
         os.path.join(args.dest_dir, changelog_filename),
         acd_version, changelog)
 
-    porting_guide_filename = f"porting_guide_v{acd_version.major}.{acd_version.minor}.rst"
+    porting_guide_filename = f"porting_guide_{acd_version.major}.{acd_version.minor}.rst"
     write_porting_guide(
         os.path.join(args.dest_dir, porting_guide_filename),
         acd_version, changelog, base_collector)

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -12,6 +12,7 @@ from packaging.version import Version as PypiVer
 
 from antsibull_changelog.rst import RstBuilder
 
+from . import app_context
 from .changelog import (
     Changelog,
     ChangelogEntry,
@@ -272,13 +273,16 @@ class ReleaseNotes:
             porting_guide_fd.write(self.porting_guide_bytes)
 
 
-def build_changelog(args: t.Any):
+def build_changelog() -> int:
     '''Create changelog and porting guide CLI command.'''
-    acd_version: PypiVer = args.acd_version
-    deps_dir: str = args.deps_dir
-    dest_dir: str = args.dest_dir
-    collection_cache: t.Optional[str] = args.collection_cache
+    app_ctx = app_context.app_ctx.get()
+
+    acd_version: PypiVer = app_ctx.extra['acd_version']
+    deps_dir: str = app_ctx.extra['deps_dir']
+    dest_dir: str = app_ctx.extra['dest_dir']
+    collection_cache: t.Optional[str] = app_ctx.extra['collection_cache']
 
     changelog = get_changelog(acd_version, deps_dir=deps_dir, collection_cache=collection_cache)
 
     ReleaseNotes.build(changelog).write_to(dest_dir)
+    return 0

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -4,321 +4,18 @@
 # License: GPLv3+
 # Copyright: Ansible Project, 2020
 
-import asyncio
-from collections import defaultdict
-import glob
 import os
 import os.path
-import tarfile
-import tempfile
 import typing as t
 
-import aiohttp
-import asyncio_pool
-import yaml
 from packaging.version import Version as PypiVer
-from semantic_version import Version as SemVer
 
-from antsibull_changelog.config import PathsConfig, CollectionDetails, ChangelogConfig
-from antsibull_changelog.changes import ChangesData
-from antsibull_changelog.changelog_generator import ChangelogGenerator
 from antsibull_changelog.rst import RstBuilder
 
-from .ansible_base import get_ansible_base
-from .constants import THREAD_MAX
-from .dependency_files import DepsFile, DependencyFileData
-from .galaxy import CollectionDownloader
-
-
-async def download_collections(deps, download_dir, collection_cache=None):
-    requestors = {}
-    async with aiohttp.ClientSession() as aio_session:
-        async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
-            downloader = CollectionDownloader(aio_session, download_dir,
-                                              collection_cache=collection_cache)
-            for collection_name, version_spec in deps.items():
-                requestors[collection_name] = await pool.spawn(
-                    downloader.download_latest_matching(collection_name, version_spec))
-
-            included_versions = {}
-            responses = await asyncio.gather(*requestors.values())
-
-    # Note: Python dicts have a stable sort order and since we haven't modified the dict since we
-    # used requestors.values() to generate responses, requestors and responses therefor have
-    # a matching order.
-    for collection_name, results in zip(requestors, responses):
-        included_versions[collection_name] = results.version
-
-    return included_versions
-
-
-def read_file(tarball_path: str, matcher: t.Callable[[str], bool]) -> t.Optional[bytes]:
-    with tarfile.open(tarball_path, "r:gz") as tar:
-        for file in tar:
-            if matcher(file.name):
-                file_p = tar.extractfile(file)
-                if file_p:
-                    with file_p:
-                        return file_p.read()
-    return None
-
-
-def read_changelog_file(tarball_path: str, is_ansible_base=False) -> t.Optional[bytes]:
-    def matcher(filename: str) -> bool:
-        if is_ansible_base:
-            return filename.endswith('changelogs/changelog.yaml')
-        else:
-            return filename in ('changelogs/changelog.yaml', 'changelog.yaml')
-
-    return read_file(tarball_path, matcher)
-
-
-def get_porting_guide_filename(version: PypiVer):
-    return f"docs/docsite/rst/porting_guides/porting_guide_{version}.rst"
-
-
-def read_porting_guide_file(tarball_path: str, version: PypiVer) -> t.Optional[bytes]:
-    filename = get_porting_guide_filename(version)
-    return read_file(tarball_path, lambda fn: fn == filename)
-
-
-class CollectionChangelogCollector:
-    collection: str
-    versions: t.List[SemVer]
-    earliest: SemVer
-    latest: SemVer
-
-    changelog: t.Optional[ChangesData]
-
-    def __init__(self, collection: str, versions: t.ValuesView[str]):
-        self.collection = collection
-        self.versions = sorted(SemVer(version) for version in versions)
-        self.earliest = self.versions[0]
-        self.latest = self.versions[-1]
-
-        paths = PathsConfig.force_collection('')
-        collection_details = CollectionDetails(paths)
-        collection_details.namespace, collection_details.name = collection.split('.', 1)
-        collection_details.version = str(self.latest)
-        collection_details.flatmap = False  # TODO!
-        self.config = ChangelogConfig.default(paths, collection_details)
-
-        self.changelog_data = None
-        self.changelog = None
-
-    async def _get_changelog(self, version: SemVer,
-                             collection_downloader: CollectionDownloader
-                             ) -> t.Optional[ChangesData]:
-        path = await collection_downloader.download(self.collection, version)
-        changelog = read_changelog_file(path)
-        if changelog is None:
-            return None
-        changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
-        return ChangesData(self.config, '/', changelog_data)
-
-    async def download(self, collection_downloader: CollectionDownloader):
-        changelog = await self._get_changelog(self.latest, collection_downloader)
-        if changelog is None:
-            return
-
-        changelog.prune_versions(versions_after=None, versions_until=str(self.latest))
-
-        changelogs = [changelog]
-        ancestor = changelog.ancestor
-        while ancestor is not None:
-            ancestor_ver = SemVer(ancestor)
-            if ancestor_ver < self.earliest:
-                break
-            changelog = await self._get_changelog(ancestor_ver, collection_downloader)
-            if changelog is None:
-                break
-            changelog.prune_versions(versions_after=None, versions_until=ancestor)
-            changelogs.append(changelog)
-            ancestor = changelog.ancestor
-
-        self.changelog = ChangesData.concatenate(changelogs)
-
-
-class AnsibleBaseChangelogCollector:
-    versions: t.List[PypiVer]
-    earliest: PypiVer
-    latest: PypiVer
-
-    changelog: t.Optional[ChangesData]
-    porting_guide: t.Optional[bytes]
-
-    def __init__(self, versions: t.ValuesView[str]):
-        self.versions = sorted(PypiVer(version) for version in versions)
-        self.earliest = self.versions[0]
-        self.latest = self.versions[-1]
-
-        paths = PathsConfig.force_ansible('')
-        collection_details = CollectionDetails(paths)
-        self.config = ChangelogConfig.default(paths, collection_details)
-
-        self.changelog_data = None
-        self.changelog = None
-        self.porting_guide = None
-
-    async def _get_files(self, version: PypiVer,
-                         base_downloader: t.Callable[[str], t.Awaitable[str]]
-                         ) -> t.Tuple[t.Optional[ChangesData], t.Optional[bytes]]:
-        path = await base_downloader(str(version))
-        if os.path.isdir(path):
-            pg_path, pg_filename = os.path.split(get_porting_guide_filename(version))
-            changelog = None
-            porting_guide = None
-            for root, _, files in os.walk(path):
-                if 'changelog.yaml' in files:
-                    with open(os.path.join(root, 'changelog.yaml'), 'rb') as f:
-                        changelog = f.read()
-                    changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
-                    changelog = ChangesData(self.config, '/', changelog_data)
-                if pg_filename in files:
-                    print(path, os.path.join(path, pg_path), root)
-                    if os.path.join(path, pg_path) == root:
-                        with open(os.path.join(path, pg_path), 'rb') as f:
-                            porting_guide = f.read()
-            return changelog_data, porting_guide
-        if os.path.isfile(path) and path.endswith('.tar.gz'):
-            changelog = read_changelog_file(path, is_ansible_base=True)
-            porting_guide = read_porting_guide_file(path, version)
-            if changelog is None:
-                return (None, porting_guide)
-            changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
-            return (ChangesData(self.config, '/', changelog_data), porting_guide)
-        return None, None
-
-    async def download(self, base_downloader: t.Callable[[str], t.Awaitable[str]]):
-        changelog, porting_guide = await self._get_files(self.latest, base_downloader)
-        if porting_guide:
-            self.porting_guide = porting_guide
-        if changelog is None:
-            return
-
-        changelog.prune_versions(versions_after=None, versions_until=str(self.latest))
-
-        changelogs = [changelog]
-        ancestor = changelog.ancestor
-        while ancestor is not None:
-            ancestor_ver = PypiVer(ancestor)
-            if ancestor_ver < self.earliest:
-                break
-            changelog, _ = await self._get_files(ancestor_ver, base_downloader)
-            if changelog is None:
-                break
-            changelog.prune_versions(versions_after=None, versions_until=ancestor)
-            changelogs.append(changelog)
-            ancestor = changelog.ancestor
-
-        self.changelog = ChangesData.concatenate(changelogs)
-
-    async def download_github(self, aio_session: 'aiohttp.client.ClientSession'):
-        branch_url = (f"https://raw.githubusercontent.com/ansible/ansible/"
-                      f"stable-{self.latest.major}.{self.latest.minor}/")
-
-        # Changelog
-        query_url = f"{branch_url}/changelogs/changelog.yaml"
-        async with aio_session.get(query_url) as response:
-            changelog = await response.read()
-        changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
-        self.changelog = ChangesData(self.config, '/', changelog_data)
-
-        # Porting Guide
-        query_url = f"{branch_url}/{get_porting_guide_filename(self.latest)}"
-        async with aio_session.get(query_url) as response:
-            self.porting_guide = await response.read()
-
-
-async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
-                             base_collector: AnsibleBaseChangelogCollector,
-                             collection_cache: t.Optional[str]):
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        async with aiohttp.ClientSession() as aio_session:
-            async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
-                downloader = CollectionDownloader(aio_session, tmp_dir,
-                                                  collection_cache=collection_cache)
-
-                async def base_downloader(version):
-                    return await get_ansible_base(aio_session, version, tmp_dir)
-
-                requestors = [
-                    await pool.spawn(collector.download(downloader)) for collector in collectors
-                ]
-                if False:  # TODO: make this depend on version or something else...
-                    requestors.append(
-                        await pool.spawn(base_collector.download(base_downloader)))
-                else:
-                    requestors.append(
-                        await pool.spawn(base_collector.download_github(aio_session)))
-                await asyncio.gather(*requestors)
-
-
-class ChangelogEntry:
-    version: PypiVer
-    version_str: str
-
-    prev_version: t.Optional[PypiVer]
-    base_versions: t.Dict[PypiVer, str]
-    versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]]
-
-    base_collector: AnsibleBaseChangelogCollector
-    collectors: t.List[CollectionChangelogCollector]
-
-    ansible_base_version: str
-    prev_ansible_base_version: t.Optional[str]
-
-    removed_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
-    added_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
-    unchanged_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
-    changed_collections: t.List[t.Tuple[CollectionChangelogCollector, str, t.Optional[str]]]
-
-    def __init__(self, version: PypiVer, version_str: str,
-                 prev_version: t.Optional[PypiVer],
-                 base_versions: t.Dict[PypiVer, str],
-                 versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]],
-                 base_collector: AnsibleBaseChangelogCollector,
-                 collectors: t.List[CollectionChangelogCollector]):
-        self.version = version
-        self.version_str = version_str
-        self.prev_version = prev_version
-        self.base_versions = base_versions
-        self.versions_per_collection = versions_per_collection
-        self.base_collector = base_collector
-        self.collectors = collectors
-
-        self.ansible_base_version = base_versions[version]
-        self.prev_ansible_base_version = base_versions.get(prev_version) if prev_version else None
-
-        self.removed_collections = []
-        self.added_collections = []
-        self.unchanged_collections = []
-        self.changed_collections = []
-        for collector in collectors:
-            if version not in versions_per_collection[collector.collection]:
-                print(f"WARNING: {collector.collection} is not included in Ansible {version}")
-
-                if prev_version and prev_version in versions_per_collection[collector.collection]:
-                    self.removed_collections.append((
-                        collector, versions_per_collection[collector.collection][prev_version]))
-
-                continue
-
-            collection_version: str = versions_per_collection[collector.collection][version]
-
-            prev_collection_version: t.Optional[str] = (
-                versions_per_collection[collector.collection].get(prev_version)
-                if prev_version else None
-            )
-            if prev_version:
-                if not prev_collection_version:
-                    self.added_collections.append((collector, collection_version))
-                elif prev_collection_version == collection_version:
-                    self.unchanged_collections.append((collector, collection_version))
-                    continue
-
-            self.changed_collections.append((
-                collector, collection_version, prev_collection_version))
+from .changelog import (
+    ChangelogEntry, CollectionChangelogCollector, AnsibleBaseChangelogCollector,
+    get_changelog_data,
+)
 
 
 def append_ansible_base_changelog(builder: RstBuilder, changelog_entry: ChangelogEntry):
@@ -337,14 +34,12 @@ def append_ansible_base_changelog(builder: RstBuilder, changelog_entry: Changelo
                                 f"{changelog_entry.prev_ansible_base_version} contained in the "
                                 f"previous Ansible release.\n")
 
-    if not same_version:
+    generator = changelog_entry.base_collector.changelog_generator
+    if not same_version and generator:
         builder.add_raw_rst('.. contents::')
         builder.add_raw_rst('  :local:')
         builder.add_raw_rst('  :depth: 5\n')
 
-        generator = ChangelogGenerator(
-            changelog_entry.base_collector.config, changelog_entry.base_collector.changelog,
-            plugins=None, fragments=None, flatmap=True)
         generator.generate_to(
             builder, 1, squash=True,
             after_version=changelog_entry.prev_ansible_base_version,
@@ -370,7 +65,8 @@ def append_collection_changelog(builder: RstBuilder, changelog_entry: ChangelogE
             builder.add_raw_rst('')
 
     changelog = collector.changelog
-    if not changelog:
+    generator = collector.changelog_generator
+    if not changelog or not generator:
         builder.add_raw_rst(f"Unfortunately, {collector.collection} has no Ansible "
                             f"compatible changelog.\n")
         # TODO: add link to collection's changelog
@@ -381,11 +77,6 @@ def append_collection_changelog(builder: RstBuilder, changelog_entry: ChangelogE
         builder.add_raw_rst("There are no changes recorded in the changelog, or "
                             "the collection did not have a changelog in this version.\n")
         return
-
-    flatmap = True  # TODO
-    generator = ChangelogGenerator(
-        collector.config, changelog,
-        plugins=None, fragments=None, flatmap=flatmap)
 
     builder.add_raw_rst('.. contents::')
     builder.add_raw_rst('  :local:')
@@ -502,48 +193,6 @@ def write_porting_guide(path: str, acd_version: PypiVer,
 
     with open(path, 'wb') as porting_guide_fd:
         porting_guide_fd.write(builder.generate().encode('utf-8'))
-
-
-def get_changelog_data(
-        acd_version: PypiVer, deps_dir: str, collection_cache: str
-        ) -> t.Tuple[t.List[ChangelogEntry], AnsibleBaseChangelogCollector]:
-    base_versions: t.Dict[PypiVer, str] = dict()
-    versions: t.List[t.Tuple[str, PypiVer, DependencyFileData]] = []
-    versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]] = defaultdict(dict)
-    for path in glob.glob(os.path.join(deps_dir, '*.deps'), recursive=False):
-        deps_file = DepsFile(path)
-        deps = deps_file.parse()
-        version = PypiVer(deps.ansible_version)
-        if version > acd_version:
-            print(f"Ignoring {path}, since {deps.ansible_version} is newer than {acd_version}")
-        versions.append((deps.ansible_version, version, deps))
-        base_versions[version] = deps.ansible_base_version
-        for collection_name, collection_version in deps.deps.items():
-            versions_per_collection[collection_name][version] = collection_version
-
-    versions.sort(key=lambda tuple: tuple[1])
-
-    base_collector = AnsibleBaseChangelogCollector(base_versions.values())
-    collectors = [
-        CollectionChangelogCollector(collection, versions_per_collection[collection].values())
-        for collection in sorted(versions_per_collection.keys())
-    ]
-    asyncio.run(collect_changelogs(collectors, base_collector, collection_cache))
-
-    changelog = []
-
-    for index, (version_str, version, deps) in enumerate(reversed(versions)):
-        if index + 1 < len(versions):
-            prev_version = versions[len(versions) - index - 2][1]
-        else:
-            prev_version = None
-
-        changelog.append(ChangelogEntry(
-            version, version_str, prev_version,
-            base_versions, versions_per_collection,
-            base_collector, collectors))
-
-    return changelog, base_collector
 
 
 def build_changelog(args):

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -249,9 +249,9 @@ def add_modules(builder: RstBuilder,
     for name, prefix, _, release_entries in data:
         for release_entry in release_entries:
             for module in release_entry.modules:
-                namespace = module['namespace'].split('.') if module['namespace'] else []
+                namespace = module['namespace'].split('.', 1) if module['namespace'] else []
                 modules.append((
-                    ['New Modules', name] + [ns.title() for ns in namespace],
+                    ['New Modules', name] + [ns.replace('_', ' ').title() for ns in namespace],
                     prefix + module['name'],
                     module['description']))
     dump_plugins(builder, modules)

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -460,13 +460,13 @@ class ReleaseNotes:
 
         return builder.generate().encode('utf-8')
 
-    @staticmethod
-    def build(changelog: Changelog) -> 'ReleaseNotes':
-        return ReleaseNotes(
+    @classmethod
+    def build(cls, changelog: Changelog) -> 'ReleaseNotes':
+        return cls(
             f"CHANGELOG-v{changelog.acd_version.major}.{changelog.acd_version.minor}.rst",
-            ReleaseNotes._get_changelog_bytes(changelog),
+            cls._get_changelog_bytes(changelog),
             f"porting_guide_{changelog.acd_version.major}.{changelog.acd_version.minor}.rst",
-            ReleaseNotes._get_porting_guide_bytes(changelog),
+            cls._get_porting_guide_bytes(changelog),
         )
 
     def write_changelog_to(self, dest_dir: str) -> None:

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -1,0 +1,257 @@
+# coding: utf-8
+# Author: Felix Fontein <tkuratom@redhat.com>
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2020
+
+import asyncio
+from collections import defaultdict
+import glob
+import os
+import os.path
+import tarfile
+import tempfile
+import typing as t
+
+import aiohttp
+import asyncio_pool
+import yaml
+from packaging.version import Version as PypiVer
+from semantic_version import Version as SemVer
+
+from antsibull_changelog.config import PathsConfig, CollectionDetails, ChangelogConfig
+from antsibull_changelog.changes import ChangesData
+from antsibull_changelog.changelog_generator import ChangelogGenerator
+from antsibull_changelog.rst import RstBuilder
+
+from .constants import THREAD_MAX
+from .dependency_files import DepsFile, DependencyFileData
+from .galaxy import CollectionDownloader
+
+
+async def download_collections(deps, download_dir, collection_cache=None):
+    requestors = {}
+    async with aiohttp.ClientSession() as aio_session:
+        async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
+            downloader = CollectionDownloader(aio_session, download_dir,
+                                              collection_cache=collection_cache)
+            for collection_name, version_spec in deps.items():
+                requestors[collection_name] = await pool.spawn(
+                    downloader.download_latest_matching(collection_name, version_spec))
+
+            included_versions = {}
+            responses = await asyncio.gather(*requestors.values())
+
+    # Note: Python dicts have a stable sort order and since we haven't modified the dict since we
+    # used requestors.values() to generate responses, requestors and responses therefor have
+    # a matching order.
+    for collection_name, results in zip(requestors, responses):
+        included_versions[collection_name] = results.version
+
+    return included_versions
+
+
+def read_changelog_file(tarball_path: str) -> t.Optional[bytes]:
+    with tarfile.open(tarball_path, "r:gz") as tar:
+        for file in tar:
+            if file.name in ('changelogs/changelog.yaml', 'changelog.yaml'):
+                with tar.extractfile(file) as file_p:
+                    return file_p.read()
+    return None
+
+
+class CollectionChangelogCollector:
+    collection: str
+    versions: t.List[SemVer]
+    earliest: SemVer
+    latest: SemVer
+
+    changelog: t.Optional[ChangesData]
+
+    def __init__(self, collection: str, versions: t.List[str]):
+        self.collection = collection
+        self.versions = sorted(SemVer(version) for version in versions)
+        self.earliest = self.versions[0]
+        self.latest = self.versions[-1]
+
+        paths = PathsConfig.force_collection('')
+        collection_details = CollectionDetails(paths)
+        collection_details.namespace, collection_details.name = collection.split('.', 1)
+        collection_details.version = str(self.latest)
+        collection_details.flatmap = False  # TODO!
+        self.config = ChangelogConfig.default(paths, collection_details)
+
+        self.changelog_data = None
+        self.changelog = None
+
+    async def _get_changelog(self, version: SemVer,
+                             collection_downloader: CollectionDownloader
+                             ) -> t.Optional[ChangesData]:
+        path = await collection_downloader.download(self.collection, version)
+        changelog = read_changelog_file(path)
+        if changelog is None:
+            return None
+        changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
+        return ChangesData(self.config, '/', changelog_data)
+
+    async def download(self, collection_downloader: CollectionDownloader):
+        changelog = await self._get_changelog(self.latest, collection_downloader)
+        if changelog is None:
+            return
+
+        changelog.prune_versions(versions_after=None, versions_until=str(self.latest))
+
+        changelogs = [changelog]
+        ancestor = changelog.ancestor
+        while ancestor is not None:
+            ancestor_ver = SemVer(ancestor)
+            if ancestor_ver < self.earliest:
+                break
+            changelog = await self._get_changelog(ancestor_ver, collection_downloader)
+            if changelog is None:
+                break
+            changelog.prune_versions(versions_after=None, versions_until=ancestor)
+            changelogs.append(changelog)
+            ancestor = changelog.ancestor
+
+        self.changelog = ChangesData.concatenate(changelogs)
+
+
+async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
+                             collection_cache: t.Optional[str]):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        async with aiohttp.ClientSession() as aio_session:
+            async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
+                downloader = CollectionDownloader(aio_session, tmp_dir,
+                                                  collection_cache=collection_cache)
+
+                requestors = {}
+                for collector in collectors:
+                    requestors[collector.collection] = await pool.spawn(
+                        collector.download(downloader))
+
+                await asyncio.gather(*requestors.values())
+
+
+def append_changelog(builder: RstBuilder, version: PypiVer, version_str: str,
+                     prev_version: t.Optional[PypiVer],
+                     versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]],
+                     collectors: t.List[CollectionChangelogCollector],
+                     ):
+    builder.add_section('v{0}'.format(version_str), 0)
+
+    # builder.add_section('Ansible Base', 1)
+    # builder.add_raw_rst('.. contents::')
+    # builder.add_raw_rst('  :local:')
+    # builder.add_raw_rst('  :depth: 5\n')
+
+    # generator = ChangelogGenerator(
+    #     ansible_config, ansible_changes, plugins=None, fragments=None, flatmap=True)
+    # generator.generate_to(
+    #     builder, 1, squash=True, after_version=previous_version, until_version=version)
+
+    for collector in collectors:
+        if version not in versions_per_collection[collector.collection]:
+            print(f"WARNING: {collector.collection} is not included in Ansible {version}")
+
+            if prev_version and prev_version in versions_per_collection[collector.collection]:
+                builder.add_section(f"{collector.collection.title()} Was Removed", 1)
+                builder.add_raw_rst(f"The collection {collector.collection} was removed "
+                                    f"in Ansible {version}.\n")
+
+            continue
+
+        collection_version: str = versions_per_collection[collector.collection][version]
+
+        prev_collection_version: t.Optional[str] = None
+        if prev_version and prev_version not in versions_per_collection[collector.collection]:
+            builder.add_section(f"{collector.collection.title()} (New)", 1)
+            builder.add_raw_rst(f"The collection {collector.collection} was "
+                                f"added in Ansible {version}.\n")
+        else:
+            builder.add_section(collector.collection.title(), 1)
+            builder.add_raw_rst(f"Ansible {version} contains {collector.collection} "
+                                f"version {collection_version}.")
+            if prev_version:
+                prev_collection_version = (
+                    versions_per_collection[collector.collection][prev_version]
+                )
+                if prev_collection_version == collection_version:
+                    builder.add_raw_rst("This is the same version as in the previous "
+                                        "Ansible release.\n")
+                    continue
+                else:
+                    builder.add_raw_rst(f"This is a newer version than version "
+                                        f"{prev_collection_version} contained in the "
+                                        f"previous Ansible release.\n")
+            else:
+                builder.add_raw_rst('')
+
+        if not collector.changelog:
+            builder.add_raw_rst(f"Unfortunately, {collector.collection} has no Ansible "
+                                f"compatible changelog.\n")
+            # TODO: add link to collection's changelog
+            continue
+
+        # TODO: actually check that there are no release information for this version range!
+        if not collector.changelog.releases:
+            builder.add_raw_rst("There are no changes recorded in the changelog, or "
+                                "the collection did not have a changelog in this version.\n")
+            continue
+
+        flatmap = True  # TODO
+        generator = ChangelogGenerator(
+            collector.config, collector.changelog,
+            plugins=None, fragments=None, flatmap=flatmap)
+
+        builder.add_raw_rst('.. contents::')
+        builder.add_raw_rst('  :local:')
+        builder.add_raw_rst('  :depth: 5\n')
+
+        generator.generate_to(
+            builder, 1, squash=True,
+            after_version=prev_collection_version,
+            until_version=collection_version)
+
+
+def build_changelog(args):
+    # args.dest_dir
+
+    versions: t.List[t.Tuple[str, PypiVer, DependencyFileData]] = []
+
+    acd_version = args.acd_version
+    versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]] = defaultdict(dict)
+    for path in glob.glob(os.path.join(args.deps_dir, '*.deps'), recursive=False):
+        deps_file = DepsFile(path)
+        deps = deps_file.parse()
+        version = PypiVer(deps.ansible_version)
+        if version > acd_version:
+            print(f"Ignoring {path}, since {deps.ansible_version} is newer than {acd_version}")
+        versions.append((deps.ansible_version, version, deps))
+        for collection_name, collection_version in deps.deps.items():
+            versions_per_collection[collection_name][version] = collection_version
+
+    versions.sort(key=lambda tuple: tuple[1])
+
+    collectors = [
+        CollectionChangelogCollector(collection, versions_per_collection[collection].values())
+        for collection in sorted(versions_per_collection.keys())
+    ]
+    asyncio.run(collect_changelogs(collectors, args.collection_cache))
+
+    builder = RstBuilder()
+    builder.set_title(f"Ansible {acd_version.major}.{acd_version.minor} Release Notes")
+    builder.add_raw_rst('.. contents::\n  :local:\n  :depth: 2\n')
+
+    for index, (version_str, version, deps) in enumerate(reversed(versions)):
+        if index + 1 < len(versions):
+            prev_version = versions[len(versions) - index - 2][1]
+        else:
+            prev_version = None
+
+        append_changelog(
+            builder, version, version_str, prev_version, versions_per_collection, collectors)
+
+    path = os.path.join(args.dest_dir, f"CHANGELOG-v{acd_version.major}.{acd_version.minor}.rst")
+    with open(path, 'wb') as changelog_fd:
+        changelog_fd.write(builder.generate().encode('utf-8'))

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -285,4 +285,14 @@ def build_changelog() -> int:
     changelog = get_changelog(acd_version, deps_dir=deps_dir, collection_cache=collection_cache)
 
     ReleaseNotes.build(changelog).write_to(dest_dir)
+
+    missing_changelogs = []
+    for collector in changelog.collection_collectors:
+        if collector.changelog is None:
+            missing_changelogs.append(collector.collection)
+    if missing_changelogs:
+        print(f"{len(missing_changelogs)} out of {len(changelog.collection_collectors)} collections"
+              f" have no compatible changelog:")
+        for changelog in missing_changelogs:
+            print(f"    {changelog}")
     return 0

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -320,14 +320,17 @@ class Changelog:
     acd_version: PypiVer
     entries: t.List[ChangelogEntry]
     base_collector: AnsibleBaseChangelogCollector
+    collection_collectors: t.List[CollectionChangelogCollector]
 
     def __init__(self,
                  acd_version: PypiVer,
                  entries: t.List[ChangelogEntry],
-                 base_collector: AnsibleBaseChangelogCollector):
+                 base_collector: AnsibleBaseChangelogCollector,
+                 collection_collectors: t.List[CollectionChangelogCollector]):
         self.acd_version = acd_version
         self.entries = entries
         self.base_collector = base_collector
+        self.collection_collectors = collection_collectors
 
 
 def get_changelog(
@@ -381,4 +384,4 @@ def get_changelog(
             base_versions, versions_per_collection,
             base_collector, collectors))
 
-    return Changelog(acd_version, changelog, base_collector)
+    return Changelog(acd_version, changelog, base_collector, collectors)

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -23,8 +23,8 @@ from antsibull_changelog.config import PathsConfig, CollectionDetails, Changelog
 from antsibull_changelog.changes import ChangesData
 from antsibull_changelog.changelog_generator import ChangelogGenerator
 
+from . import app_context
 from .ansible_base import get_ansible_base
-from .constants import THREAD_MAX
 from .dependency_files import DepsFile, DependencyFileData
 from .galaxy import CollectionDownloader
 
@@ -227,9 +227,10 @@ class AnsibleBaseChangelogCollector:
 async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
                              base_collector: AnsibleBaseChangelogCollector,
                              collection_cache: t.Optional[str]):
+    lib_ctx = app_context.lib_ctx.get()
     with tempfile.TemporaryDirectory() as tmp_dir:
         async with aiohttp.ClientSession() as aio_session:
-            async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
+            async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
                 downloader = CollectionDownloader(aio_session, tmp_dir,
                                                   collection_cache=collection_cache)
 

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -1,0 +1,379 @@
+# coding: utf-8
+# Author: Felix Fontein <tkuratom@redhat.com>
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2020
+
+import asyncio
+from collections import defaultdict
+import glob
+import os
+import os.path
+import tarfile
+import tempfile
+import typing as t
+
+import aiohttp
+import asyncio_pool
+import yaml
+from packaging.version import Version as PypiVer
+from semantic_version import Version as SemVer
+
+from antsibull_changelog.config import PathsConfig, CollectionDetails, ChangelogConfig
+from antsibull_changelog.changes import ChangesData
+from antsibull_changelog.changelog_generator import ChangelogGenerator
+
+from .ansible_base import get_ansible_base
+from .constants import THREAD_MAX
+from .dependency_files import DepsFile, DependencyFileData
+from .galaxy import CollectionDownloader
+
+
+async def download_collections(deps, download_dir, collection_cache=None):
+    requestors = {}
+    async with aiohttp.ClientSession() as aio_session:
+        async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
+            downloader = CollectionDownloader(aio_session, download_dir,
+                                              collection_cache=collection_cache)
+            for collection_name, version_spec in deps.items():
+                requestors[collection_name] = await pool.spawn(
+                    downloader.download_latest_matching(collection_name, version_spec))
+
+            included_versions = {}
+            responses = await asyncio.gather(*requestors.values())
+
+    # Note: Python dicts have a stable sort order and since we haven't modified the dict since we
+    # used requestors.values() to generate responses, requestors and responses therefor have
+    # a matching order.
+    for collection_name, results in zip(requestors, responses):
+        included_versions[collection_name] = results.version
+
+    return included_versions
+
+
+def read_file(tarball_path: str, matcher: t.Callable[[str], bool]) -> t.Optional[bytes]:
+    with tarfile.open(tarball_path, "r:gz") as tar:
+        for file in tar:
+            if matcher(file.name):
+                file_p = tar.extractfile(file)
+                if file_p:
+                    with file_p:
+                        return file_p.read()
+    return None
+
+
+def read_changelog_file(tarball_path: str, is_ansible_base=False) -> t.Optional[bytes]:
+    def matcher(filename: str) -> bool:
+        if is_ansible_base:
+            return filename.endswith('changelogs/changelog.yaml')
+        else:
+            return filename in ('changelogs/changelog.yaml', 'changelog.yaml')
+
+    return read_file(tarball_path, matcher)
+
+
+def get_porting_guide_filename(version: PypiVer):
+    return f"docs/docsite/rst/porting_guides/porting_guide_{version.major}.{version.minor}.rst"
+
+
+def read_porting_guide_file(tarball_path: str, version: PypiVer) -> t.Optional[bytes]:
+    filename = get_porting_guide_filename(version)
+    return read_file(tarball_path, lambda fn: fn == filename)
+
+
+class CollectionChangelogCollector:
+    collection: str
+    versions: t.List[SemVer]
+    earliest: SemVer
+    latest: SemVer
+
+    config: ChangelogConfig
+
+    changelog: t.Optional[ChangesData]
+    changelog_generator: t.Optional[ChangelogGenerator]
+
+    def __init__(self, collection: str, versions: t.ValuesView[str]):
+        self.collection = collection
+        self.versions = sorted(SemVer(version) for version in versions)
+        self.earliest = self.versions[0]
+        self.latest = self.versions[-1]
+
+        paths = PathsConfig.force_collection('')
+        collection_details = CollectionDetails(paths)
+        collection_details.namespace, collection_details.name = collection.split('.', 1)
+        collection_details.version = str(self.latest)
+        collection_details.flatmap = False  # TODO!
+        self.config = ChangelogConfig.default(paths, collection_details)
+
+        self.changelog = None
+        self.changelog_generator = None
+
+    async def _get_changelog(self, version: SemVer,
+                             collection_downloader: CollectionDownloader
+                             ) -> t.Optional[ChangesData]:
+        path = await collection_downloader.download(self.collection, version)
+        changelog = read_changelog_file(path)
+        if changelog is None:
+            return None
+        changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
+        return ChangesData(self.config, '/', changelog_data)
+
+    async def download(self, collection_downloader: CollectionDownloader):
+        changelog = await self._get_changelog(self.latest, collection_downloader)
+        if changelog is None:
+            return
+
+        changelog.prune_versions(versions_after=None, versions_until=str(self.latest))
+
+        changelogs = [changelog]
+        ancestor = changelog.ancestor
+        while ancestor is not None:
+            ancestor_ver = SemVer(ancestor)
+            if ancestor_ver < self.earliest:
+                break
+            changelog = await self._get_changelog(ancestor_ver, collection_downloader)
+            if changelog is None:
+                break
+            changelog.prune_versions(versions_after=None, versions_until=ancestor)
+            changelogs.append(changelog)
+            ancestor = changelog.ancestor
+
+        changelog = ChangesData.concatenate(changelogs)
+        flatmap = True  # TODO
+
+        self.changelog = changelog
+        self.changelog_generator = ChangelogGenerator(
+            self.config, changelog, plugins=None, fragments=None, flatmap=flatmap)
+
+
+class AnsibleBaseChangelogCollector:
+    versions: t.List[PypiVer]
+    earliest: PypiVer
+    latest: PypiVer
+
+    config: ChangelogConfig
+
+    changelog: t.Optional[ChangesData]
+    changelog_generator: t.Optional[ChangelogGenerator]
+
+    porting_guide: t.Optional[bytes]
+
+    def __init__(self, versions: t.ValuesView[str]):
+        self.versions = sorted(PypiVer(version) for version in versions)
+        self.earliest = self.versions[0]
+        self.latest = self.versions[-1]
+
+        paths = PathsConfig.force_ansible('')
+        collection_details = CollectionDetails(paths)
+        self.config = ChangelogConfig.default(paths, collection_details)
+
+        self.changelog = None
+        self.changelog_generator = None
+
+        self.porting_guide = None
+
+    async def _get_files(self, version: PypiVer,
+                         base_downloader: t.Callable[[str], t.Awaitable[str]]
+                         ) -> t.Tuple[t.Optional[ChangesData], t.Optional[bytes]]:
+        path = await base_downloader(str(version))
+        if os.path.isdir(path):
+            pg_path, pg_filename = os.path.split(get_porting_guide_filename(version))
+            changelog = None
+            porting_guide = None
+            for root, _, files in os.walk(path):
+                if 'changelog.yaml' in files:
+                    with open(os.path.join(root, 'changelog.yaml'), 'rb') as f:
+                        changelog = f.read()
+                    changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
+                    changelog = ChangesData(self.config, '/', changelog_data)
+                if pg_filename in files:
+                    if os.path.join(path, pg_path) == root:
+                        with open(os.path.join(path, pg_path), 'rb') as f:
+                            porting_guide = f.read()
+            return changelog_data, porting_guide
+        if os.path.isfile(path) and path.endswith('.tar.gz'):
+            changelog = read_changelog_file(path, is_ansible_base=True)
+            porting_guide = read_porting_guide_file(path, version)
+            if changelog is None:
+                return (None, porting_guide)
+            changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
+            return (ChangesData(self.config, '/', changelog_data), porting_guide)
+        return None, None
+
+    def _set_changelog(self, changelog: ChangesData):
+        self.changelog = changelog
+        self.changelog_generator = ChangelogGenerator(
+            self.config, changelog, plugins=None, fragments=None, flatmap=True)
+
+    async def download(self, base_downloader: t.Callable[[str], t.Awaitable[str]]):
+        changelog, porting_guide = await self._get_files(self.latest, base_downloader)
+        if porting_guide:
+            self.porting_guide = porting_guide
+        if changelog is None:
+            return
+
+        changelog.prune_versions(versions_after=None, versions_until=str(self.latest))
+
+        changelogs = [changelog]
+        ancestor = changelog.ancestor
+        while ancestor is not None:
+            ancestor_ver = PypiVer(ancestor)
+            if ancestor_ver < self.earliest:
+                break
+            changelog, _ = await self._get_files(ancestor_ver, base_downloader)
+            if changelog is None:
+                break
+            changelog.prune_versions(versions_after=None, versions_until=ancestor)
+            changelogs.append(changelog)
+            ancestor = changelog.ancestor
+
+        self._set_changelog(ChangesData.concatenate(changelogs))
+
+    async def download_github(self, aio_session: 'aiohttp.client.ClientSession'):
+        branch_url = (f"https://raw.githubusercontent.com/ansible/ansible/"
+                      f"stable-{self.latest.major}.{self.latest.minor}")
+
+        # Changelog
+        query_url = f"{branch_url}/changelogs/changelog.yaml"
+        async with aio_session.get(query_url) as response:
+            changelog = await response.read()
+        changelog_data = yaml.load(changelog, Loader=yaml.SafeLoader)
+        self._set_changelog(ChangesData(self.config, '/', changelog_data))
+
+        # Porting Guide
+        query_url = f"{branch_url}/{get_porting_guide_filename(self.latest)}"
+        async with aio_session.get(query_url) as response:
+            self.porting_guide = await response.read()
+
+
+async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
+                             base_collector: AnsibleBaseChangelogCollector,
+                             collection_cache: t.Optional[str]):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        async with aiohttp.ClientSession() as aio_session:
+            async with asyncio_pool.AioPool(size=THREAD_MAX) as pool:
+                downloader = CollectionDownloader(aio_session, tmp_dir,
+                                                  collection_cache=collection_cache)
+
+                async def base_downloader(version):
+                    return await get_ansible_base(aio_session, version, tmp_dir)
+
+                requestors = [
+                    await pool.spawn(collector.download(downloader)) for collector in collectors
+                ]
+                if False:  # TODO: make this depend on version or something else...
+                    requestors.append(
+                        await pool.spawn(base_collector.download(base_downloader)))
+                else:
+                    requestors.append(
+                        await pool.spawn(base_collector.download_github(aio_session)))
+                await asyncio.gather(*requestors)
+
+
+class ChangelogEntry:
+    version: PypiVer
+    version_str: str
+
+    prev_version: t.Optional[PypiVer]
+    base_versions: t.Dict[PypiVer, str]
+    versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]]
+
+    base_collector: AnsibleBaseChangelogCollector
+    collectors: t.List[CollectionChangelogCollector]
+
+    ansible_base_version: str
+    prev_ansible_base_version: t.Optional[str]
+
+    removed_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
+    added_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
+    unchanged_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
+    changed_collections: t.List[t.Tuple[CollectionChangelogCollector, str, t.Optional[str]]]
+
+    def __init__(self, version: PypiVer, version_str: str,
+                 prev_version: t.Optional[PypiVer],
+                 base_versions: t.Dict[PypiVer, str],
+                 versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]],
+                 base_collector: AnsibleBaseChangelogCollector,
+                 collectors: t.List[CollectionChangelogCollector]):
+        self.version = version
+        self.version_str = version_str
+        self.prev_version = prev_version
+        self.base_versions = base_versions
+        self.versions_per_collection = versions_per_collection
+        self.base_collector = base_collector
+        self.collectors = collectors
+
+        self.ansible_base_version = base_versions[version]
+        self.prev_ansible_base_version = base_versions.get(prev_version) if prev_version else None
+
+        self.removed_collections = []
+        self.added_collections = []
+        self.unchanged_collections = []
+        self.changed_collections = []
+        for collector in collectors:
+            if version not in versions_per_collection[collector.collection]:
+                print(f"WARNING: {collector.collection} is not included in Ansible {version}")
+
+                if prev_version and prev_version in versions_per_collection[collector.collection]:
+                    self.removed_collections.append((
+                        collector, versions_per_collection[collector.collection][prev_version]))
+
+                continue
+
+            collection_version: str = versions_per_collection[collector.collection][version]
+
+            prev_collection_version: t.Optional[str] = (
+                versions_per_collection[collector.collection].get(prev_version)
+                if prev_version else None
+            )
+            if prev_version:
+                if not prev_collection_version:
+                    self.added_collections.append((collector, collection_version))
+                elif prev_collection_version == collection_version:
+                    self.unchanged_collections.append((collector, collection_version))
+                    continue
+
+            self.changed_collections.append((
+                collector, collection_version, prev_collection_version))
+
+
+def get_changelog_data(
+        acd_version: PypiVer, deps_dir: str, collection_cache: str
+        ) -> t.Tuple[t.List[ChangelogEntry], AnsibleBaseChangelogCollector]:
+    base_versions: t.Dict[PypiVer, str] = dict()
+    versions: t.List[t.Tuple[str, PypiVer, DependencyFileData]] = []
+    versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]] = defaultdict(dict)
+    for path in glob.glob(os.path.join(deps_dir, '*.deps'), recursive=False):
+        deps_file = DepsFile(path)
+        deps = deps_file.parse()
+        version = PypiVer(deps.ansible_version)
+        if version > acd_version:
+            print(f"Ignoring {path}, since {deps.ansible_version} is newer than {acd_version}")
+        versions.append((deps.ansible_version, version, deps))
+        base_versions[version] = deps.ansible_base_version
+        for collection_name, collection_version in deps.deps.items():
+            versions_per_collection[collection_name][version] = collection_version
+
+    versions.sort(key=lambda tuple: tuple[1])
+
+    base_collector = AnsibleBaseChangelogCollector(base_versions.values())
+    collectors = [
+        CollectionChangelogCollector(collection, versions_per_collection[collection].values())
+        for collection in sorted(versions_per_collection.keys())
+    ]
+    asyncio.run(collect_changelogs(collectors, base_collector, collection_cache))
+
+    changelog = []
+
+    for index, (version_str, version, deps) in enumerate(reversed(versions)):
+        if index + 1 < len(versions):
+            prev_version = versions[len(versions) - index - 2][1]
+        else:
+            prev_version = None
+
+        changelog.append(ChangelogEntry(
+            version, version_str, prev_version,
+            base_versions, versions_per_collection,
+            base_collector, collectors))
+
+    return changelog, base_collector

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -291,8 +291,6 @@ class ChangelogEntry:
         self.changed_collections = []
         for collector in collectors:
             if version not in versions_per_collection[collector.collection]:
-                print(f"WARNING: {collector.collection} is not included in Ansible {version}")
-
                 if prev_version and prev_version in versions_per_collection[collector.collection]:
                     self.removed_collections.append((
                         collector, versions_per_collection[collector.collection][prev_version]))

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -19,6 +19,7 @@ from ..config import load_config
 from ..new_acd import new_acd_command
 from ..build_collection import build_collection_command
 from ..build_acd_commands import build_single_command, build_multiple_command
+from ..build_changelog import build_changelog
 
 
 mlog = log.fields(mod=__name__)
@@ -30,6 +31,7 @@ ARGS_MAP = {'new-acd': new_acd_command,
             'build-single': build_single_command,
             'build-multiple': build_multiple_command,
             'build-collection': build_collection_command,
+            'build-changelog': build_changelog,
             }
 
 
@@ -163,6 +165,12 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                    ' versions which were included in this version of ACD'
                                    f' The default is to look for {DEFAULT_FILE_BASE}-X.Y.Z.deps'
                                    ' inside of --dest-dir')
+
+    changelog_parser = subparsers.add_parser('build-changelog',
+                                             parents=[common_parser, cache_parser],
+                                             description='Build the ACD changelog')
+    changelog_parser.add_argument('--deps-dir', required=True,
+                                  help='Directory which contains the versioning data')
 
     args: argparse.Namespace = parser.parse_args(args)
 

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -167,7 +167,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                    ' inside of --dest-dir')
 
     changelog_parser = subparsers.add_parser('build-changelog',
-                                             parents=[common_parser, cache_parser],
+                                             parents=[build_parser, cache_parser],
                                              description='Build the ACD changelog')
     changelog_parser.add_argument('--deps-dir', required=True,
                                   help='Directory which contains the versioning data')


### PR DESCRIPTION
Current output: https://gist.github.com/felixfontein/7d5efcc70c8a25c218d9e8082f5ee92f

Doesn't yet contain ansible-base's changelog.

(I've added a 2.10.0a2 release with the latest collection versions, as otherwise there are no changelogs at all.)