### PR TITLE
Plugin indices

### DIFF
--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -27,7 +27,12 @@ from ...galaxy import CollectionDownloader
 from ...logging import log
 from ...schemas.docs import DOCS_SCHEMAS
 from ...venv import VenvRunner, FakeVenvRunner
-from ...write_docs import output_all_plugin_rst, output_collection_index, output_indexes
+from ...write_docs import (
+    output_all_plugin_rst,
+    output_collection_index,
+    output_indexes,
+    output_plugin_indexes,
+)
 
 if t.TYPE_CHECKING:
     import semantic_version as semver
@@ -287,6 +292,8 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
     if collection_names is None:
         asyncio_run(output_collection_index(collection_info, dest_dir))
         flog.notice('Finished writing collection index')
+        asyncio_run(output_plugin_indexes(collection_info, dest_dir))
+        flog.notice('Finished writing plugin indexes')
 
     asyncio_run(output_indexes(collection_info, dest_dir, squash_hierarchy=squash_hierarchy))
     flog.notice('Finished writing indexes')

--- a/antsibull/data/docsite/list_of_plugins.rst.j2
+++ b/antsibull/data/docsite/list_of_plugins.rst.j2
@@ -2,7 +2,7 @@
 
 .. _list_of_@{ plugin_type }@_plugins:
 
-Index Of All @{ plugin_type | capitalize }@ Plugins
+Index of all @{ plugin_type | capitalize }@ Plugins
 =============@{ '=' * (plugin_type | length) }@========
 
 {% for collection_name, plugins in per_collection_data.items() | sort %}

--- a/antsibull/data/docsite/list_of_plugins.rst.j2
+++ b/antsibull/data/docsite/list_of_plugins.rst.j2
@@ -10,7 +10,7 @@ Index Of All @{ plugin_type | capitalize }@ Plugins
 @{ '-' * (collection_name | length) }@
 
 {%   for plugin_name, plugin_desc in plugins.items() | sort %}
-* :ref:`@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_@{ plugin_type }@>` -- @{ plugin_desc | rst_ify }@
+* :ref:`@{ collection_name }@.@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_@{ plugin_type }@>` -- @{ plugin_desc | rst_ify }@
 {%   endfor %}
 
 {% endfor %}

--- a/antsibull/data/docsite/list_of_plugins.rst.j2
+++ b/antsibull/data/docsite/list_of_plugins.rst.j2
@@ -10,7 +10,7 @@ Index of all @{ plugin_type | capitalize }@ Plugins
 =============@{ '=' * (plugin_type | length) }@========
 {% endif %}
 
-{% for collection_name, plugins in per_collection_data.items() | sort %}
+{% for collection_name, plugins in per_collection_plugins.items() | sort %}
 @{ collection_name }@
 @{ '-' * (collection_name | length) }@
 

--- a/antsibull/data/docsite/list_of_plugins.rst.j2
+++ b/antsibull/data/docsite/list_of_plugins.rst.j2
@@ -2,8 +2,13 @@
 
 .. _list_of_@{ plugin_type }@_plugins:
 
+{% if plugin_type == 'module' %}
+Index of all Modules
+====================
+{% else %}
 Index of all @{ plugin_type | capitalize }@ Plugins
 =============@{ '=' * (plugin_type | length) }@========
+{% endif %}
 
 {% for collection_name, plugins in per_collection_data.items() | sort %}
 @{ collection_name }@

--- a/antsibull/data/docsite/list_of_plugins.rst.j2
+++ b/antsibull/data/docsite/list_of_plugins.rst.j2
@@ -1,0 +1,16 @@
+:orphan:
+
+.. _list_of_@{ plugin_type }@_plugins:
+
+Index Of All @{ plugin_type | capitalize }@ Plugins
+=============@{ '=' * (plugin_type | length) }@========
+
+{% for collection_name, plugins in per_collection_data.items() | sort %}
+@{ collection_name }@
+@{ '-' * (collection_name | length) }@
+
+{%   for plugin_name, plugin_desc in plugins.items() | sort %}
+* :ref:`@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_@{ plugin_type }@>` -- @{ plugin_desc | rst_ify }@
+{%   endfor %}
+
+{% endfor %}

--- a/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -12,8 +12,13 @@ These are the plugins in the @{collection_name}@ collection
 
 {% for category, plugins in plugin_maps.items() | sort %}
 
