### PR TITLE
Fix changelog and porting guides

### DIFF
--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -196,7 +196,8 @@ class CollectionChangelogCollector:
             changelog = await self._download_changelog_stream(
                 missing_version, collection_downloader)
             if changelog:
-                if self.changelog is None:
+                current_changelog = self.changelog
+                if current_changelog is None:
                     # If we didn't have a changelog so far, start with it
                     self.changelog = changelog
                     missing_versions -= {SemVer(version) for version in changelog.changes.releases}
@@ -205,7 +206,7 @@ class CollectionChangelogCollector:
                     for version, entry in changelog.changes.releases.items():
                         sem_version = SemVer(version)
                         if sem_version in missing_versions:
-                            self.changelog.changes.releases[version] = entry
+                            current_changelog.changes.releases[version] = entry
                             missing_versions.remove(sem_version)
 
             # Make sure that this version isn't checked again

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -273,7 +273,7 @@ class AnsibleBaseChangelogCollector:
         self.changelog = ChangelogData.concatenate(changelogs)
 
     async def download_porting_guide(self, aio_session: 'aiohttp.client.ClientSession'):
-        branch_url = (f"https://raw.githubusercontent.com/ansible/ansible/devel")
+        branch_url = 'https://raw.githubusercontent.com/ansible/ansible/devel'
 
         query_url = f"{branch_url}/{get_porting_guide_filename(self.latest)}"
         async with aio_session.get(query_url) as response:


### PR DESCRIPTION
Fixes several problems:
1. The ansible/ansible stable-2.10 branch no longer contains the ansible-base 2.10 porting guide. Porting guides are always in devel.
2. Make sure that changelog entries for all versions are fetched/preserved.
