### PR TITLE
Fix a typo in the plugin docs template.

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -436,7 +436,7 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                     {% if value['version_added'] is still_relevant %}
                       <div style="font-style: italic; font-size: small; color: darkgreen">
                         added in @{value['version_added']}@
-                        {% if value['version_added_collection' and value['version_added_collection' != collection %}
+                        {% if value['version_added_collection'] and value['version_added_collection'] != collection %}
                           of @{ doc['version_added_collection'] | escape }@
                         {% endif %}
                       </div>


### PR DESCRIPTION
The template had a typo which was causing it to fail.