### PR TITLE
Add --squash-hierarchy option to collection subcommand

### DIFF
--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -89,6 +89,15 @@ def _normalize_stable_options(args: argparse.Namespace) -> None:
                                    ' per line')
 
 
+def _normalize_collection_options(args: argparse.Namespace) -> None:
+    if args.command != 'collection':
+        return
+
+    if args.squash_hierarchy and len(args.collections) > 1:
+        raise InvalidArgumentError('The option --squash-hierarchy can only be used when'
+                                   ' only one collection is specified')
+
+
 def _normalize_current_options(args: argparse.Namespace) -> None:
     if args.command != 'current':
         return
@@ -184,6 +193,10 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                    ' these collections have been installed with the current'
                                    ' version of ansible. Specified --collection-version will be'
                                    ' ignored.')
+    collection_parser.add_argument('--squash-hierarchy', action='store_true',
+                                   help='Do not use the full hierarchy collections/namespace/name/'
+                                   ' in the destination directory. Only valid if there is only'
+                                   ' one collection specified.')
     collection_parser.add_argument(nargs='+', dest='collections',
                                    help='One or more collections to document.  If the names are'
                                    ' directories on disk, they will be parsed as expanded'
@@ -212,6 +225,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     _normalize_devel_options(args)
     _normalize_stable_options(args)
     _normalize_current_options(args)
+    _normalize_collection_options(args)
     _normalize_plugin_options(args)
     flog.fields(args=args).debug('Arguments normalized')
 

--- a/antsibull/cli/doc_commands/collection.py
+++ b/antsibull/cli/doc_commands/collection.py
@@ -12,7 +12,7 @@ from .stable import generate_docs_for_all_collections
 mlog = log.fields(mod=__name__)
 
 
-def generate_current_docs() -> int:
+def generate_current_docs(squash_hierarchy: bool) -> int:
     flog = mlog.fields(func='generate_current_docs')
     flog.debug('Begin processing docs')
 
@@ -21,7 +21,8 @@ def generate_current_docs() -> int:
     venv = FakeVenvRunner()
 
     generate_docs_for_all_collections(
-        venv, None, app_ctx.extra['dest_dir'], flog, app_ctx.extra['collections'])
+        venv, None, app_ctx.extra['dest_dir'], flog, app_ctx.extra['collections'],
+        squash_hierarchy=squash_hierarchy)
 
     return 0
 
@@ -39,8 +40,10 @@ def generate_docs() -> int:
     """
     app_ctx = app_context.app_ctx.get()
 
+    squash_hierarchy: bool = app_ctx.extra['squash_hierarchy']
+
     if app_ctx.extra['use_current']:
-        return generate_current_docs()
+        return generate_current_docs(squash_hierarchy)
 
     raise NotImplementedError('Priority to implement subcommands is stable, devel, plugin, and'
                               ' then collection commands. Only --use-current is implemented'

--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -219,7 +219,8 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
                                       collection_dir: t.Optional[str],
                                       dest_dir: str,
                                       flog,
-                                      collection_names: t.Optional[t.List[str]] = None) -> None:
+                                      collection_names: t.Optional[t.List[str]] = None,
+                                      squash_hierarchy: bool = False) -> None:
     """
     Create documentation for a set of installed collections.
 
@@ -231,6 +232,9 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
     :arg flog: A logger instance.
     :arg collection_names: Optional list of collection names. If specified, only documentation
                            for these collections will be collected and generated.
+    :arg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
+                           Undefined behavior if documentation for multiple collections are
+                           created.
     """
 
     # Get the info from the plugins
@@ -284,11 +288,12 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
         asyncio_run(output_collection_index(collection_info, dest_dir))
         flog.notice('Finished writing collection index')
 
-    asyncio_run(output_indexes(collection_info, dest_dir))
+    asyncio_run(output_indexes(collection_info, dest_dir, squash_hierarchy=squash_hierarchy))
     flog.notice('Finished writing indexes')
 
     asyncio_run(output_all_plugin_rst(collection_info, plugin_info,
-                                      nonfatal_errors, dest_dir))
+                                      nonfatal_errors, dest_dir,
+                                      squash_hierarchy=squash_hierarchy))
     flog.debug('Finished writing plugin docs')
 
 


### PR DESCRIPTION
This option can only be used when at most one collection is specified. It will avoid the subdirectory hierarchy: all output files will be directly written into the dest-dir. Useful for example in theforeman/foreman-ansible-modules#895.

CC @evgeni