### PR TITLE
Add indexes to collection docs subcommand

### DIFF
--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -175,9 +175,6 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     stable_parser.add_argument('--deps-file', required=True,
                                help='File which contains the list of collections and'
                                ' versions which were included in this version of Ansible')
-    stable_parser.add_argument('--limit', nargs='*', action='extend',
-                               help='Limit processing to these collections.'
-                               ' Must be specified once per collection')
 
     current_parser = subparsers.add_parser('current',
                                            parents=[docs_parser],
@@ -188,9 +185,6 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                 help='Path to the directory containing ansible_collections. If not'
                                 ' specified, all collections in the currently configured ansible'
                                 ' search paths will be used')
-    current_parser.add_argument('--limit', nargs='*', action='extend',
-                                help='Limit processing to these collections.'
-                                ' Must be specified once per collection')
 
     collection_parser = subparsers.add_parser('collection',
                                               parents=[docs_parser],
@@ -205,6 +199,9 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                    ' these collections have been installed with the current'
                                    ' version of ansible. Specified --collection-version will be'
                                    ' ignored.')
+    collection_parser.add_argument('--skip-indexes', action='store_true',
+                                   help='Do not create the collection index and plugin indexes.'
+                                   ' Automatically assumed when --squash-hierarchy is specified.')
     collection_parser.add_argument('--squash-hierarchy', action='store_true',
                                    help='Do not use the full hierarchy collections/namespace/name/'
                                    ' in the destination directory. Only valid if there is only'

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -175,6 +175,9 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     stable_parser.add_argument('--deps-file', required=True,
                                help='File which contains the list of collections and'
                                ' versions which were included in this version of Ansible')
+    stable_parser.add_argument('--limit', nargs='*', action='extend',
+                               help='Limit processing to these collections.'
+                               ' Must be specified once per collection')
 
     current_parser = subparsers.add_parser('current',
                                            parents=[docs_parser],
@@ -185,6 +188,9 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                 help='Path to the directory containing ansible_collections. If not'
                                 ' specified, all collections in the currently configured ansible'
                                 ' search paths will be used')
+    current_parser.add_argument('--limit', nargs='*', action='extend',
+                                help='Limit processing to these collections.'
+                                ' Must be specified once per collection')
 
     collection_parser = subparsers.add_parser('collection',
                                               parents=[docs_parser],

--- a/antsibull/cli/doc_commands/collection.py
+++ b/antsibull/cli/doc_commands/collection.py
@@ -22,7 +22,7 @@ def generate_current_docs(skip_indexes: bool, squash_hierarchy: bool) -> int:
 
     generate_docs_for_all_collections(
         venv, None, app_ctx.extra['dest_dir'], flog, app_ctx.extra['collections'],
-        create_index=not skip_indexes and not squash_hierarchy,
+        create_indexes=not skip_indexes and not squash_hierarchy,
         squash_hierarchy=squash_hierarchy)
 
     return 0

--- a/antsibull/cli/doc_commands/collection.py
+++ b/antsibull/cli/doc_commands/collection.py
@@ -12,7 +12,7 @@ from .stable import generate_docs_for_all_collections
 mlog = log.fields(mod=__name__)
 
 
-def generate_current_docs(squash_hierarchy: bool) -> int:
+def generate_current_docs(skip_indexes: bool, squash_hierarchy: bool) -> int:
     flog = mlog.fields(func='generate_current_docs')
     flog.debug('Begin processing docs')
 
@@ -22,6 +22,7 @@ def generate_current_docs(squash_hierarchy: bool) -> int:
 
     generate_docs_for_all_collections(
         venv, None, app_ctx.extra['dest_dir'], flog, app_ctx.extra['collections'],
+        create_index=not skip_indexes and not squash_hierarchy,
         squash_hierarchy=squash_hierarchy)
 
     return 0
@@ -40,10 +41,11 @@ def generate_docs() -> int:
     """
     app_ctx = app_context.app_ctx.get()
 
+    skip_indexes: bool = app_ctx.extra['skip_indexes']
     squash_hierarchy: bool = app_ctx.extra['squash_hierarchy']
 
     if app_ctx.extra['use_current']:
-        return generate_current_docs(squash_hierarchy)
+        return generate_current_docs(skip_indexes, squash_hierarchy)
 
     raise NotImplementedError('Priority to implement subcommands is stable, devel, plugin, and'
                               ' then collection commands. Only --use-current is implemented'

--- a/antsibull/cli/doc_commands/current.py
+++ b/antsibull/cli/doc_commands/current.py
@@ -30,6 +30,7 @@ def generate_docs() -> int:
     venv = FakeVenvRunner()
 
     generate_docs_for_all_collections(
-        venv, app_ctx.extra['collection_dir'], app_ctx.extra['dest_dir'], flog)
+        venv, app_ctx.extra['collection_dir'], app_ctx.extra['dest_dir'], flog,
+        collection_names=app_ctx.extra['limit'] or None, create_index=True)
 
     return 0

--- a/antsibull/cli/doc_commands/current.py
+++ b/antsibull/cli/doc_commands/current.py
@@ -30,7 +30,6 @@ def generate_docs() -> int:
     venv = FakeVenvRunner()
 
     generate_docs_for_all_collections(
-        venv, app_ctx.extra['collection_dir'], app_ctx.extra['dest_dir'], flog,
-        collection_names=app_ctx.extra['limit'] or None, create_index=True)
+        venv, app_ctx.extra['collection_dir'], app_ctx.extra['dest_dir'], flog)
 
     return 0

--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -247,7 +247,7 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
                                       dest_dir: str,
                                       flog,
                                       collection_names: t.Optional[t.List[str]] = None,
-                                      create_index: t.Optional[bool] = None,
+                                      create_index: bool = True,
                                       squash_hierarchy: bool = False) -> None:
     """
     Create documentation for a set of installed collections.
@@ -260,15 +260,12 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
     :arg flog: A logger instance.
     :arg collection_names: Optional list of collection names. If specified, only documentation
                            for these collections will be collected and generated.
-    :arg create_index: Whether to create a collection index. By default, it is created if
-                       collection_names is not specified.
+    :arg create_index: Whether to create the collection index and plugin indexes. By default,
+                       they are created.
     :arg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
                            Undefined behavior if documentation for multiple collections are
                            created.
     """
-    if create_index is None:
-        create_index = (collection_names is None)
-
     # Get the info from the plugins
     plugin_info = asyncio_run(get_ansible_plugin_info(
         venv, collection_dir, collection_names=collection_names))
@@ -392,8 +389,6 @@ def generate_docs() -> int:
         venv.install_package(ansible_base_path)
         flog.fields(venv=venv).notice('Finished installing ansible-base')
 
-        generate_docs_for_all_collections(venv, collection_dir, app_ctx.extra['dest_dir'], flog,
-                                          collection_names=app_ctx.extra['limit'] or None,
-                                          create_index=True)
+        generate_docs_for_all_collections(venv, collection_dir, app_ctx.extra['dest_dir'], flog)
 
     return 0

--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -247,7 +247,7 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
                                       dest_dir: str,
                                       flog,
                                       collection_names: t.Optional[t.List[str]] = None,
-                                      create_index: bool = True,
+                                      create_indexes: bool = True,
                                       squash_hierarchy: bool = False) -> None:
     """
     Create documentation for a set of installed collections.
@@ -260,12 +260,13 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
     :arg flog: A logger instance.
     :arg collection_names: Optional list of collection names. If specified, only documentation
                            for these collections will be collected and generated.
-    :arg create_index: Whether to create the collection index and plugin indexes. By default,
-                       they are created.
+    :arg create_indexes: Whether to create the collection index and plugin indexes. By default,
+                         they are created.
     :arg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
                            Undefined behavior if documentation for multiple collections are
                            created.
     """
+
     # Get the info from the plugins
     plugin_info = asyncio_run(get_ansible_plugin_info(
         venv, collection_dir, collection_names=collection_names))
@@ -313,8 +314,8 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
     collection_info = get_collection_contents(plugin_contents)
     flog.debug('Finished getting collection data')
 
-    # Only build top-level index if no collection names were specified
-    if create_index:
+    # Only build top-level index if requested
+    if create_indexes:
         asyncio_run(output_collection_index(collection_info, dest_dir))
         flog.notice('Finished writing collection index')
         asyncio_run(output_plugin_indexes(plugin_contents, dest_dir))


### PR DESCRIPTION
I'm using this for my "toy" docsite so I can have the collection index and plugin indexes, but not have to generate documentation for all collections (including ansible.builtin).

Alternatively, instead of allowing limiting for `stable` and `current`, we could also allow creating the index(es) for the `collection` subcommand. @abadger what do you prefer?