### PR TITLE
Assorted fixes to the code which prevents upgrade from 2.9 or less to 2.10 and greater

### DIFF
--- a/antsibull/data/acd-setup_py.j2
+++ b/antsibull/data/acd-setup_py.j2
@@ -3,66 +3,80 @@
 import os
 from setuptools import setup
 
-if not os.environ.get('ANSIBLE_ALLOW_2_9_UPGRADE'):
+
+def detect_bad_upgrade():
+    # prevent direct upgrade from 2.9.x or earlier to 2.10 due to pip limitations
     try:
         import ansible
     except ImportError:
-        pass
+        # ansible is not installed
+        return False
+
+    try:
+        current_version = ansible.__version__.split('.')
+    except AttributeError:
+        # ansible is installed but already broken.  We're probably being reinstalled.
+        return False
+
+    try:
+        current_version = (int(current_version[0]), int(current_version[1]))
+    except Exception as e:
+        print("""\n
+            ### ERROR ###
+
+            The currently installed ansible is of an unknown version.  Since upgrading directly
+            from ansible-2.9 or less to ansible-2.10 with pip is unsupported, please uninstall
+            the old version and install the new version:
+
+                pip uninstall ansible
+                pip install ansible
+
+            If you have a broken installation, perhaps because ansible-base was installed before
+            ansible was upgraded, try this to resolve it:
+
+                pip install --force-reinstall ansible ansible-base
+
+            If you want to install anyways and cleanup any breakage afterwards, set the
+            ANSIBLE_ALLOW_2_10_UPGRADE environment variable:
+
+                ANSIBLE_ALLOW_2_10_UPGRADE=1 pip install ansible
+
+            ### END ERROR ###
+
+            """)
     else:
-        # prevent direct upgrade from 2.9.x or earlier to 2.10 due to pip limitations
-        current_version = ansible.__version__.split()
-        try:
-            current_version = (int(current_version[0]), int(current_version[1]))
-        except Exception as e:
-            print("""\n
-                ### ERROR ###
+        if current_version >= (2, 10):
+            return False
 
-                The currently installed ansible is of an unknown version.  Since upgrading directly
-                from ansible-2.9 or less to ansible-2.10 with pip is unsupported, please uninstall
-                the old version and install the new version:
+        print("""\n
+            ### ERROR ###
 
-                    pip uninstall ansible
-                    pip install ansible
+            Upgrading directly from ansible-2.9 or less to ansible-2.10 or greater with pip is
+            unsupported.  Please uninstall the old version and install the new version:
 
-                If you have a broken installation, perhaps because ansible-base was installed before
-                ansible was upgraded, try this to resolve it:
+                pip uninstall ansible
+                pip install ansible
 
-                    pip install --force-reinstall ansible ansible-base
+            If you have a broken installation, perhaps because ansible-base was installed before
+            ansible was upgraded, try this to resolve it:
 
-                If you want to install anyways and cleanup any breakage afterwards, set the
-                ANSIBLE_ALLOW_2_9_UPGRADE environment variable:
+                pip install --force-reinstall ansible ansible-base
 
-                    ANSIBLE_ALLOW_2_9_UPGRADE=1 pip install ansible
+            If you want to install anyways and cleanup any breakage afterwards, set the
+            ANSIBLE_ALLOW_2_10_UPGRADE environment variable:
 
-                ### END ERROR ###
+                ANSIBLE_ALLOW_2_10_UPGRADE=1 pip install ansible
 
-                """
-            sys.exit(1)
-        else:
-            if not current_version >= (2, 10):
-                print("""\n
-                    ### ERROR ###
+            ### END ERROR ###
 
-                    Upgrading directly from ansible-2.9 or less to ansible-2.10 with pip is
-                    unsupported.  Please uninstall the old version and install the new version:
+            """)
 
-                        pip uninstall ansible
-                        pip install ansible
+    return True
 
-                    If you have a broken installation, perhaps because ansible-base was installed before
-                    ansible was upgraded, try this to resolve it:
 
-                        pip install --force-reinstall ansible ansible-base
-
-                    If you want to install anyways and cleanup any breakage afterwards, set the
-                    ANSIBLE_ALLOW_2_9_UPGRADE environment variable:
-
-                        ANSIBLE_ALLOW_2_9_UPGRADE=1 pip install ansible
-
-                    ### END ERROR ###
-
-                    """)
-                sys.exit(1)
+if not os.environ.get('ANSIBLE_ALLOW_2_10_UPGRADE'):
+    if detect_bad_upgrade():
+        sys.exit(1)
 
 
 __version__ = '{{ version }}'


### PR DESCRIPTION
Left off a parenthesis

Split version number on the wrong value

Refactor the code into a function