### PR TITLE
Fix the link in the generated release notes

### DIFF
--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -432,7 +432,7 @@ class ReleaseNotes:
             " In preparation for the release of 2.10, many plugins and modules have migrated to"
             " Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current"
             " development status of Collections and FAQ see `Ansible Collections Community Guide"
-            " <https://github.com/ansible-collections/overview/blob/master/README.rst>`_. We"
+            " <https://github.com/ansible-collections/overview/blob/main/README.rst>`_. We"
             " expect the 2.10 Porting Guide to change frequently up to the 2.10 release. Follow"
             " the conversations about collections on our various :ref:`communication` channels"
             " for the latest information on the status of the ``devel`` branch."


### PR DESCRIPTION
master branch in ansible-collections has been renamed to main.