### PR TITLE
Fix pages with errors

### DIFF
--- a/antsibull/cli/doc_commands/current.py
+++ b/antsibull/cli/doc_commands/current.py
@@ -40,7 +40,7 @@ def generate_docs(args: 'argparse.Namespace') -> int:
     flog.debug('Finished parsing info from plugins')
 
     """
-    # Turn these into some sort of decorator that will load choose to dump or load the values
+    # Turn these into some sort of decorator that will choose to dump or load the values
     # if a command line arg is specified.
     with open('dump_raw_plugin_info.json', 'w') as f:
         import json
@@ -75,13 +75,14 @@ def generate_docs(args: 'argparse.Namespace') -> int:
     flog.debug('Finished loading errors')
     """
 
-    asyncio_run(output_all_plugin_rst(plugin_info, nonfatal_errors, args.dest_dir))
-    flog.debug('Finished writing plugin docs')
-
     collection_info = get_collection_contents(plugin_info, nonfatal_errors)
     flog.debug('Finished writing collection data')
 
     asyncio_run(output_indexes(collection_info, args.dest_dir))
     flog.debug('Finished writing indexes')
+
+    asyncio_run(output_all_plugin_rst(collection_info, plugin_info,
+                                      nonfatal_errors, args.dest_dir))
+    flog.debug('Finished writing plugin docs')
 
     return 0

--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -266,12 +266,12 @@ def generate_docs(args: 'argparse.Namespace') -> int:
             venv.install_package(ansible_base_path)
         flog.debug('Finished installing ansible-base')
 
-        # Get the list of plugins
+        # Get the data on every plugin
         plugin_info = asyncio_run(get_ansible_plugin_info(venv, collection_dir))
         flog.debug('Finished parsing info from plugins')
 
         """
-        # Turn these into some sort of decorator that will load choose to dump or load the values
+        # Turn these into some sort of decorator that will choose to dump or load the values
         # if a command line arg is specified.
         with open('dump_raw_plugin_info.json', 'w') as f:
             import json
@@ -310,13 +310,14 @@ def generate_docs(args: 'argparse.Namespace') -> int:
         flog.debug('Finished loading errors')
         """
 
-        asyncio_run(output_all_plugin_rst(plugin_info, nonfatal_errors, args.dest_dir))
-        flog.debug('Finished writing plugin docs')
-
         collection_info = get_collection_contents(plugin_info, nonfatal_errors)
-        flog.debug('Finished writing collection data')
+        flog.debug('Finished extracting collection data')
 
         asyncio_run(output_indexes(collection_info, args.dest_dir))
         flog.debug('Finished writing indexes')
+
+        asyncio_run(output_all_plugin_rst(collection_info, plugin_info,
+                                          nonfatal_errors, args.dest_dir))
+        flog.debug('Finished writing plugin docs')
 
     return 0

--- a/antsibull/docs_parsing/ansible_doc.py
+++ b/antsibull/docs_parsing/ansible_doc.py
@@ -23,26 +23,33 @@ if TYPE_CHECKING:
 
 
 #: Clear Ansible environment variables that set paths where plugins could be found.
