### PR TITLE
[WIP]  Docsite redirects script

### DIFF
--- a/antsibull/cli/redirects.py
+++ b/antsibull/cli/redirects.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python3 -tt
+import os.path
+import tempfile
+
+from antsibull.docs_parsing.plugindump import get_redirected_plugin_dump
+from antsibull.venv import VenvRunner
+
+# https://docs.ansible.com/ansible/{$VERSION,latest,devel}/
+URL_PREFIX = '^(/ansible/[^/]+)/'
+# /var/www/html/ansible/prod/
+FS_PREFIX = '/srv/ansible/tmp'
+
+
+def old_to_new_redirect(plugin_type, old, new):
+    """
+    Format a redirect for placement in the 2.10+ tree.
+
+    This will create a redirect string from a 2.9 or less location to the 2.10 and newer location.
+
+    :arg plugin_type: The type of the plugin.
+    :old_name: The old name is the short name that was usable in past ansible releases.
+    :new_name: The new name is a FQCN.
+    """
+
+    namespace, collection, new_name = new.split('.', 2)
+
+    if plugin_type == 'module':
+        old_url = f'{URL_PREFIX}modules/{old}_module.html'
+    else:
+        old_url = f'{URL_PREFIX}plugins/{plugin_type}/{old}.html'
+
+    return (f'RedirectMatch permanent "{old_url}"'
+            f' "$1/collections/{namespace}/{collection}/{new_name}_{plugin_type}.html"')
+
+
+def new_to_old_redirect(plugin_type, old, new):
+    """
+    Format a redirect for placement in the 2.9 or less tree.
+
+    This will create a redirect string from a 2.10 or greater location to the 2.9 or less location.
+
+    :arg plugin_type: The type of the plugin.
+    :old_name: The old name is the short name that was usable in past ansible releases.
+    :new_name: The new name is a FQCN.
+    """
+    namespace, collection, new_name = new.split('.', 2)
+
+    if plugin_type == 'module':
+        old_url = f'$1/modules/{old}_module.html'
+    else:
+        old_url = f'$1/plugins/{plugin_type}/{old}.html'
+
+    return (f'RedirectMatch permanent'
+            f' "{URL_PREFIX}collections/{namespace}/{collection}/{new_name}_{plugin_type}.html"'
+            f' "{old_url}"')
+
+
+def write_apache_file(redirects, directory):
+    """
+    Write the apache config to disk.
+
+    :arg redirects: The redirect lines to put into the new config file
+    :arg directory: The directory teh apache config file will land in
+
+    .. warn:: This writes an apache .htaccess file which overwrites any existing one.
+    """
+    apache_file = os.path.join(FS_PREFIX, directory, '.htaccess')
+    with open(apache_file, 'w') as f:
+        f.write('\n'.join(redirects))
+
+
+def run(new_dirs, old_dirs):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        venv = VenvRunner('ansible-venv', tmp_dir)
+        ansible_installed_dir = venv._python('-c', 'import sysconfig; print(sysconfig.get_path("purelib"))')
+        ansible_installed_dir = ansible_installed_dir.stdout.decode('utf-8').strip()
+
+        # FIXME: Use the latest ansible or from a command line switch
+        venv.install_package('ansible==2.10.0a9')
+
+        # FIXME: This function saves global state (using python's import mechanisms) so once we have
+        # multiple ansible-base's (one for 2.10, one for 2.11, one for devel, etc), then we'll need
+        # to modify this script to run multiple times.  It won't be able to handle multiple
+        # ansible-base's from a single run.
+        plugin_data = get_redirected_plugin_dump(ansible_installed_dir)
+
+        redirects_for_new_site = []
+        redirects_for_old_site = []
+        # FIXME: Take care of renames inside of collections as well
+        # for collection_name in sorted(plugin_data):
+        plugins = plugin_data['ansible.builtin']
+        for plugin_type, plugin_list in sorted(plugins.items()):
+            redirects = plugins[plugin_type]
+            for old, new in sorted(redirects.items()):
+                # The plugin has not moved
+                if not new:
+                    new = f'ansible.builtin.{old}'
+
+                redirects_for_new_site.append(old_to_new_redirect(plugin_type, old, new))
+                redirects_for_old_site.append(new_to_old_redirect(plugin_type, old, new))
+
+        for directory in old_dirs:
+            # Redirects when people use the version switcher to go from 2.10+ to the 2.8 and 2.9
+            # docs.
+            write_apache_file(redirects_for_old_site, directory)
+
+        for directory in new_dirs:
+            # Redirects when people use the version switcher to go from 2.8 or 2.9 to 2.10+
+            write_apache_file(redirects_for_new_site, directory)
+
+
+def main():
+    # FIXME: How to handle devel and latest?  They don't have real directories for the .htaccess
+    # to land in.  Since this is a regex, they may just work.
+
+    # FIXME: Add devel and 2.8 to this
+    run(new_dirs=['2.10'], old_dirs=['2.9'])
+
+
+if __name__ == '__main__':
+    main()

