### PR TITLE
Write changelog into build data directory after build

### DIFF
--- a/antsibull/build_acd_commands.py
+++ b/antsibull/build_acd_commands.py
@@ -229,6 +229,9 @@ def build_single_command():
         new_dependencies.ansible_base_version,
         new_dependencies.deps)
 
+    # Write changelog also to destination directory
+    release_notes.write_changelog_to(deps_dir)
+
     return 0
 
 #


### PR DESCRIPTION
Would update the changelog in ansible-community/ansible-build-data#21 after a build.