### PR TITLE
Support has_action

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -97,6 +97,11 @@ Synopsis
 - @{ desc | rst_ify }@
 {%   endfor %}
 
+{% if doc['has_action'] %}
+.. note::
+    This module has a corresponding :ref:`action plugin <action_plugins>`.
+{% endif %}
+
 .. Aliases
 
 {% if doc['aliases'] -%}

--- a/antsibull/schemas/module.py
+++ b/antsibull/schemas/module.py
@@ -32,6 +32,7 @@ class ModuleOptionsSchema(OptionsSchema):
 
 class OuterModuleDocSchema(DocSchema):
     options: t.Dict[str, ModuleOptionsSchema] = {}
+    has_action: bool = False
 
 
 # Ignore Uninitialized attribute error as BaseModel works some magic to initialize the

--- a/tests/functional/schema/good_data/one_module.json
+++ b/tests/functional/schema/good_data/one_module.json
@@ -11,6 +11,7 @@
                 "This module is also supported for Windows targets."
             ],
             "filename": "/var/tmp/tmpwn9e2j6c/ansible-base-venv/lib64/python3.8/site-packages/ansible/modules/inventory/add_host.py",
+            "has_action": true,
             "module": "add_host",
             "notes": [
                 "This module bypasses the play host loop and only runs once for all the hosts in the play, if you need it to iterate use a with-loop construct.",

--- a/tests/functional/schema/good_data/one_module_results.json
+++ b/tests/functional/schema/good_data/one_module_results.json
@@ -16,6 +16,7 @@
                 ],
                 "extends_documentation_fragment": [],
                 "filename": "/var/tmp/tmpwn9e2j6c/ansible-base-venv/lib64/python3.8/site-packages/ansible/modules/inventory/add_host.py",
+                "has_action": true,
                 "name": "add_host",
                 "notes": [
                     "This module bypasses the play host loop and only runs once for all the hosts in the play, if you need it to iterate use a with-loop construct.",


### PR DESCRIPTION
Once ansible/ansible#72359 is merged, all module docs with antsibull will fail because of the unknown new field. This adds support for that field to the schema, and adds a note similar to the text output of ansible-doc. Compare https://ansible.fontein.de/collections/community/sops/load_vars_module.html#synopsis (action plugin) vs. https://ansible.fontein.de/collections/community/sops/sops_encrypt_module.html#synopsis (plain module) for the result.