### PR TITLE
WIP: Stop requiring Python 3.8

### DIFF
--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -1,5 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with
-# a variety of Python versions For more information see:
+# This workflow will install Python 3.8 and other dependencies to lint the code.
+# For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python linting
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Need to separate out 3.8-only code as we add tests for files which
-        # have 3.8 syntax in them
         python-version: [3.6, 3.7, 3.8]
 
     steps:

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -1,5 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with
-# a variety of Python versions For more information see:
+# This workflow will install a variety of Python versions and other
+# dependencies to run tests. For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python testing
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/antsibull/cli/antsibull_build.py
+++ b/antsibull/cli/antsibull_build.py
@@ -329,8 +329,4 @@ def main() -> int:
         :3: version in an input file does not match with the version specified on the command line
         :4: Needs to be run on a newer version of Python
     """
-    if sys.version_info < (3, 8):
-        print('Needs Python 3.8 or later')
-        return 4
-
     return run(sys.argv)

--- a/docs/build-ansible.rst
+++ b/docs/build-ansible.rst
@@ -12,9 +12,6 @@ Feedback welcome via GitHub issues in this repo.
 Building the Ansible package
 ============================
 
-.. note::
-    * The script needs python-3.8 or later.
-
 
 Setup for running from source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
antsibull-build now requires at least Python 3.8. However, antsibull-docs and antsibull-lint are most probably still usable with less strict requirements: should we let things as is to provide wider compatibility for these two tools, or should we completely move to ^3.8.0 so that the announced (Poetry + section 'Meta' of the project page) requirements  are valid for the three scripts?

In the second case, the section 'Meta' of the project page (https://pypi.org/project/antsibull/) would also needs to be updated.

Based on information provided by https://pypi.org/project/aiocontextvars/, I have kept the following line intact at the moment, although we might need to update it at some point, along with other relevant parts:
aiocontextvars = {version = "*", python = "~3.6"}

UPDATE: A finer analysis from Toshio (@abadger) reveals the need to roll back to Python 3.6.