### PR TITLE
Add logging which will show which plugins had errors in parsing.

### DIFF
--- a/antsibull/config.py
+++ b/antsibull/config.py
@@ -72,20 +72,34 @@ class LoggingModel(BaseModel):
 
 
 #: Default logging configuration
-DEFAULT_LOGGING_CONFIG = LoggingModel.parse_obj({'version': '1.0',
-                                                 'outputs': {
-                                                     'logfile': {
-                                                         'output': 'twiggy.outputs.StreamOutput'
-                                                     }
-                                                 },
-                                                 'emitters': {
-                                                     'all': {
-                                                         'level': 'WARNING',
-                                                         'output_name': 'logfile',
-                                                         'filters': []
-                                                     }
-                                                 }
-                                                 })
+DEFAULT_LOGGING_CONFIG = LoggingModel.parse_obj(
+    {'version': '1.0',
+     'outputs': {
+         'logfile': {
+             'output': 'twiggy.outputs.FileOutput',
+             'args': [
+                 '/srv/ansible/antsibull.log'
+             ]
+         },
+         'stderr': {
+             'output': 'twiggy.outputs.StreamOutput'
+         },
+     },
+     'emitters': {
+         'all': {
+             'level': 'WARNING',
+             'output_name': 'logfile',
+             'filters': []
+         },
+         'plugin_problems': {
+             'level': 'ERROR',
+             'output_name': 'stderr',
+             'filters': [
+                 {'filter': 'antsibull.logging.plugin_filter'}
+             ]
+         },
+     }
+     })
 
 
 class ConfigModel(BaseModel):

--- a/antsibull/logging.py
+++ b/antsibull/logging.py
@@ -71,4 +71,16 @@ log.min_level = twiggy.levels.DISABLED
 mlog = log.fields(mod=__name__)
 mlog.debug('logging loaded')
 
-__all__ = ('log',)
+
+def plugin_filter():
+    """
+    Filter out messages which come from plugin error output.
+
+    :arg msg: A :twiggy:obj:`twiggy.message.Message` object which would be filtered
+    """
+    def wrapped(msg):
+        return msg.fields['func'] == 'write_rst' and msg.fields['mod'] == 'antsibull.write_docs'
+    return wrapped
+
+
+__all__ = ('log', 'plugin_filter')


### PR DESCRIPTION
Fixes #124

