### PR TITLE
If ansible-base source is passed in, install it rather than running it directly

### DIFF
--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -332,7 +332,6 @@ def generate_docs() -> int:
 
         # Get the ansible-base location
         try:
-            # Note, this may be a tarball or the path to an ansible-base checkout/expanded sdist.
             ansible_base_path = collection_tarballs.pop('_ansible_base')
         except KeyError:
             print('ansible-base did not download successfully')
@@ -355,10 +354,7 @@ def generate_docs() -> int:
 
         # Create venv for ansible-base
         venv = VenvRunner('ansible-base-venv', tmp_dir)
-        if os.path.isdir(ansible_base_path):
-            venv.install_package(ansible_base_path, from_project_path=True)
-        else:
-            venv.install_package(ansible_base_path)
+        venv.install_package(ansible_base_path)
         flog.fields(venv=venv).notice('Finished installing ansible-base')
 
         generate_docs_for_all_collections(venv, collection_dir, app_ctx.extra['dest_dir'], flog)

--- a/antsibull/venv.py
+++ b/antsibull/venv.py
@@ -43,24 +43,15 @@ class VenvRunner:
         """
         return sh.Command(os.path.join(self.venv_dir, 'bin', executable_name))
 
-    def install_package(self, package_name: str, from_project_path=False) -> sh.RunningCommand:
+    def install_package(self, package_name: str) -> sh.RunningCommand:
         """
         Install a python package into the venv.
 
         :arg package_name: This can be a bare package name or a path to a file.  It's passed
             directly to :command:`pip install`.
-        :arg from_project_path: Instead of a package name or file, package_name is a path to a
-            project.  ie: an expanded sdist or a checkout of a source repo.  At the moment,
-            pip -e is used to install these sorts of packages but this is an implementation
-            detail.
         :returns: An :sh:obj:`sh.RunningCommand` for the pip output.
         """
-        if from_project_path:
-            package_args = ('-e', package_name)
-        else:
-            package_args = (package_name,)
-
-        return self._python('-m', 'pip', 'install', *package_args)
+        return self._python('-m', 'pip', 'install', package_name)
 
 
 class FakeVenvRunner:
@@ -81,16 +72,12 @@ class FakeVenvRunner:
         """
         return sh.Command(executable_name)
 
-    def install_package(self, package_name: str, from_project_path=False) -> sh.RunningCommand:
+    def install_package(self, package_name: str) -> sh.RunningCommand:
         """
         Install a python package into the venv.
 
         :arg package_name: This can be a bare package name or a path to a file.  It's passed
             directly to :command:`pip install`.
-        :arg from_project_path: Instead of a package name or file, package_name is a path to a
-            project.  ie: an expanded sdist or a checkout of a source repo.  At the moment,
-            pip -e is used to install these sorts of packages but this is an implementation
-            detail.
         :returns: An :sh:obj:`sh.RunningCommand` for the pip output.
         """
         raise Exception('Not implemented')


### PR DESCRIPTION
This fixes a bug where some pip -e usage doesn't install dependencies of
the package.  This just cropped up recently for me but not for anyone
else.  Unsure of exactly what changed about pip.

This also makes it even harder for us to modify the source accidentally
so it seems good to do regardless of whether the above bug is a general
flaw or only in specific environments.