### PR TITLE
Clarify the error message when installing ansible >= 2.10 with an existing older version.

### DIFF
--- a/antsibull/data/ansible-setup_py.j2
+++ b/antsibull/data/ansible-setup_py.j2
@@ -15,6 +15,7 @@ def detect_bad_upgrade():
 
     try:
         current_version = ansible.__version__.split('.')
+        current_filename = ansible.__file__
     except AttributeError:
         # ansible is installed but already broken.  We're probably being reinstalled.
         return False
@@ -25,9 +26,13 @@ def detect_bad_upgrade():
         print("""\n
             ### ERROR ###
 
-            The currently installed ansible is of an unknown version.  Since upgrading directly
-            from ansible-2.9 or less to ansible-2.10 with pip is known to cause problems, please
-            uninstall the old version and install the new version:
+            The currently installed ansible found at:
+
+            {0}
+
+            is of an unknown version.  Since upgrading directly from ansible-2.9 or less to
+            ansible-2.10 with pip is known to cause problems, please uninstall the old version and
+            install the new version:
 
                 pip uninstall ansible
                 pip install ansible
@@ -37,14 +42,18 @@ def detect_bad_upgrade():
 
                 pip install --force-reinstall ansible ansible-base
 
-            If you want to install anyways and cleanup any breakage afterwards, set the
-            ANSIBLE_SKIP_CONFLICT_CHECK environment variable:
+            If ansible is installed in a different location than you will be installing it now
+            (for example, if the old version is installed by a system package manager to
+            /usr/lib/python3.8/site-packages/ansible but you are installing the new version into
+            ~/.local/lib/python3.8/site-packages/ansible with `pip install --user ansible`)
+            or you want to install anyways and cleanup any breakage afterwards, then you may set
+            the ANSIBLE_SKIP_CONFLICT_CHECK environment variable to ignore this check:
 
-                ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install ansible
+                ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install --user ansible
 
             ### END ERROR ###
 
-            """)
+            """.format(current_filename))
     else:
         if current_version >= (2, 10):
             return False
@@ -53,7 +62,11 @@ def detect_bad_upgrade():
             ### ERROR ###
 
             Upgrading directly from ansible-2.9 or less to ansible-2.10 or greater with pip is
-            known to cause problems.  Please uninstall the old version and install the new version:
+            known to cause problems.  Please uninstall the old version found at:
+
+            {0}
+
+            and install the new version:
 
                 pip uninstall ansible
                 pip install ansible
@@ -63,14 +76,18 @@ def detect_bad_upgrade():
 
                 pip install --force-reinstall ansible ansible-base
 
-            If you want to install anyways and cleanup any breakage afterwards, set the
-            ANSIBLE_SKIP_CONFLICT_CHECK environment variable:
+            If ansible is installed in a different location than you will be installing it now
+            (for example, if the old version is installed by a system package manager to
+            /usr/lib/python3.8/site-packages/ansible but you are installing the new version into
+            ~/.local/lib/python3.8/site-packages/ansible with `pip install --user ansible`)
+            or you want to install anyways and cleanup any breakage afterwards, then you may set
+            the ANSIBLE_SKIP_CONFLICT_CHECK environment variable to ignore this check:
 
-                ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install ansible
+                ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install --user ansible
 
             ### END ERROR ###
 
-            """)
+            """.format(current_filename))
 
     return True
 


### PR DESCRIPTION
@gundalow  noticed that:

(1) There's some valid use cases for installing the new ansible when an older ansible is present and
(2) It will make debugging easier if we print out where the older ansible is installed.

this change fixes those.