### PR TITLE
Use production pypi for getting package info

### DIFF
--- a/antsibull/ansible_base.py
+++ b/antsibull/ansible_base.py
@@ -24,7 +24,7 @@ if t.TYPE_CHECKING:
 #: URL to checkout ansible-base from.
 ANSIBLE_BASE_URL = 'https://github.com/ansible/ansible'
 #: URL to pypi.
-PYPI_SERVER_URL = 'https://test.pypi.org/'
+PYPI_SERVER_URL = 'https://pypi.org/'
 
 
 class UnknownVersion(Exception):


### PR DESCRIPTION
Now that ansible-base 2.10.0b1 is on production pypi we don't need to
query test.pypi.org anymore.