### PR TITLE
Remove remaining manual path expansions

### DIFF
--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -39,7 +39,6 @@ DEFAULT_PIECES_FILE: str = 'ansible.in'
 
 
 def _normalize_docs_options(args: argparse.Namespace) -> None:
-    args.dest_dir = os.path.expanduser(os.path.expandvars(args.dest_dir))
     args.dest_dir = os.path.abspath(os.path.realpath(args.dest_dir))
 
     # We're going to be writing a deep hierarchy of files into this directory so we need to make

--- a/antsibull/config.py
+++ b/antsibull/config.py
@@ -175,7 +175,7 @@ def read_config(filename: str) -> ConfigModel:
     flog = mlog.fields(func='read_config')
     flog.debug('Enter')
 
-    filename = os.path.abspath(os.path.expanduser(os.path.expandvars(filename)))
+    filename = os.path.abspath(filename)
 
     flog.fields(filename=filename).info('loading config file')
     raw_config_data = perky.load(filename)

--- a/antsibull/config.py
+++ b/antsibull/config.py
@@ -4,6 +4,7 @@
 # Copyright: Ansible Project, 2020
 """Functions to handle config files."""
 
+import itertools
 import os.path
 import typing as t
 
@@ -141,23 +142,17 @@ class ConfigModel(BaseModel):
         return value
 
 
-def find_config_files(conf_files: t.Iterable[str],
-                      user_supplied_conf_files: t.Optional[t.Iterable[str]] = None) -> t.List[str]:
+def find_config_files(conf_files: t.Iterable[str]) -> t.List[str]:
     """
     Find all config files that exist.
 
-    :arg conf_files: An iterable of config filenames to search for. These names
-                     will get user and variable expanded.
-    :arg user_supplied_conf_files: An iterable of config filenames to search for.
-                                   These names will get interpreted literally.
+    :arg conf_files: An iterable of config filenames to search for.
     :returns: A List of filenames which actually existed on the system.
     """
     flog = mlog.fields(func='find_config_file')
     flog.fields(conf_files=conf_files).debug('Enter')
 
-    paths = [os.path.abspath(os.path.expanduser(os.path.expandvars(p))) for p in conf_files]
-    if user_supplied_conf_files:
-        paths.extend([os.path.abspath(p) for p in user_supplied_conf_files])
+    paths = [p for p in conf_files]
     flog.fields(paths=paths).info('Paths to check')
 
     config_files = []
@@ -213,7 +208,9 @@ def load_config(conf_files: t.Union[t.Iterable[str], str, None] = None) -> t.Dic
     elif conf_files is None:
         conf_files = ()
 
-    available_files = find_config_files((SYSTEM_CONFIG_FILE, USER_CONFIG_FILE), conf_files)
+    user_config_file = os.path.expanduser(USER_CONFIG_FILE)
+    available_files = find_config_files(itertools.chain((SYSTEM_CONFIG_FILE, user_config_file),
+                                                        conf_files))
 
     includes = list(available_files)
 

--- a/antsibull/config.py
+++ b/antsibull/config.py
@@ -152,7 +152,7 @@ def find_config_files(conf_files: t.Iterable[str]) -> t.List[str]:
     flog = mlog.fields(func='find_config_file')
     flog.fields(conf_files=conf_files).debug('Enter')
 
-    paths = [p for p in conf_files]
+    paths = [os.path.abspath(p) for p in conf_files]
     flog.fields(paths=paths).info('Paths to check')
 
     config_files = []


### PR DESCRIPTION
As this is done by the shell. Fixes #183.

This also fixes two more places in the config module. Expansion is only needed for the hardcoded default config paths, but not for user-supplied paths.