### PR TITLE
Manually extended changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ PyYAML = "*"
 pydantic = "*"
 asyncio-pool = "*"
 perky = "*"
-antsibull-changelog = "*"
+antsibull-changelog = ">= 0.7.0"
 # 0.5.0 introduces dict_config
 twiggy = ">= 0.5.0"
 aiocontextvars = {version = "*", python = "~3.6"}


### PR DESCRIPTION
This is the subset of #153 which does not change the porting guide (and does not rely on ansible/ansible#70891). Thus this (with an appropriately updated version of ansible-community/ansible-build-data#22) could be merged first.