### PR TITLE
Improve plugin indexes, add plugin indexes index

### DIFF
--- a/antsibull/data/docsite/list_of_plugin_indexes.rst.j2
+++ b/antsibull/data/docsite/list_of_plugin_indexes.rst.j2
@@ -1,0 +1,10 @@
+:orphan:
+
+.. _list_of_plugin_indexes:
+
+Index of all Module/Plugin Indexes
+==================================
+
+{% for plugin_type in plugin_types %}
+* :ref:`list_of_@{ plugin_type }@_plugins`
+{% endfor %}

--- a/antsibull/data/docsite/list_of_plugins.rst.j2
+++ b/antsibull/data/docsite/list_of_plugins.rst.j2
@@ -10,12 +10,25 @@ Index of all @{ plugin_type | capitalize }@ Plugins
 =============@{ '=' * (plugin_type | length) }@========
 {% endif %}
 
-{% for collection_name, plugins in per_collection_plugins.items() | sort %}
+{% if per_collection_plugins %}
+
+{%   if per_collection_plugins | length > 1 %}
+.. contents:: Collections listed below:
+  :local:
+{%   endif %}
+
+{%   for collection_name, plugins in per_collection_plugins.items() | sort %}
 @{ collection_name }@
 @{ '-' * (collection_name | length) }@
 
-{%   for plugin_name, plugin_desc in plugins.items() | sort %}
+{%     for plugin_name, plugin_desc in plugins.items() | sort %}
 * :ref:`@{ collection_name }@.@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_@{ plugin_type }@>` -- @{ plugin_desc | rst_ify }@
+{%     endfor %}
+
 {%   endfor %}
 
-{% endfor %}
+{% elif plugin_type == 'module' %}
+None of the collections provide modules.
+{% else %}
+None of the collections provide @{ plugin_type }@ plugins.
+{% endif %}


### PR DESCRIPTION
This adds:
1. A collection list at the top of every plugin index (i.e. table of contents) if there is more than one collection in the list; see https://ansible.fontein.de/collections/index_module.html as an example (`Collections listed below:`).
2. An index of all plugin indexes; see https://ansible.fontein.de/collections/all_indexes.html as an example. This could be linked from the TOC of https://docs.ansible.com/ansible/latest/ directly below `Collection Index`.
