### PR TITLE
Add an error when attempting to pip upgrade from 2.9 or earlier

### DIFF
--- a/antsibull/data/acd-setup_py.j2
+++ b/antsibull/data/acd-setup_py.j2
@@ -1,6 +1,68 @@
 #!/usr/bin/python -tt
 
+import os
 from setuptools import setup
+
+if not os.environ.get('ANSIBLE_ALLOW_2_9_UPGRADE'):
+    try:
+        import ansible
+    except ImportError:
+        pass
+    else:
+        # prevent direct upgrade from 2.9.x or earlier to 2.10 due to pip limitations
+        current_version = ansible.__version__.split()
+        try:
+            current_version = (int(current_version[0]), int(current_version[1]))
+        except Exception as e:
+            print("""\n
+                ### ERROR ###
+
+                The currently installed ansible is of an unknown version.  Since upgrading directly
+                from ansible-2.9 or less to ansible-2.10 with pip is unsupported, please uninstall
+                the old version and install the new version:
+
+                    pip uninstall ansible
+                    pip install ansible
+
+                If you have a broken installation, perhaps because ansible-base was installed before
+                ansible was upgraded, try this to resolve it:
+
+                    pip install --force-reinstall ansible ansible-base
+
+                If you want to install anyways and cleanup any breakage afterwards, set the
+                ANSIBLE_ALLOW_2_9_UPGRADE environment variable:
+
+                    ANSIBLE_ALLOW_2_9_UPGRADE=1 pip install ansible
+
+                ### END ERROR ###
+
+                """
+            sys.exit(1)
+        else:
+            if not current_version >= (2, 10):
+                print("""\n
+                    ### ERROR ###
+
+                    Upgrading directly from ansible-2.9 or less to ansible-2.10 with pip is
+                    unsupported.  Please uninstall the old version and install the new version:
+
+                        pip uninstall ansible
+                        pip install ansible
+
+                    If you have a broken installation, perhaps because ansible-base was installed before
+                    ansible was upgraded, try this to resolve it:
+
+                        pip install --force-reinstall ansible ansible-base
+
+                    If you want to install anyways and cleanup any breakage afterwards, set the
+                    ANSIBLE_ALLOW_2_9_UPGRADE environment variable:
+
+                        ANSIBLE_ALLOW_2_9_UPGRADE=1 pip install ansible
+
+                    ### END ERROR ###
+
+                    """)
+                sys.exit(1)
 
 
 __version__ = '{{ version }}'


### PR DESCRIPTION
Due to pip limitations, upgrading from ansible-2.9 to ansile-2.10 will end up corrupting the files installed by ansible-base (and thus, breaking the install).  This PR adds an error message to stop the upgrade from working and tell people what to do instead (basically, pip uninstall ansible ; pip install ansible).