--- a/antsibull/cli/redirects.py
+++ b/antsibull/cli/redirects.py
@@ -29,7 +29,9 @@ def old_to_new_redirect(plugin_type, old, new):
     else:
         old_url = f'{URL_PREFIX}plugins/{plugin_type}/{old}.html'
 
-    return (f'RedirectMatch permanent "{old_url}"'
+    # Make the Redirect temporary until we're done testing it.
+    # return (f'RedirectMatch permanent "{old_url}"'
+    return (f'RedirectMatch "{old_url}"'
             f' "$1/collections/{namespace}/{collection}/{new_name}_{plugin_type}.html"')
 
 
@@ -50,7 +52,9 @@ def new_to_old_redirect(plugin_type, old, new):
     else:
         old_url = f'$1/plugins/{plugin_type}/{old}.html'
 
-    return (f'RedirectMatch permanent'
+    # Make the Redirect temporary until we're done testing it.
+    # return (f'RedirectMatch permanent'
+    return (f'RedirectMatch'
             f' "{URL_PREFIX}collections/{namespace}/{collection}/{new_name}_{plugin_type}.html"'
             f' "{old_url}"')
 

--- a/antsibull/docs_parsing/plugindump.py
+++ b/antsibull/docs_parsing/plugindump.py
@@ -1,0 +1,150 @@
+# Copyright: 2020, Ansible Project
+# Author: Matt Davis, nitzmahone
+# License: GPLv3+
+
+import importlib
+import os
+import pkgutil
+import sys
+from pathlib import Path
+
+from ..constants import DOCUMENTABLE_PLUGINS
+from ..logging import log
+
+
+# note these are the loader attribute prefix names from loader.py, we convert them later to the collection loader plugin type values
+#PLUGIN_TYPES = ['module', 'become', 'cache', 'callback', 'connection', 'lookup', 'shell', 'inventory']
+
+mlog = log.fields(mod=__name__)
+
+
+def get_collection_names(site_dir):
+    pkg_root = Path(site_dir, 'ansible_collections')
+    namespaces = [p[1] for p in pkgutil.iter_modules([pkg_root]) if p[2]]
+
+    collections = []
+
+    for ns in namespaces:
+        collections += [p[1] for p in pkgutil.iter_modules([Path(pkg_root, ns)], f'{ns}.') if p[2]]
+
+    # hardcode the builtin collection as well
+    collections.append('ansible.builtin')
+
+    return collections
+
+
+def get_builtin_plugins(loader):
+    return [Path(p).stem for p in loader.all(path_only=True)]
+
+
+def get_collection_plugins(plugin_type, collection_name, loader):
+    if collection_name == 'ansible.builtin':
+        return get_builtin_plugins(loader)
+
+    plugins = []
+
+    try:
+        plugin_pkg = importlib.import_module(f'ansible_collections.{collection_name}.plugins.{plugin_type}')
+    except ImportError:
+        return plugins
+
+    # ignore packages, only include modules
+    plugins = [p[1] for p in pkgutil.walk_packages(plugin_pkg.__path__, f'') if not p[2]]
+
+    return plugins
+
+
+def get_redirected_plugin_dump(ansible_base_site_dir, acd_site_dir=None):
+    flog = mlog.fields(func='get_redirected_plugin_dump')
+    flog.debug('Enter')
+
+    if not acd_site_dir:
+        acd_site_dir = ansible_base_site_dir
+
+    if not Path(ansible_base_site_dir).is_dir() or not Path(ansible_base_site_dir, 'ansible').is_dir():
+        raise FileNotFoundError(f'`ansible` package not found at {ansible_base_site_dir}')
+
+    if not Path(acd_site_dir).is_dir() or not Path(acd_site_dir, 'ansible_collections').is_dir():
+        raise FileNotFoundError(f'ansible_collections` package not found at {acd_site_dir}')
+
+    if ansible_base_site_dir in sys.path:
+        sys.path.remove(ansible_base_site_dir)
+
+    sys.path[0] = ansible_base_site_dir
+
+    os.environ['ANSIBLE_DEPRECATION_WARNINGS'] = '0'
+    os.environ['ANSIBLE_COLLECTIONS_PATH'] = acd_site_dir
+    os.environ['ANSIBLE_COLLECTIONS_SCAN_SYS_PATH'] = '0'
+
+    from ansible.errors import AnsiblePluginRemovedError
+    from ansible.plugins import loader as core_loader
+    from ansible.utils.collection_loader import AnsibleCollectionRef
+
+    # get all the collection names we can find in the acd site dir
+    collection_names = get_collection_names(acd_site_dir)
+
+    result = dict()
+
+    for collection_name in collection_names:
+        collection_map = dict()
+        result[collection_name] = collection_map
+        collection_pkg = importlib.import_module(f'ansible_collections.{collection_name}')
+
+        for plugin_type in DOCUMENTABLE_PLUGINS:
+            plugin_map = dict()
+            collection_map[plugin_type] = plugin_map
+            loader = getattr(core_loader, plugin_type + '_loader')
+
+            plugin_type_subdir = AnsibleCollectionRef.legacy_plugin_dir_to_plugin_type(loader.subdir)
+            plugin_map.update({k: '' for k in get_collection_plugins(plugin_type_subdir, collection_name, loader)})
+
+            # grab the pre-chewed collection metadata the loader stuffed in
+            collection_meta = collection_pkg._collection_meta
+
+            plugin_type_meta = collection_meta.get('plugin_routing', {}).get(plugin_type_subdir, {})
+            for plugin_name, routing_entry in plugin_type_meta.items():
+                redirect = routing_entry.get('redirect')
+                if not redirect:
+                    continue
+
+                try:
+                    ctx = loader.find_plugin_with_context(redirect)
+                except AnsiblePluginRemovedError:
+                    flog.warning('{plugin_type} {plugin_name} marked as removed',
+                                 plugin_type=plugin_type, plugin_name=plugin_name)
+                    continue
+
+                if ctx.resolved:
+                    plugin_map[plugin_name] = ctx.redirect_list[-1]
+                else:
+                    flog.warning('redirected {plugin_type} {plugin_name} from collection'
+                                 ' {collection_name} did not resolve',
+                                 plugin_type=plugin_type, plugin_name=plugin_name,
+                                 collection_name=collection_name)
+
+    flog.debug('Exit')
+    return result
+
+
+def main():
+    if len(sys.argv) != 2:
+        print('usage: plugindump [ansible_base_site_dir]')
+        sys.exit(1)
+
+    dump = get_redirected_plugin_dump(sys.argv[1])
+
+    #print(dump)
+    #sys.exit(1)
+    for collection_name in sorted(dump):
+        plugins = dump[collection_name]
+        print(f'collection: {collection_name}')
+        for plugin_type in sorted(plugins):
+            redirects = plugins[plugin_type]
+            print(f'\tplugin type: {plugin_type}')
+            for src in sorted(redirects):
+                dest = redirects[src]
+                print(f'\t\t{src} -> {dest}')
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ packages = [
 antsibull-build = "antsibull.cli.antsibull_build:main"
 antsibull-lint = "antsibull.cli.antsibull_lint:main"
 antsibull-docs = "antsibull.cli.antsibull_docs:main"
+# This is a one-off script.  If we need it for ongoing maintenance, we'll
+# probably fold it into antsibull-docs
+ansible-docsite-redirects = "antsibull.cli.redirects:main"
 
 [tool.poetry.dependencies]
 python = "^3.6.0"


### PR DESCRIPTION
We need to be able to redirect urls for plugins between 2.9 or less and 2.10 and greater.  This PR contains the code to write out apache redirects to do that.

The current implementation is a one-off script which can be run to generate .htaccess files and then the .htaccess files will be modified in the future for any further needs.  If we want the script to aid in ongoing maintenance we should look into integrating it with antsibull-docs.

There is also some additional plugin "parsing" (information retrieval might be a better description) code which gets the redirect information.  That code will be useful for other things as well.

Currently known bugs and limitations:

- [x] ansible.builtin is not handled correctly (bug)
- [x] sometimes a module doesn't exist on 2.9.  Then the redirect will lead to a 404
      * This scenario  affects the version switcher for 2.8 <=> 2.9 as well.  not something to solve here
- [ ] renames can cause problems.
      * example: in 2.9, there is openssl_certificate.  In 2.10, it's called x509_certificate and openssl_certificate is an alternate name for that.  The redirects between 2.9/openssl_certificate and 2.10/x509_certificate work.  but the redirect from 2.10/openssl_certificate => 2.9/openssl_certificate do not work.
      * If this affects previous versions as well, then we definitely don't need to solve it.
- [ ] Right now the code is only using one version of the runtime.yml's to determine the redirects for every version.  That will more or less work right now but once 2.11 comes out, that will get messier.
      * If we decide this is a one-off script, it's probably okay to leave this.  If it's going to be used for continuing maintenance, we probably need to fix it.

Testing:
* I've built the 2.10 and 2.9 docs to https://toshio.fedorapeople.org/ansible/  Try manually switching urls between the 2.10 and 2.9 documentation and make sure the redirects work:
  * Example: navigate to: https://toshio.fedorapeople.org/ansible/2.10/collections/community/general/bzr_module.html
  * Change the 2.10 in the URL to 2.9: https://toshio.fedorapeople.org/ansible/2.9/collections/community/general/bzr_module.html
  * You should be redirected to https://toshio.fedorapeople.org/ansible/2.9/modules/bzr_module.html
  * Change the 2.9 in the URL to 2.10:  https://toshio.fedorapeople.org/ansible/2.10/modules/bzr_module.html
  * You should be redirected back to the original page.
* This should work with any plugin type and between any of the versions I have uploaded (2.10, 2.9, latest [symlink to 2.9], and devel [symlink to 2.10])