### PR TITLE
Don't crash when no subcommand is specified

### DIFF
--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -123,8 +123,9 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(prog=program_name,
                                      description='Script to manage building ACD')
-    subparsers = parser.add_subparsers(title='Subcommands', dest='command', required=True,
+    subparsers = parser.add_subparsers(title='Subcommands', dest='command',
                                        help='for help use antsibull-build SUBCOMMANDS -h')
+    subparsers.required = True
 
     new_parser = subparsers.add_parser('new-acd', parents=[build_parser],
                                        description='Generate a new build description from the'

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -166,6 +166,10 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
 
     args: argparse.Namespace = parser.parse_args(args)
 
+    if args.command is None:
+        parser.print_help()
+        raise InvalidArgumentError('Please specify a subcommand')
+
     # Validation and coercion
     normalize_common_options(args)
     _normalize_build_options(args)

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -166,10 +166,6 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
 
     args: argparse.Namespace = parser.parse_args(args)
 
-    if args.command is None:
-        parser.print_help()
-        raise InvalidArgumentError('Please specify a subcommand')
-
     # Validation and coercion
     normalize_common_options(args)
     _normalize_build_options(args)

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -34,9 +34,6 @@ ARGS_MAP = {'new-acd': new_acd_command,
 
 
 def _normalize_build_options(args: argparse.Namespace) -> None:
-    if args.command is None:
-        raise InvalidArgumentError('Please specify a subcommand to run')
-
     args.dest_dir = os.path.expanduser(os.path.expandvars(args.dest_dir))
     if not os.path.isdir(args.dest_dir):
         raise InvalidArgumentError(f'{args.dest_dir} must be an existing directory')

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -126,7 +126,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(prog=program_name,
                                      description='Script to manage building ACD')
-    subparsers = parser.add_subparsers(title='Subcommands', dest='command',
+    subparsers = parser.add_subparsers(title='Subcommands', dest='command', required=True,
                                        help='for help use antsibull-build SUBCOMMANDS -h')
 
     new_parser = subparsers.add_parser('new-acd', parents=[build_parser],

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -142,8 +142,9 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog=program_name,
                                      description='Script to manage generated documentation for'
                                      ' ansible')
-    subparsers = parser.add_subparsers(title='Subcommands', dest='command', required=True,
+    subparsers = parser.add_subparsers(title='Subcommands', dest='command',
                                        help='for help use  SUBCOMMANDS -h')
+    subparsers.required = True
 
     # Document the next version of ansible
     devel_parser = subparsers.add_parser('devel', parents=[docs_parser, cache_parser],

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -145,7 +145,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog=program_name,
                                      description='Script to manage generated documentation for'
                                      ' ansible')
-    subparsers = parser.add_subparsers(title='Subcommands', dest='command',
+    subparsers = parser.add_subparsers(title='Subcommands', dest='command', required=True,
                                        help='for help use  SUBCOMMANDS -h')
 
     # Document the next version of ansible

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -39,9 +39,6 @@ DEFAULT_PIECES_FILE: str = 'acd.in'
 
 
 def _normalize_docs_options(args: argparse.Namespace) -> None:
-    if args.command is None:
-        raise InvalidArgumentError('Please specify a subcommand to run')
-
     args.dest_dir = os.path.expanduser(os.path.expandvars(args.dest_dir))
     args.dest_dir = os.path.abspath(os.path.realpath(args.dest_dir))
 

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -208,6 +208,10 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     args: argparse.Namespace = parser.parse_args(args)
     flog.fields(args=args).debug('Arguments parsed')
 
+    if args.command is None:
+        parser.print_help()
+        raise InvalidArgumentError('Please specify a subcommand')
+
     # Validation and coercion
     normalize_common_options(args)
     _normalize_docs_options(args)

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -208,10 +208,6 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     args: argparse.Namespace = parser.parse_args(args)
     flog.fields(args=args).debug('Arguments parsed')
 
-    if args.command is None:
-        parser.print_help()
-        raise InvalidArgumentError('Please specify a subcommand')
-
     # Validation and coercion
     normalize_common_options(args)
     _normalize_docs_options(args)

--- a/antsibull/cli/antsibull_lint.py
+++ b/antsibull/cli/antsibull_lint.py
@@ -41,12 +41,12 @@ def run(args: List[str]) -> int:
                             default=0,
                             help='increase verbosity of output')
 
-        subparsers = parser.add_subparsers(metavar='COMMAND')
+        subparsers = parser.add_subparsers(dest='command', required=True)
 
         changelog_yaml = subparsers.add_parser('changelog-yaml',
                                                parents=[common],
                                                help='changelogs/changelog.yaml linter')
-        changelog_yaml.set_defaults(func=command_lint_changelog)
+        changelog_yaml.set_defaults(command=command_lint_changelog)
 
         changelog_yaml.add_argument('changelog_yaml_path',
                                     metavar='/path/to/changelog.yaml',
@@ -57,14 +57,10 @@ def run(args: List[str]) -> int:
 
         arguments = parser.parse_args(args[1:])
 
-        if getattr(arguments, 'func', None) is None:
-            parser.print_help()
-            return 2
-
         verbosity = arguments.verbose
         setup_logger(verbosity)
 
-        return arguments.func(arguments)
+        return arguments.command(arguments)
     except SystemExit as e:
         return e.code
     except Exception:  # pylint: disable=broad-except

--- a/antsibull/cli/antsibull_lint.py
+++ b/antsibull/cli/antsibull_lint.py
@@ -41,7 +41,8 @@ def run(args: List[str]) -> int:
                             default=0,
                             help='increase verbosity of output')
 
-        subparsers = parser.add_subparsers(dest='command', required=True)
+        subparsers = parser.add_subparsers(dest='command')
+        subparsers.required = True
 
         changelog_yaml = subparsers.add_parser('changelog-yaml',
                                                parents=[common],


### PR DESCRIPTION
Right now, running `antsibull-docs` without arguments yields:
```
Traceback (most recent call last):
  File "/usr/bin/antsibull-docs", line 33, in <module>
    sys.exit(load_entry_point('antsibull', 'console_scripts', 'antsibull-docs')())
  File "/home/felix/projects/code/github-cloned/antsibull/antsibull/cli/antsibull_docs.py", line 274, in main
    return run(sys.argv)
  File "/home/felix/projects/code/github-cloned/antsibull/antsibull/cli/antsibull_docs.py", line 240, in run
    args: argparse.Namespace = parse_args(program_name, args[1:])
  File "/home/felix/projects/code/github-cloned/antsibull/antsibull/cli/antsibull_docs.py", line 212, in parse_args
    normalize_common_options(args)
  File "/home/felix/projects/code/github-cloned/antsibull/antsibull/args.py", line 37, in normalize_common_options
    for conf_file in args.config_file:
AttributeError: 'Namespace' object has no attribute 'config_file'
```
Running `antsibull-build` without arguments yields:
```
Traceback (most recent call last):
  File "/usr/bin/antsibull-build", line 33, in <module>
    sys.exit(load_entry_point('antsibull', 'console_scripts', 'antsibull-build')())
  File "/home/felix/projects/code/github-cloned/antsibull/antsibull/cli/antsibull_build.py", line 229, in main
    return run(sys.argv)
  File "/home/felix/projects/code/github-cloned/antsibull/antsibull/cli/antsibull_build.py", line 192, in run
    args: argparse.Namespace = parse_args(program_name, args[1:])
  File "/home/felix/projects/code/github-cloned/antsibull/antsibull/cli/antsibull_build.py", line 170, in parse_args
    normalize_common_options(args)
  File "/home/felix/projects/code/github-cloned/antsibull/antsibull/args.py", line 37, in normalize_common_options
    for conf_file in args.config_file:
AttributeError: 'Namespace' object has no attribute 'config_file'
```
This PR fixes that to print help and a message (`Please specify a subcommand`).