Here's the default output:
```
2020-07-07T00:17:55Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['11 validation errors for PluginDocSchema\ndoc -> options -> connections -> api_key\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> ca_cert\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> client_cert\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> client_key\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> context\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> host\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> kubeconfig\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> namespaces\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> password\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> username\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> validate_certs\n  extra fields not permitted (type=value_error.extra)']:plugin_name=community.kubernetes.k8s:plugin_type=inventory|community.kubernetes.k8s did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:55Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['11 validation errors for PluginDocSchema\ndoc -> options -> connections -> api_key\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> ca_cert\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> client_cert\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> client_key\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> context\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> host\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> kubeconfig\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> namespaces\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> password\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> username\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> connections -> validate_certs\n  extra fields not permitted (type=value_error.extra)']:plugin_name=community.kubernetes.openshift:plugin_type=inventory|community.kubernetes.openshift did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:55Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['1 validation error for PluginDocSchema\ndoc -> options -> cache -> deprecated -> removed_from_collection\n  field required (type=value_error.missing)']:plugin_name=ansible.builtin.script:plugin_type=inventory|ansible.builtin.script did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:55Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['18 validation errors for PluginDocSchema\ndoc -> options -> ca_path -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> ca_path -> ini -> 1 -> section\n  field required (type=value_error.missing)\ndoc -> options -> follow_redirects -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> follow_redirects -> ini -> 1 -> section\n  field required (type=value_error.missing)\ndoc -> options -> force -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> force -> ini -> 1 -> section\n  field required (type=value_error.missing)\ndoc -> options -> force_basic_auth -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> force_basic_auth -> ini -> 1 -> section\n  field required (type=value_error.missing)\ndoc -> options -> http_agent -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> http_agent -> ini -> 1 -> section\n  field required (type=value_error.missing)\ndoc -> options -> timeout -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> timeout -> ini -> 1 -> section\n  field required (type=value_error.missing)\ndoc -> options -> unix_socket -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> unix_socket -> ini -> 1 -> section\n  field required (type=value_error.missing)\ndoc -> options -> unredirected_headers -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> unredirected_headers -> ini -> 1 -> section\n  field required (type=value_error.missing)\ndoc -> options -> use_gssapi -> ini -> 0 -> key\n  field required (type=value_error.missing)\ndoc -> options -> use_gssapi -> ini -> 1 -> section\n  field required (type=value_error.missing)']:plugin_name=ansible.builtin.url:plugin_type=lookup|ansible.builtin.url did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:56Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['1 validation error for PluginDocSchema\ndoc -> deprecated -> removed_from_collection\n  field required (type=value_error.missing)']:plugin_name=community.network.sros:plugin_type=netconf|community.network.sros did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:56Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['7 validation errors for PluginDocSchema\ndoc -> seealso -> 1 -> module\n  field required (type=value_error.missing)\ndoc -> seealso -> 1 -> ref\n  extra fields not permitted (type=value_error.extra)\ndoc -> seealso -> 1 -> description\n  field required (type=value_error.missing)\ndoc -> seealso -> 1 -> description\n  field required (type=value_error.missing)\ndoc -> seealso -> 1 -> link\n  field required (type=value_error.missing)\ndoc -> seealso -> 1 -> name\n  field required (type=value_error.missing)\ndoc -> seealso -> 1 -> ref\n  extra fields not permitted (type=value_error.extra)']:plugin_name=community.general.etcd3:plugin_type=lookup|community.general.etcd3 did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:56Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['1 validation error for CallbackDocSchema\ndoc -> deprecated -> removed_from_collection\n  field required (type=value_error.missing)']:plugin_name=community.general.actionable:plugin_type=callback|community.general.actionable did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:56Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['1 validation error for CallbackDocSchema\ndoc -> deprecated -> removed_from_collection\n  field required (type=value_error.missing)']:plugin_name=community.general.full_skip:plugin_type=callback|community.general.full_skip did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:56Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['1 validation error for CallbackDocSchema\ndoc -> deprecated -> removed_from_collection\n  field required (type=value_error.missing)']:plugin_name=community.general.stderr:plugin_type=callback|community.general.stderr did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:57Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['4 validation errors for ModuleDocSchema\ndoc -> options -> config -> suboptions -> processes -> suboptions -> areas -> suboptions -> bfd -> suboptions\n  none is not an allowed value (type=type_error.none.not_allowed)\ndoc -> options -> config -> suboptions -> processes -> suboptions -> areas -> suboptions -> bfd -> fast_detect\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> config -> suboptions -> processes -> suboptions -> areas -> suboptions -> bfd -> minimum_interval\n  extra fields not permitted (type=value_error.extra)\ndoc -> options -> config -> suboptions -> processes -> suboptions -> areas -> suboptions -> bfd -> multiplier\n  extra fields not permitted (type=value_error.extra)']:plugin_name=cisco.iosxr.iosxr_ospfv2:plugin_type=module|cisco.iosxr.iosxr_ospfv2 did not return correct DOCUMENTATION.  An error page will be generated.
2020-07-07T00:17:57Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['Unable to normalize vmware_local_role_info: return due to: 1 validation error for PluginReturnSchema\nreturn -> local_role_info -> type\n  string does not match regex "^(bool|complex|dict|float|int|list|str)$" (type=value_error.str.regex; pattern=^(bool|complex|dict|float|int|list|str)$)']:plugin_name=community.vmware.vmware_local_role_info:plugin_type=module|community.vmware.vmware_local_role_info did not return correct RETURN or EXAMPLES.
2020-07-07T00:17:58Z:ERROR:antsibull:func=write_rst:mod=antsibull.write_docs:nonfatal_errors=['1 validation error for CallbackDocSchema\ndoc -> deprecated -> removed_from_collection\n  field required (type=value_error.missing)']:plugin_name=ansible.posix.skippy:plugin_type=callback|ansible.posix.skippy did not return correct DOCUMENTATION.  An error page will be generated.
```

Note that when ansible-doc fails to parse something, it doesn't yet show an error message.