### PR TITLE
Bump antsibull-changelog requirement to have sanitization of collection changelogs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ PyYAML = "*"
 pydantic = "*"
 asyncio-pool = "*"
 perky = "*"
-antsibull-changelog = ">= 0.7.0"
+antsibull-changelog = ">= 0.8.0"
 # 0.5.0 introduces dict_config
 twiggy = ">= 0.5.0"
 aiocontextvars = {version = "*", python = "~3.6"}


### PR DESCRIPTION
Prevents crash for next alpha build.

@abadger I'm not sure whether this is a good idea, since it is only needed for Ansible builds (and changelog build), but not for docs builds - and bumping the requirement here affects ansible/ansible's use for the docs build.