### PR TITLE
In syncing the jinja2 filters to ansible-doc, discovered a few bugs.

### DIFF
--- a/antsibull/jinja2/filters.py
+++ b/antsibull/jinja2/filters.py
@@ -21,14 +21,14 @@ from jinja2.runtime import Undefined
 
 # Warning: If you add to this, then you also have to change ansible-doc
 # (ansible/cli/__init__.py) in the ansible/ansible repository
-_ITALIC = re.compile(r"I\(([^)]+)\)")
-_BOLD = re.compile(r"B\(([^)]+)\)")
-_MODULE = re.compile(r"M\(([^)]+)\)")
-_URL = re.compile(r"U\(([^)]+)\)")
-_LINK = re.compile(r"L\(([^)]+), *([^)]+)\)")
-_REF = re.compile(r"R\(([^)]+), *([^)]+)\)")
-_CONST = re.compile(r"C\(([^)]+)\)")
-_RULER = re.compile(r"HORIZONTALLINE")
+_ITALIC = re.compile(r"\bI\(([^)]+)\)")
+_BOLD = re.compile(r"\bB\(([^)]+)\)")
+_MODULE = re.compile(r"\bM\(([^)]+)\)")
+_URL = re.compile(r"\bU\(([^)]+)\)")
+_LINK = re.compile(r"\bL\(([^)]+), *([^)]+)\)")
+_REF = re.compile(r"\bR\(([^)]+), *([^)]+)\)")
+_CONST = re.compile(r"\bC\(([^)]+)\)")
+_RULER = re.compile(r"\bHORIZONTALLINE\b")
 
 
 def html_ify(text):
@@ -78,7 +78,7 @@ def rst_ify(text):
     t = _URL.sub(r"\1", t)
     t = _REF.sub(r":ref:`\1 <\2>`", t)
     t = _CONST.sub(r"``\1``", t)
-    t = _RULER.sub(r"------------", t)
+    t = _RULER.sub(f"\n\n{'-' * 13}\n\n", t)
 
     return t
 

--- a/tests/units/test_jinja2.py
+++ b/tests/units/test_jinja2.py
@@ -1,0 +1,33 @@
+import pytest
+
+from antsibull.jinja2.filters import rst_ify
+
+
+RST_IFY_DATA = {
+    # No substitutions
+    'no-op': 'no-op',
+    'no-op Z(test)': 'no-op Z(test)',
+    # Simple cases of all substitutions
+    'I(italic)': '*italic*',
+    'B(bold)': '**bold**',
+    'M(ansible.builtin.yum)': ':ref:`ansible.builtin.yum'
+    ' <ansible_collections.ansible.builtin.yum_module>`',
+    'U(https://docs.ansible.com)': 'https://docs.ansible.com',
+    'L(the user guide,https://docs.ansible.com/user-guide.html)': '`the user guide'
+    ' <https://docs.ansible.com/user-guide.html>`_',
+    'R(the user guide,user-guide)': ':ref:`the user guide <user-guide>`',
+    'C(/usr/bin/file)': '``/usr/bin/file``',
+    'HORIZONTALLINE': '\n\n{0}\n\n'.format('-' * 13),
+    # Multiple substitutions
+    'The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info':
+    'The :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>` module **MUST** be given the ``package`` parameter.  See the :ref:`looping docs <using-loops>` for more info',
+    # Problem cases
+    'IBM(International Business Machines)': 'IBM(International Business Machines)',
+    'L(the user guide, https://docs.ansible.com/)': '`the user guide <https://docs.ansible.com/>`_',
+    'R(the user guide, user-guide)': ':ref:`the user guide <user-guide>`',
+}
+
+
+@pytest.mark.parametrize('text, expected', RST_IFY_DATA.items())
+def test_rst_ify(text, expected):
+    assert rst_ify(text) == expected


### PR DESCRIPTION
* Fix for words that are followed directly by a parenthesis [like:
  `IM(Instant Messaging)`] being replaced ith their macro.
* Fix for horizontal rules not being properly formatted in rst.
* Add unittest for rst_ify