### PR TITLE
Fix bugs in porting guide / changelog generation

### DIFF
--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -362,6 +362,7 @@ def get_changelog(
             version = PypiVer(deps.ansible_version)
             if version > acd_version:
                 print(f"Ignoring {path}, since {deps.ansible_version} is newer than {acd_version}")
+                continue
             dependencies[deps.ansible_version] = deps
         acd_changelog = ChangesData(acd_changelog_config, os.path.join(deps_dir, 'changelog.yaml'))
     if deps_data:


### PR DESCRIPTION
1. Actually ignore too new versions during changelog collection, instead of just saying so
2. "Changed Collections" should be called "Included Collections" with slightly different wording when appearing in the first (i.e. the one last in the file) changelog entry.