### PR TITLE
Add a `--build-data-dir` option to `build-single`, `rebuild-single` and `build-multiple` commands

### DIFF
--- a/antsibull/build_ansible_commands.py
+++ b/antsibull/build_ansible_commands.py
@@ -272,7 +272,8 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
 def build_single_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
-    build_file = BuildFile(os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['build_file']))
+    build_file = BuildFile(
+        os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['build_file']))
     build_ansible_version, ansible_base_version, deps = build_file.parse()
     ansible_base_version = PypiVer(ansible_base_version)
 
@@ -412,7 +413,8 @@ async def make_collection_dists(dest_dir: str, collection_dirs: t.List[str]) -> 
 def build_multiple_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
-    build_file = BuildFile(os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['build_file']))
+    build_file = BuildFile(
+        os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['build_file']))
     build_ansible_version, ansible_base_version, deps = build_file.parse()
     ansible_base_version = PypiVer(ansible_base_version)
 

--- a/antsibull/build_ansible_commands.py
+++ b/antsibull/build_ansible_commands.py
@@ -212,8 +212,7 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
                                          download_dir, app_ctx.extra['collection_cache']))
 
         # Get Ansible changelog, add new release
-        deps_dir = os.path.dirname(app_ctx.extra['build_file'])
-        ansible_changelog = ChangelogData.ansible(deps_dir)
+        ansible_changelog = ChangelogData.ansible(app_ctx.extra['build_data_dir'])
         if add_release:
             date = datetime.date.today()
             ansible_changelog.add_ansible_release(
@@ -226,7 +225,7 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
         # Get changelog and porting guide data
         changelog = get_changelog(
             app_ctx.extra['ansible_version'],
-            deps_dir=deps_dir,
+            deps_dir=app_ctx.extra['build_data_dir'],
             deps_data=[dependency_data],
             collection_cache=app_ctx.extra['collection_cache'],
             ansible_changelog=ansible_changelog)
@@ -263,8 +262,8 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
         make_dist(package_dir, app_ctx.extra['dest_dir'])
 
     # Write changelog and porting guide also to destination directory
-    release_notes.write_changelog_to(deps_dir)
-    release_notes.write_porting_guide_to(deps_dir)
+    release_notes.write_changelog_to(app_ctx.extra['build_data_dir'])
+    release_notes.write_porting_guide_to(app_ctx.extra['build_data_dir'])
 
     if add_release:
         ansible_changelog.changes.save()
@@ -273,7 +272,7 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
 def build_single_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
-    build_file = BuildFile(app_ctx.extra['build_file'])
+    build_file = BuildFile(os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['build_file']))
     build_ansible_version, ansible_base_version, deps = build_file.parse()
     ansible_base_version = PypiVer(ansible_base_version)
 
@@ -320,7 +319,7 @@ def build_single_command() -> int:
 
     build_single_impl(dependency_data)
 
-    deps_filename = os.path.join(app_ctx.extra['dest_dir'], app_ctx.extra['deps_file'])
+    deps_filename = os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['deps_file'])
     deps_file = DepsFile(deps_filename)
     deps_file.write(
         dependency_data.ansible_version,
@@ -333,7 +332,7 @@ def build_single_command() -> int:
 def rebuild_single_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
-    deps_filename = os.path.join(app_ctx.extra['dest_dir'], app_ctx.extra['deps_file'])
+    deps_filename = os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['deps_file'])
     deps_file = DepsFile(deps_filename)
     dependency_data = deps_file.parse()
 
@@ -413,7 +412,7 @@ async def make_collection_dists(dest_dir: str, collection_dirs: t.List[str]) -> 
 def build_multiple_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
-    build_file = BuildFile(app_ctx.extra['build_file'])
+    build_file = BuildFile(os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['build_file']))
     build_ansible_version, ansible_base_version, deps = build_file.parse()
     ansible_base_version = PypiVer(ansible_base_version)
 
@@ -461,7 +460,7 @@ def build_multiple_command() -> int:
         make_dist(package_dir, app_ctx.extra['dest_dir'])
 
     # Write the deps file
