### PR TITLE
remove collections keyword note

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -374,10 +374,6 @@ See Also
 {% if examples -%}
 Examples
 --------
-{% if collection != 'ansible.builtin' %}
-.. note::
-    These examples assume the ``collections`` keyword is defined in  playbook and do not use the fully qualified collection name.
-{% endif %}
 
 .. code-block:: yaml+jinja
 


### PR DESCRIPTION
The big collections are already including FQCN in their examples and we are telling the rest of the collection folks to do this as well. Removing the 'collection' keyword note from the Examples section as it's causing confusions now with collections that are already FQCN.