### PR TITLE
The .build file needs to record the y-stream info for collections.

### DIFF
--- a/antsibull/dependency_files.py
+++ b/antsibull/dependency_files.py
@@ -142,15 +142,18 @@ class BuildFile:
         Write a build dependency file.
 
         A build dependency file records the collections that went into a given Ansible release along
-        with the exact version of the collection that was included.
+        with the range of versions that are allowed for that collection.  The range is meant to
+        define the set of collection versions that are compatible with what was present in the
+        collection as of the first beta release, when we feature freeze the collections.
 
         :arg ansible_version: The version of Ansible that is being recorded.
         :arg ansible_base_version: The version of Ansible base that will be depended on.
-        :arg dependencies: Dictionary with keys of collection names and values of versions.
+        :arg dependencies: Dictionary with keys of collection names and values of the latest
+            versions of those collections.
         """
         records = []
         for dep, version in dependencies.items():
-            records.append(f'{dep}: >={version.major}.0.0,<{version.next_major()}')
+            records.append(f'{dep}: >={version.major}.{version.minor}.0,<{version.next_major()}')
         records.sort()
 
         with open(self.filename, 'w') as f:


### PR DESCRIPTION
In semantic versioning, a version of X.Y.Z has the following meanings:

* X is bumped and Y and Z are set to 0 if there are backwards
  incompatible changes
* Y is bumped and Z is set to 0 if there are new features (and thus
  something that runs with X.Y might not run with X.(Y-1).)
* Z is bumped for bugfixes.  The interface is not changed.

Our policy for new ansible Z-stream releases is that new features may be
added.  So the .builds file was only really recording the information
about X, not Y or Z.

However, our policy for changes to the ansible package between feature
freeze and final (including beta and rc releases) is that we will only
accept bugfixes, not new features, in that timeframe.  So we need to
include the Y version to account for changes in this period.