-    deps_filename = os.path.join(app_ctx.extra['dest_dir'], app_ctx.extra['deps_file'])
+    deps_filename = os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['deps_file'])
     deps_file = DepsFile(deps_filename)
     deps_file.write(app_ctx.extra['ansible_version'], ansible_base_version, included_versions)
 

--- a/antsibull/build_ansible_commands.py
+++ b/antsibull/build_ansible_commands.py
@@ -212,7 +212,8 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
                                          download_dir, app_ctx.extra['collection_cache']))
 
         # Get Ansible changelog, add new release
-        ansible_changelog = ChangelogData.ansible(app_ctx.extra['build_data_dir'])
+        ansible_changelog = ChangelogData.ansible(
+            app_ctx.extra['data_dir'], app_ctx.extra['dest_data_dir'])
         if add_release:
             date = datetime.date.today()
             ansible_changelog.add_ansible_release(
@@ -225,7 +226,7 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
         # Get changelog and porting guide data
         changelog = get_changelog(
             app_ctx.extra['ansible_version'],
-            deps_dir=app_ctx.extra['build_data_dir'],
+            deps_dir=app_ctx.extra['data_dir'],
             deps_data=[dependency_data],
             collection_cache=app_ctx.extra['collection_cache'],
             ansible_changelog=ansible_changelog)
@@ -259,11 +260,11 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
                                  package_dir, release_notes, app_ctx.extra['debian'])
         if app_ctx.extra['debian']:
             write_debian_directory(app_ctx.extra['ansible_version'], package_dir)
-        make_dist(package_dir, app_ctx.extra['dest_dir'])
+        make_dist(package_dir, app_ctx.extra['sdist_dir'])
 
     # Write changelog and porting guide also to destination directory
-    release_notes.write_changelog_to(app_ctx.extra['build_data_dir'])
-    release_notes.write_porting_guide_to(app_ctx.extra['build_data_dir'])
+    release_notes.write_changelog_to(app_ctx.extra['dest_data_dir'])
+    release_notes.write_porting_guide_to(app_ctx.extra['dest_data_dir'])
 
     if add_release:
         ansible_changelog.changes.save()
@@ -272,8 +273,8 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
 def build_single_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
-    build_file = BuildFile(
-        os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['build_file']))
+    build_filename = os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['build_file'])
+    build_file = BuildFile(build_filename)
     build_ansible_version, ansible_base_version, deps = build_file.parse()
     ansible_base_version = PypiVer(ansible_base_version)
 
@@ -308,7 +309,7 @@ def build_single_command() -> int:
     included_versions = asyncio.run(get_collection_versions(deps, app_ctx.galaxy_url))
 
     if not str(app_ctx.extra['ansible_version']).startswith(build_ansible_version):
-        print(f'{app_ctx.extra["build_file"]} is for version {build_ansible_version} but we need'
+        print(f'{build_filename} is for version {build_ansible_version} but we need'
               f' {app_ctx.extra["ansible_version"].major}'
               f'.{app_ctx.extra["ansible_version"].minor}')
         return 1
@@ -320,7 +321,7 @@ def build_single_command() -> int:
 
     build_single_impl(dependency_data)
 
-    deps_filename = os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['deps_file'])
+    deps_filename = os.path.join(app_ctx.extra['dest_data_dir'], app_ctx.extra['deps_file'])
     deps_file = DepsFile(deps_filename)
     deps_file.write(
         dependency_data.ansible_version,
@@ -333,7 +334,7 @@ def build_single_command() -> int:
 def rebuild_single_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
-    deps_filename = os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['deps_file'])
+    deps_filename = os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['deps_file'])
     deps_file = DepsFile(deps_filename)
     dependency_data = deps_file.parse()
 
@@ -413,13 +414,15 @@ async def make_collection_dists(dest_dir: str, collection_dirs: t.List[str]) -> 
 def build_multiple_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
-    build_file = BuildFile(
-        os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['build_file']))
+    build_filename = os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['build_file'])
+    build_file = BuildFile(build_filename)
     build_ansible_version, ansible_base_version, deps = build_file.parse()
     ansible_base_version = PypiVer(ansible_base_version)
 