-ANSIBLE_PATH_ENVVARS: Dict[str, str] = {'ANSIBLE_COLLECTIONS_PATHS': "/dev/null",
-                                        'ANSIBLE_ACTION_PLUGINS': "/dev/null",
-                                        'ANSIBLE_CACHE_PLUGINS': "/dev/null",
-                                        'ANSIBLE_CALLBACK_PLUGINS': "/dev/null",
-                                        'ANSIBLE_CLICONF_PLUGINS': "/dev/null",
-                                        'ANSIBLE_CONNECTION_PLUGINS': "/dev/null",
-                                        'ANSIBLE_FILTER_PLUGINS': "/dev/null",
-                                        'ANSIBLE_HTTPAPI_PLUGINS': "/dev/null",
-                                        'ANSIBLE_INVENTORY_PLUGINS': "/dev/null",
-                                        'ANSIBLE_LOOKUP_PLUGINS': "/dev/null",
-                                        'ANSIBLE_LIBRARY': "/dev/null",
-                                        'ANSIBLE_MODULE_UTILS': "/dev/null",
-                                        'ANSIBLE_NETCONF_PLUGINS': "/dev/null",
-                                        'ANSIBLE_ROLES_PATH': "/dev/null",
-                                        'ANSIBLE_STRATEGY_PLUGINS': "/dev/null",
-                                        'ANSIBLE_TERMINAL_PLUGINS': "/dev/null",
-                                        'ANSIBLE_TEST_PLUGINS': "/dev/null",
-                                        'ANSIBLE_VARS_PLUGINS': "/dev/null",
-                                        'ANSIBLE_DOC_FRAGMENT_PLUGINS': "/dev/null",
-                                        }
+ANSIBLE_PATH_ENVIRON: Dict[str, str] = os.environ.copy()
+ANSIBLE_PATH_ENVIRON.update({'ANSIBLE_COLLECTIONS_PATHS': '/dev/null',
+                             'ANSIBLE_ACTION_PLUGINS': '/dev/null',
+                             'ANSIBLE_CACHE_PLUGINS': '/dev/null',
+                             'ANSIBLE_CALLBACK_PLUGINS': '/dev/null',
+                             'ANSIBLE_CLICONF_PLUGINS': '/dev/null',
+                             'ANSIBLE_CONNECTION_PLUGINS': '/dev/null',
+                             'ANSIBLE_FILTER_PLUGINS': '/dev/null',
+                             'ANSIBLE_HTTPAPI_PLUGINS': '/dev/null',
+                             'ANSIBLE_INVENTORY_PLUGINS': '/dev/null',
+                             'ANSIBLE_LOOKUP_PLUGINS': '/dev/null',
+                             'ANSIBLE_LIBRARY': '/dev/null',
+                             'ANSIBLE_MODULE_UTILS': '/dev/null',
+                             'ANSIBLE_NETCONF_PLUGINS': '/dev/null',
+                             'ANSIBLE_ROLES_PATH': '/dev/null',
+                             'ANSIBLE_STRATEGY_PLUGINS': '/dev/null',
+                             'ANSIBLE_TERMINAL_PLUGINS': '/dev/null',
+                             'ANSIBLE_TEST_PLUGINS': '/dev/null',
+                             'ANSIBLE_VARS_PLUGINS': '/dev/null',
+                             'ANSIBLE_DOC_FRAGMENT_PLUGINS': '/dev/null',
+                             })
+try:
+    del ANSIBLE_PATH_ENVIRON['PYTHONPATH']
+except KeyError:
+    # We just wanted to make sure there was no PYTHONPATH set...
+    # all python libs will come from the venv
+    pass
 
 
 class ParsingError(Exception):
@@ -146,11 +153,11 @@ async def get_ansible_plugin_info(venv: Union['VenvRunner', 'FakeVenvRunner'],
                 {information from ansible-doc --json.  See the ansible-doc documentation for more
                  info.}
     """
+    env = ANSIBLE_PATH_ENVIRON.copy()
+    env['ANSIBLE_COLLECTIONS_PATHS'] = collection_dir
+
     # Setup an sh.Command to run ansible-doc from the venv with only the collections we
     # found as providers of extra plugins.
-    env = os.environ.copy()
-    env.update(ANSIBLE_PATH_ENVVARS)
-    env['ANSIBLE_COLLECTIONS_PATHS'] = collection_dir
 
     venv_ansible_doc = venv.get_command('ansible-doc')
     venv_ansible_doc = venv_ansible_doc.bake('-vvv', _env=env)

--- a/antsibull/schemas/base.py
+++ b/antsibull/schemas/base.py
@@ -292,12 +292,13 @@ class DeprecationSchema(BaseModel):
         """Make sure either removed_in or removed_at_date are specified, but not both."""
         # This should be changed to a way that also works in the JSON schema; see
         # https://github.com/ansible-community/antsibull/issues/104
-        has_removed_in = values.get('removed_in', _SENTINEL) is _SENTINEL
-        has_removed_at_date = values.get('removed_at_date', _SENTINEL) is _SENTINEL
-        if not has_removed_in and not has_removed_at_date:
-            raise ValueError('One of `removed_at_date` and `removed_in` must be specified')
-        if has_removed_in and has_removed_at_date:
-            raise ValueError('Not both of `removed_at_date` and `removed_in` can be specified')
+        removed_in = values.get('removed_in')
+        removed_at_date = values.get('removed_at_date')
+
+        if not removed_in and not removed_at_date:
+            raise ValueError('One of `removed_at_date` or `removed_in` must be specified')
+        if removed_in and removed_at_date:
+            raise ValueError('Cannot specify both of `removed_at_date` and `removed_in`')
 
         return values
 


### PR DESCRIPTION
There were a few errors with docs generation that needed fixing:
* The validator that xor'ed removed_at_date and removed_in_date needed some fixes since the last schema changes.
* PYTHONPATH needed to be unset when running ansible-doc in an isolated environment
* The error pages weren't being generated when docs failed to parse due to using an incomplete list of plugins.  Correct that by using the list of plugins which was assembled to construct the collection index pages.