### PR TITLE
Versioning changes

### DIFF
--- a/antsibull/build_ansible_commands.py
+++ b/antsibull/build_ansible_commands.py
@@ -201,30 +201,24 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
         asyncio.run(download_collections(included_versions, app_ctx.galaxy_url,
                                          download_dir, app_ctx.extra['collection_cache']))
 
-        if dependency_data is None:
-            dependency_data = DependencyFileData(
-                str(app_ctx.extra["ansible_version"]),
-                str(ansible_base_version),
-                {collection: str(version) for collection, version in included_versions.items()})
-
         # Get Ansible changelog, add new release
-        deps_dir = os.path.dirname(app_ctx.extra["build_file"])
+        deps_dir = os.path.dirname(app_ctx.extra['build_file'])
         ansible_changelog = ChangelogData.ansible(deps_dir)
         if add_release:
             date = datetime.date.today()
             ansible_changelog.add_ansible_release(
-                str(app_ctx.extra["ansible_version"]),
+                str(app_ctx.extra['ansible_version']),
                 date,
-                f"Release Date: {date}"
-                f"\n\n"
-                f"`Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_")
+                f'Release Date: {date}'
+                f'\n\n'
+                f'`Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_')
 
         # Get changelog and porting guide data
         changelog = get_changelog(
-            app_ctx.extra["ansible_version"],
+            app_ctx.extra['ansible_version'],
             deps_dir=deps_dir,
             deps_data=[dependency_data],
-            collection_cache=app_ctx.extra["collection_cache"],
+            collection_cache=app_ctx.extra['collection_cache'],
             ansible_changelog=ansible_changelog)
 
         # Create package and collections directories
@@ -281,7 +275,7 @@ def build_single_command() -> int:
         return 1
 
     dependency_data = DependencyFileData(
-        str(app_ctx.extra["ansible_version"]),
+        str(app_ctx.extra['ansible_version']),
         str(ansible_base_version),
         {collection: str(version) for collection, version in included_versions.items()})
 

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -163,6 +163,9 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                    ' collections at versions which were included in this version'
                                    ' of Ansible. The default is to place'
                                    ' $BASENAME_OF_BUILD_FILE-X.Y.Z.deps into --dest-dir')
+    build_step_parser.add_argument('--feature-frozen', action='store_true',
+                                   help='If this is given, then do not allow collections whose'
+                                   ' version implies there are new features.')
 
     parser = argparse.ArgumentParser(prog=program_name,
                                      description='Script to manage building Ansible')

--- a/antsibull/galaxy.py
+++ b/antsibull/galaxy.py
@@ -154,12 +154,15 @@ class GalaxyClient:
         return collection_info
 
     async def get_latest_matching_version(self, collection: str,
-                                          version_spec: str) -> semver.Version:
+                                          version_spec: str,
+                                          pre: bool = False) -> semver.Version:
         """
         Get the latest version of a collection that matches a specification.
 
         :arg collection: Namespace.collection identifying a collection.
         :arg version_spec: String specifying the allowable versions.
+        :kwarg pre: If True, allow prereleases (versions which have the form X.Y.Z.SOMETHING).
+            This is **not** for excluding 0.Y.Z versions.  The default is False.
         :returns: :obj:`semantic_version.Version` of the latest collection version that satisfied
             the specification.
 
@@ -172,6 +175,9 @@ class GalaxyClient:
 
         spec = semver.SimpleSpec(version_spec)
         for version in (v for v in versions if v in spec):
+            # If we're excluding prereleases and this is a prerelease, then skip it.
+            if not pre and version.prerelease:
+                continue
             return version
 
         # No matching versions were found


### PR DESCRIPTION
* Add a --feature-frozen command line argument to antsibull-build single   
  When this is specifed, the version information in the ansible-X.Y.build
  file is changed so that only versions without new features are used.
    
  This allows creating a new beta or rc1 release (when we're in a feature
  freeze).

* Exclude prereleases (1.0.0-beta1, 1.2.0-dev1)   
  We don't want to ship prereleases in the Ansible release.
  Fixes #107     
  Fixes #108

* Cleanup build_single   
    * Normalize quotes to fix flake8 complaint
    * Remove setting of dependency_file which was moved to a higher level