+    # TODO: implement --feature-frozen support
+
     if not str(app_ctx.extra['ansible_version']).startswith(build_ansible_version):
-        print(f'{app_ctx.extra["build_file"]} is for version {build_ansible_version} but we need'
+        print(f'{build_filename} is for version {build_ansible_version} but we need'
               f' {app_ctx.extra["ansible_version"].major}'
               f'.{app_ctx.extra["ansible_version"].minor}')
         return 1
@@ -442,7 +445,7 @@ def build_multiple_command() -> int:
                 collections_to_install.append(path)
 
         collection_dirs = asyncio.run(install_separately(collections_to_install, download_dir))
-        asyncio.run(make_collection_dists(app_ctx.extra['dest_dir'], collection_dirs))
+        asyncio.run(make_collection_dists(app_ctx.extra['sdist_dir'], collection_dirs))
 
         # Create the ansible package that deps on the collections we just wrote
         package_dir = os.path.join(tmp_dir, f'ansible-{app_ctx.extra["ansible_version"]}')
@@ -459,10 +462,10 @@ def build_multiple_command() -> int:
         write_python_build_files(app_ctx.extra['ansible_version'], ansible_base_version,
                                  collection_deps, package_dir)
 
-        make_dist(package_dir, app_ctx.extra['dest_dir'])
+        make_dist(package_dir, app_ctx.extra['sdist_dir'])
 
     # Write the deps file
-    deps_filename = os.path.join(app_ctx.extra['build_data_dir'], app_ctx.extra['deps_file'])
+    deps_filename = os.path.join(app_ctx.extra['dest_data_dir'], app_ctx.extra['deps_file'])
     deps_file = DepsFile(deps_filename)
     deps_file.write(app_ctx.extra['ansible_version'], ansible_base_version, included_versions)
 

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -509,15 +509,15 @@ def build_changelog() -> int:
     app_ctx = app_context.app_ctx.get()
 
     ansible_version: PypiVer = app_ctx.extra['ansible_version']
-    deps_dir: str = app_ctx.extra['deps_dir']
-    dest_dir: str = app_ctx.extra['dest_dir']
+    data_dir: str = app_ctx.extra['data_dir']
+    dest_data_dir: str = app_ctx.extra['dest_data_dir']
     collection_cache: t.Optional[str] = app_ctx.extra['collection_cache']
 
-    changelog = get_changelog(ansible_version, deps_dir=deps_dir, collection_cache=collection_cache)
+    changelog = get_changelog(ansible_version, deps_dir=data_dir, collection_cache=collection_cache)
 
     release_notes = ReleaseNotes.build(changelog)
-    release_notes.write_changelog_to(dest_dir)
-    release_notes.write_porting_guide_to(dest_dir)
+    release_notes.write_changelog_to(dest_data_dir)
+    release_notes.write_porting_guide_to(dest_data_dir)
 
     missing_changelogs = []
     last_entry = changelog.entries[0]

--- a/antsibull/build_collection.py
+++ b/antsibull/build_collection.py
@@ -27,7 +27,7 @@ def build_collection_command():
             f.write(readme)
 
         # Parse the deps file
-        deps_file = DepsFile(app_ctx.extra['deps_file'])
+        deps_file = DepsFile(os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['deps_file']))
         dummy1_, dummy2_, deps = deps_file.parse()
 
         # Template the galaxy.yml file
@@ -42,7 +42,7 @@ def build_collection_command():
             f.write(galaxy_yml_contents)
 
         sh.ansible_galaxy('collection', 'build',
-                          '--output-path', app_ctx.extra['dest_dir'],
+                          '--output-path', app_ctx.extra['collection_dir'],
                           collection_dir)
 
     return 0

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -74,7 +74,8 @@ class ChangelogData:
         return cls(paths, config, ChangesData(config, '', changelog_data), flatmap=False)
 
     @classmethod
