### PR TITLE
sys has not been included in setup.py

### DIFF
--- a/antsibull/data/ansible-setup_py.j2
+++ b/antsibull/data/ansible-setup_py.j2
@@ -1,6 +1,7 @@
 #!/usr/bin/python -tt
 
 import os
+import sys
 from setuptools import setup
 
 


### PR DESCRIPTION
Thus it crashes when calling `sys.exit(1)`.

(Saw this when rebuilding ansible 2.10.0a7 while I currently had some 2.9 backport checked out.)