+{% if category == 'module' %}
+Modules
+-------
+{% else %}
 @{ category | capitalize }@ Plugins
 @{ '-' * ((category | length) + 8) }@
+{% endif %}
 
 {% for name, desc in plugins.items() | sort %}
 * :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | rst_ify | indent(width=2) }@

--- a/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -16,7 +16,7 @@ These are the plugins in the @{collection_name}@ collection
 @{ '-' * ((category | length) + 8) }@
 
 {% for name, desc in plugins.items() | sort %}
-* :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | indent(width=2) }@
+* :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | rst_ify | indent(width=2) }@
 {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
Adds one index of all plugins for every plugin type (grouped by collection).

For example, for lookup plugins, `collections/index_lookup.rst` is created with content:
```.rst
:orphan:

.. _list_of_lookup_plugins:

Index Of All Lookup Plugins
===========================

ansible.builtin
---------------

* :ref:`config <ansible_collections.ansible.builtin.config_lookup>` -- Lookup current Ansible configuration values
* :ref:`csvfile <ansible_collections.ansible.builtin.csvfile_lookup>` -- read data from a TSV or CSV file
* :ref:`dict <ansible_collections.ansible.builtin.dict_lookup>` -- returns key/value pair items from dictionaries
* :ref:`env <ansible_collections.ansible.builtin.env_lookup>` -- Read the value of environment variables
* :ref:`file <ansible_collections.ansible.builtin.file_lookup>` -- read file contents
* :ref:`fileglob <ansible_collections.ansible.builtin.fileglob_lookup>` -- list files matching a pattern
* :ref:`first_found <ansible_collections.ansible.builtin.first_found_lookup>` -- return first file found from list
* :ref:`indexed_items <ansible_collections.ansible.builtin.indexed_items_lookup>` -- rewrites lists to return 'indexed items'
* :ref:`ini <ansible_collections.ansible.builtin.ini_lookup>` -- read data from a ini file
* :ref:`inventory_hostnames <ansible_collections.ansible.builtin.inventory_hostnames_lookup>` -- list of inventory hosts matching a host pattern
* :ref:`items <ansible_collections.ansible.builtin.items_lookup>` -- list of items
* :ref:`lines <ansible_collections.ansible.builtin.lines_lookup>` -- read lines from command
* :ref:`list <ansible_collections.ansible.builtin.list_lookup>` -- simply returns what it is given.
* :ref:`nested <ansible_collections.ansible.builtin.nested_lookup>` -- composes a list with nested elements of other lists
* :ref:`password <ansible_collections.ansible.builtin.password_lookup>` -- retrieve or generate a random password, stored in a file
* :ref:`pipe <ansible_collections.ansible.builtin.pipe_lookup>` -- read output from a command
* :ref:`random_choice <ansible_collections.ansible.builtin.random_choice_lookup>` -- return random element from list
* :ref:`sequence <ansible_collections.ansible.builtin.sequence_lookup>` -- generate a list based on a number sequence
* :ref:`subelements <ansible_collections.ansible.builtin.subelements_lookup>` -- traverse nested key from a list of dictionaries
* :ref:`template <ansible_collections.ansible.builtin.template_lookup>` -- retrieve contents of file after templating with Jinja2
* :ref:`together <ansible_collections.ansible.builtin.together_lookup>` -- merges lists into synchronized list
* :ref:`unvault <ansible_collections.ansible.builtin.unvault_lookup>` -- read vaulted file(s) contents
* :ref:`url <ansible_collections.ansible.builtin.url_lookup>` -- 
* :ref:`varnames <ansible_collections.ansible.builtin.varnames_lookup>` -- Lookup matching variable names
* :ref:`vars <ansible_collections.ansible.builtin.vars_lookup>` -- Lookup templated value of variables

community.sops
--------------

* :ref:`sops <ansible_collections.community.sops.sops_lookup>` -- Read sops encrypted file contents

felixfontein.tools
------------------

* :ref:`dependent <ansible_collections.felixfontein.tools.dependent_lookup>` -- Composes a list with nested elements of other lists or dicts which can depend on previous indices

felixfontein.versioning_test_collection
---------------------------------------

* :ref:`bob <ansible_collections.felixfontein.versioning_test_collection.bob_lookup>` -- Bob was there, too
* :ref:`reverse <ansible_collections.felixfontein.versioning_test_collection.reverse_lookup>` -- reverse magic

```
(I used a small set of collections to speed up runtime. The collections are not necessarily related to Ansible :) )