-    def ansible(cls, directory: t.Optional[str]) -> 'ChangelogData':
+    def ansible(cls, directory: t.Optional[str],
+                output_directory: t.Optional[str] = None) -> 'ChangelogData':
         paths = PathsConfig.force_ansible('')
 
         config = ChangelogConfig.default(paths, CollectionDetails(paths), 'Ansible')
@@ -86,7 +87,10 @@ class ChangelogData:
         changelog_path = ''
         if directory is not None:
             changelog_path = os.path.join(directory, 'changelog.yaml')
-        return cls(paths, config, ChangesData(config, changelog_path), flatmap=True)
+        changes = ChangesData(config, changelog_path)
+        if output_directory is not None:
+            changes.path = os.path.join(output_directory, 'changelog.yaml')
+        return cls(paths, config, changes, flatmap=True)
 
     @classmethod
     def concatenate(cls, changelogs: t.List['ChangelogData']) -> 'ChangelogData':

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -47,6 +47,8 @@ def _normalize_build_options(args: argparse.Namespace) -> None:
     if not os.path.isdir(args.data_dir):
         raise InvalidArgumentError(f'{args.data_dir} must be an existing directory')
 
+
+def _normalize_build_write_data_options(args: argparse.Namespace) -> None:
     if args.command not in (
             'new-ansible', 'single', 'rebuild-single', 'multiple', 'changelog',
             'new-acd', 'build-single', 'build-multiple'):
@@ -272,6 +274,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     # Validation and coercion
     normalize_common_options(args)
     _normalize_build_options(args)
+    _normalize_build_write_data_options(args)
     _normalize_new_release_options(args)
     _normalize_release_build_options(args)
     _normalize_release_rebuild_options(args)

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -88,9 +88,6 @@ def _normalize_release_build_options(args: argparse.Namespace) -> None:
     if args.command not in ('single', 'multiple', 'rebuild-single'):
         return
 
-    if args.build_data_dir is None:
-        args.build_data_dir = args.dest_dir
-
     if args.build_file is None:
         args.build_file = (DEFAULT_FILE_BASE
                            + f'-{args.ansible_version.major}.{args.ansible_version.minor}.build')
@@ -158,10 +155,9 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                               ' tarballs.')
 
     build_step_parser = argparse.ArgumentParser(add_help=False)
