### PR TITLE
Some config changes

### DIFF
--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -10,21 +10,32 @@ logging_cfg = {
         logfile = {
             output = twiggy.outputs.FileOutput
             args = [
-                /srv/ansible/antsibull.log
+                ~/antsibull.log
             ]
         }
         stderr = {
             output = twiggy.outputs.StreamOutput
-            format = twiggy.formats.line_format
+            format = twiggy.formats.shell_format
         }
     }
     emitters = {
         all = {
-            level = DEBUG
+            # DEBUG is the most verbose level
+            level = WARNING
             output_name = logfile
         }
-        display = {
-            level = NOTICE
+        # Log plugin_problems specifically to stderr so they can be reported and taken care of.
+        plugin_problems = {
+            level = ERROR
             output_name = stderr
-        }
+            filters = [
+                {
+                    filter = antsibull.logging.plugin_filter
+                }
+            ]
+        # Example of log messages for things the end user can change written to stderr
+        # display = {
+        #     level = NOTICE
+        #     output_name = stderr
+        # }
     }


### PR DESCRIPTION
* Set the default log location to a logfile in the user's home directory
  for portability between user's systems.
* Add a validator to expand tilde in logfile locations in config (will
  only work for the default twiggy logfile).
* Sync the example config file with the present defaults