### PR TITLE
fix collections keyword

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -46,7 +46,7 @@
 .. note::
     This module is part of ``ansible-base`` and included in all Ansible
     installations. In most cases, you can use the short module name
-    @{ plugin_name.rsplit('.', 1)[-1] }@ even without specifying the ``collection:`` keyword.
+    @{ plugin_name.rsplit('.', 1)[-1] }@ even without specifying the ``collections:`` keyword.
     Despite that, we recommend you use the FQCN for easy linking to the module
     documentation and to avoid conflicting with other collections that may have
     the same module name.


### PR DESCRIPTION
fix `collection:` keyword to `collections:`


ref.: https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#simplifying-module-names-with-the-collections-keyword