-    build_step_parser.add_argument('--build-data-dir',
+    build_step_parser.add_argument('--build-data-dir', default='.',
                                    help='Directory which contains the existing .deps files'
-                                   ' for previous builds. The default is to use the same value'
-                                   ' as for --dest-dir.')
+                                   ' for previous builds.')
     build_step_parser.add_argument('--build-file', default=None,
                                    help='File containing the list of collections with version'
                                    ' ranges. The default is to look for'

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -44,9 +44,19 @@ ARGS_MAP = {'new-ansible': new_ansible_command,
 
 
 def _normalize_build_options(args: argparse.Namespace) -> None:
-    args.dest_dir = os.path.expanduser(os.path.expandvars(args.dest_dir))
-    if not os.path.isdir(args.dest_dir):
-        raise InvalidArgumentError(f'{args.dest_dir} must be an existing directory')
+    if not os.path.isdir(args.data_dir):
+        raise InvalidArgumentError(f'{args.data_dir} must be an existing directory')
+
+    if args.command not in (
+            'new-ansible', 'single', 'rebuild-single', 'multiple', 'changelog',
+            'new-acd', 'build-single', 'build-multiple'):
+        return
+
+    if args.dest_data_dir is None:
+        args.dest_data_dir = args.data_dir
+
+    if not os.path.isdir(args.dest_data_dir):
+        raise InvalidArgumentError(f'{args.dest_data_dir} must be an existing directory')
 
 
 def _normalize_new_release_options(args: argparse.Namespace) -> None:
@@ -60,10 +70,11 @@ def _normalize_new_release_options(args: argparse.Namespace) -> None:
         return
 
     if args.pieces_file is None:
-        args.pieces_file = os.path.join(args.dest_dir, DEFAULT_PIECES_FILE)
+        args.pieces_file = DEFAULT_PIECES_FILE
 
-    if not os.path.isfile(args.pieces_file):
-        raise InvalidArgumentError(f'The pieces file, {args.pieces_file}, must already'
+    pieces_path = os.path.join(args.data_dir, args.pieces_file)
+    if not os.path.isfile(pieces_path):
+        raise InvalidArgumentError(f'The pieces file, {pieces_path}, must already'
                                    ' exist. It should contain one namespace.collection'
                                    ' per line')
 
@@ -92,7 +103,7 @@ def _normalize_release_build_options(args: argparse.Namespace) -> None:
         args.build_file = (DEFAULT_FILE_BASE
                            + f'-{args.ansible_version.major}.{args.ansible_version.minor}.build')
 
-    build_filename = os.path.join(args.build_data_dir, args.build_file)
+    build_filename = os.path.join(args.data_dir, args.build_file)
     if not os.path.isfile(build_filename):
         raise InvalidArgumentError(f'The build file, {build_filename} must already exist.'
                                    ' It should contains one namespace.collection and range'
@@ -106,12 +117,16 @@ def _normalize_release_build_options(args: argparse.Namespace) -> None:
 
         args.deps_file = f'{basename}-{args.ansible_version}.deps'
 
+    if args.command in ('single', 'multiple'):
+        if not os.path.isdir(args.sdist_dir):
+            raise InvalidArgumentError(f'{args.sdist_dir} must be an existing directory')
+
 
 def _normalize_release_rebuild_options(args: argparse.Namespace) -> None:
     if args.command not in ('rebuild-single', ):
         return
 
-    deps_filename = os.path.join(args.build_data_dir, args.deps_file)
+    deps_filename = os.path.join(args.data_dir, args.deps_file)
     if not os.path.isfile(deps_filename):
         raise InvalidArgumentError(f'The dependency file, {deps_filename} must already exist.')
 
@@ -129,6 +144,9 @@ def _normalize_collection_build_options(args: argparse.Namespace) -> None:
     if args.deps_file is None:
         args.deps_file = DEFAULT_FILE_BASE + f'{args.ansible_version}.deps'
 
+    if not os.path.isdir(args.collection_dir):
+        raise InvalidArgumentError(f'{args.collection_dir} must be an existing directory')
+
 
 def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     """
@@ -144,8 +162,14 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     build_parser = argparse.ArgumentParser(add_help=False, parents=[common_parser])
     build_parser.add_argument('ansible_version', type=PypiVer,
                               help='The X.Y.Z version of Ansible that this will be for')
-    build_parser.add_argument('--dest-dir', default='.',
-                              help='Directory to write the output to')
+    build_parser.add_argument('--data-dir', default='.',
+                              help='Directory to read .build and .deps files from')
+
+    build_write_data_parser = argparse.ArgumentParser(add_help=False, parents=[build_parser])
+    build_write_data_parser.add_argument('--dest-data-dir', default=None,
+                                         help='Directory to write .build and .deps files to,'
+                                         ' as well as changelog and porting guide if applicable.'
+                                         '  Defaults to --data-dir')
 
     cache_parser = argparse.ArgumentParser(add_help=False)
     cache_parser.add_argument('--collection-cache', default=None,
@@ -155,21 +179,22 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                               ' tarballs.')
 
     build_step_parser = argparse.ArgumentParser(add_help=False)
-    build_step_parser.add_argument('--build-data-dir', default='.',
-                                   help='Directory which contains the existing .deps files'
-                                   ' for previous builds.')
     build_step_parser.add_argument('--build-file', default=None,
                                    help='File containing the list of collections with version'
-                                   ' ranges. The default is to look for'
-                                   ' $DEFAULT_FILE_BASE-X.Y.build inside of --build-data-dir')
+                                   ' ranges.  This is considered to be relative to'
+                                   ' --build-data-dir.  The default is'
+                                   ' $DEFAULT_FILE_BASE-X.Y.build')
     build_step_parser.add_argument('--deps-file', default=None,
                                    help='File which will be written containing the list of'
                                    ' collections at versions which were included in this version'
-                                   ' of Ansible. The default is to place'
-                                   ' $BASENAME_OF_BUILD_FILE-X.Y.Z.deps into --build-data-dir')
-    build_step_parser.add_argument('--feature-frozen', action='store_true',
-                                   help='If this is given, then do not allow collections whose'
-                                   ' version implies there are new features.')
+                                   ' of Ansible.  This is considered to be relative to'
+                                   ' --build-data-dir.  The default is'
+                                   ' $BASENAME_OF_BUILD_FILE-X.Y.Z.deps')
+
+    feature_freeze_parser = argparse.ArgumentParser(add_help=False)
+    feature_freeze_parser.add_argument('--feature-frozen', action='store_true',
+                                       help='If this is given, then do not allow collections whose'
+                                       ' version implies there are new features.')
 
     parser = argparse.ArgumentParser(prog=program_name,
                                      description='Script to manage building Ansible')
@@ -177,41 +202,48 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                        help='for help use antsibull-build SUBCOMMANDS -h')
     subparsers.required = True
 
-    new_parser = subparsers.add_parser('new-ansible', parents=[build_parser],
+    new_parser = subparsers.add_parser('new-ansible', parents=[build_write_data_parser],
                                        description='Generate a new build description from the'
                                        ' latest available versions of ansible-base and the'
                                        ' included collections')
     new_parser.add_argument('--pieces-file', default=None,
-                            help='File containing a list of collections to include.  The'
-                            f' default is to look for {DEFAULT_PIECES_FILE} inside of --dest-dir')
+                            help='File containing a list of collections to include.  This is'
+                            ' considered to be relative to --data-dir.  The default is'
+                            f' {DEFAULT_PIECES_FILE}')
     new_parser.add_argument('--build-file', default=None,
                             help='File which will be written which contains the list'
-                            ' of collections with version ranges.  The default is to'
-                            ' place $BASENAME_OF_PIECES_FILE-X.Y.build into --dest-dir')
+                            ' of collections with version ranges.  This is considered to be'
+                            ' relative to --dest-data-dir.  The default is'
+                            ' $BASENAME_OF_PIECES_FILE-X.Y.build')
 
     build_single_parser = subparsers.add_parser('single',
-                                                parents=[build_parser, cache_parser,
-                                                         build_step_parser],
+                                                parents=[build_write_data_parser, cache_parser,
+                                                         build_step_parser, feature_freeze_parser],
                                                 description='Build a single-file Ansible')
-
+    build_single_parser.add_argument('--sdist-dir', default='.',
+                                     help='Directory to write the generated sdist tarball to')
     build_single_parser.add_argument('--debian', action='store_true',
                                      help='Include Debian/Ubuntu packaging files in'
                                      ' the resulting output directory')
 
     rebuild_single_parser = subparsers.add_parser('rebuild-single',
-                                                  parents=[build_parser, cache_parser,
+                                                  parents=[build_write_data_parser, cache_parser,
                                                            build_step_parser],
                                                   description='Rebuild a single-file Ansible from'
                                                               ' a dependency file')
-
+    rebuild_single_parser.add_argument('--sdist-dir', default='.',
+                                       help='Directory to write the generated sdist tarball to')
     rebuild_single_parser.add_argument('--debian', action='store_true',
                                        help='Include Debian/Ubuntu packaging files in'
                                        ' the resulting output directory')
 
     build_multiple_parser = subparsers.add_parser('multiple',
-                                                  parents=[build_parser, cache_parser,
-                                                           build_step_parser],
+                                                  parents=[build_write_data_parser, cache_parser,
+                                                           build_step_parser,
+                                                           feature_freeze_parser],
                                                   description='Build a multi-file Ansible')
+    build_multiple_parser.add_argument('--sdist-dir', default='.',
+                                       help='Directory to write the generated sdist tarballs to')
 
     collection_parser = subparsers.add_parser('collection',
                                               parents=[build_parser],
@@ -219,15 +251,15 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                               ' install Ansible')
     collection_parser.add_argument('--deps-file', default=None,
                                    help='File which contains the list of collections and'
-                                   ' versions which were included in this version of Ansible'
-                                   f' The default is to look for {DEFAULT_FILE_BASE}-X.Y.Z.deps'
-                                   ' inside of --dest-dir')
+                                   ' versions which were included in this version of Ansible.'
+                                   '  This is considered to be relative to --data-dir.'
+                                   f'  The default is {DEFAULT_FILE_BASE}-X.Y.Z.deps')
+    build_parser.add_argument('--collection-dir', default='.',
+                              help='Directory to write collection to')
 
-    changelog_parser = subparsers.add_parser('changelog',
-                                             parents=[build_parser, cache_parser],
+    changelog_parser = subparsers.add_parser('changelog',  # noqa: F841
+                                             parents=[build_write_data_parser, cache_parser],
                                              description='Build the Ansible changelog')
-    changelog_parser.add_argument('--deps-dir', required=True,
-                                  help='Directory which contains the versioning data')
 
     # Backwards compat.
     subparsers.add_parser('new-acd', add_help=False, parents=[new_parser])

--- a/antsibull/data/build-ansible.sh.j2
+++ b/antsibull/data/build-ansible.sh.j2
@@ -5,12 +5,13 @@ MAJOR_MINOR="{{ version.major }}.{{ version.minor }}"
 pip install --user antsibull
 git clone git@github.com:ansible-community/ansible-build-data
 mkdir built
-if test -e "ansible-build-data/${MAJOR_MINOR}/ansible-${MAJOR_MINOR}.build" ; then
-  BUILDFILE="ansible-build-data/${MAJOR_MINOR}/ansible-${MAJOR_MINOR}.build"
+BUILD_DATA_DIR="ansible-build-data/${MAJOR_MINOR}"
+if test -e "${BUILD_DATA_DIR}/ansible-${MAJOR_MINOR}.build" ; then
+  BUILDFILE="ansible-${MAJOR_MINOR}.build"
 else
-  BUILDFILE="ansible-build-data/${MAJOR_MINOR}/acd-${MAJOR_MINOR}.build"
+  BUILDFILE="acd-${MAJOR_MINOR}.build"
 fi
-antsibull-build rebuild-single "{{ version }}" --build-file "$BUILDFILE" --dest-dir built
+antsibull-build rebuild-single "{{ version }}" --build-data-dir "${BUILD_DATA_DIR}" --build-file "$BUILDFILE" --dest-dir built
 
 #pip install twine
 #twine upload "built/ansible-{{ version }}.tar.gz"

--- a/antsibull/new_ansible.py
+++ b/antsibull/new_ansible.py
@@ -74,17 +74,18 @@ def find_latest_compatible(ansible_base_version, raw_dependency_versions):
 
 def new_ansible_command():
     app_ctx = app_context.app_ctx.get()
-    collections = parse_pieces_file(app_ctx.extra['pieces_file'])
+    collections = parse_pieces_file(
+        os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['pieces_file']))
     dependencies = asyncio.run(get_version_info(collections, app_ctx.pypi_url))
 
     ansible_base_version = dependencies.pop('_ansible_base')[0]
     dependencies = find_latest_compatible(ansible_base_version, dependencies)
 
-    build_filename = os.path.join(app_ctx.extra['dest_dir'], app_ctx.extra['build_file'])
+    build_filename = os.path.join(app_ctx.extra['dest_data_dir'], app_ctx.extra['build_file'])
     build_file = BuildFile(build_filename)
     build_file.write(app_ctx.extra['ansible_version'], ansible_base_version, dependencies)
 
-    changelog = ChangelogData.ansible(app_ctx.extra['dest_dir'])
+    changelog = ChangelogData.ansible(app_ctx.extra['dest_data_dir'])
     changelog.changes.save()
 
     return 0

--- a/docs/build-ansible.rst
+++ b/docs/build-ansible.rst
@@ -29,11 +29,11 @@ package is installed, you won't need to know about poetry at all::
     # Generate the list of compatible versions.  Intended to be run when we feature freeze
     poetry run antsibull-build new-ansible 2.10.0 --dest-dir ansible-build-data/2.10
 
-    # Create an ansible release using *one* of the following:
+    # Create an ansible release using **one** of the following:
     # Single tarball for ansible with a dep on the ansible-base package
-    poetry run antsibull-build single 2.10.0 --build-file ansible-build-data/2.10/ansible-2.10.build --deps-file ansible-build-data/2.10/ansible-2.10.0.deps --dest-dir built
+    poetry run antsibull-build single 2.10.0 --build-data-dir ansible-build-data/2.10 --build-file ansible-2.10.build --deps-file ansible-2.10.0.deps --dest-dir built
     # One tarball per collection plus the ansible package which deps on all of them and ansible-base
-    poetry run antsibull-build multiple 2.10.0 --build-file ansible-build-data/2.10/ansible-2.10.build --deps-file ansible-build-data/2.10/ansible-2.10.0.deps --dest-dir built
+    poetry run antsibull-build multiple 2.10.0 --build-data-dir ansible-build-data/2.10 --build-file ansible-2.10.build --deps-file ansible-2.10.0.deps --dest-dir built
 
     # Create a collection that can be installed to pull in all of the collections
     poetry run antsibull-build collection 2.10.0 --deps-file ansible-build-data/2.10/ansible-2.10.0.deps --dest-dir built

--- a/docs/build-ansible.rst
+++ b/docs/build-ansible.rst
@@ -27,16 +27,16 @@ package is installed, you won't need to know about poetry at all::
     poetry install
 
     # Generate the list of compatible versions.  Intended to be run when we feature freeze
-    poetry run antsibull-build new-ansible 2.10.0 --dest-dir ansible-build-data/2.10
+    poetry run antsibull-build new-ansible 2.10.0 --data-dir ansible-build-data/2.10
 
     # Create an ansible release using **one** of the following:
     # Single tarball for ansible with a dep on the ansible-base package
-    poetry run antsibull-build single 2.10.0 --build-data-dir ansible-build-data/2.10 --build-file ansible-2.10.build --deps-file ansible-2.10.0.deps --dest-dir built
+    poetry run antsibull-build single 2.10.0 --data-dir ansible-build-data/2.10 --sdist-dir built
     # One tarball per collection plus the ansible package which deps on all of them and ansible-base
-    poetry run antsibull-build multiple 2.10.0 --build-data-dir ansible-build-data/2.10 --build-file ansible-2.10.build --deps-file ansible-2.10.0.deps --dest-dir built
+    poetry run antsibull-build multiple 2.10.0 --data-dir ansible-build-data/2.10 --sdist-dir built
 
     # Create a collection that can be installed to pull in all of the collections
-    poetry run antsibull-build collection 2.10.0 --deps-file ansible-build-data/2.10/ansible-2.10.0.deps --dest-dir built
+    poetry run antsibull-build collection 2.10.0 --data-dir ansible-build-data/2.10 --dest-dir built
 
     # Record the files used to build:
     cd ansible-build-data/2.10

--- a/docs/build-ansible.rst
+++ b/docs/build-ansible.rst
@@ -40,7 +40,7 @@ package is installed, you won't need to know about poetry at all::
 
     # Record the files used to build:
     cd ansible-build-data/2.10
-    git add ansible-2.10.build ansible-2.10.0.deps
+    git add ansible-2.10.build ansible-2.10.0.deps changelog.yaml CHANGELOG-v2.10.rst
     git commit -m 'Collection dependency information for ansible 2.10.x and ansible-2.10.0'
     git push
     git tag 2.10.0


### PR DESCRIPTION
Fixes #159.

The default value is the value of `--dest-dir`, to make it backwards compatible. `--build-file` and `--deps-file` are now relative to `--build-data-dir`.

Unfortunately `--build-file` was documented as being relative to `--dest-dir`, but was taken relatively to CWD, so this is now in fact a **breaking change**.

I think it is probably good to have this integrated for the beta versions, so that we don't have to make this backwards compatibility breaking change later on.
