### PR TITLE
Improve changelog (changed collections sections)

### DIFF
--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -96,7 +96,12 @@ def append_changelog_changes_collections(builder: RstBuilder,
         builder.add_raw_rst(
             'If not mentioned explicitly, the changes are reported in the combined changelog'
             ' below.\n')
-        headings = ['Collection', 'Previous version', 'New version', 'Notes']
+        headings = [
+            'Collection',
+            f'Ansible {changelog_entry.prev_version}',
+            f'Ansible {changelog_entry.version_str}',
+            'Notes'
+        ]
         cells = []
         for (
                 collector, collection_version, prev_collection_version

--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -52,6 +52,9 @@ def append_changelog_changes_collections(builder: RstBuilder,
 
     if changelog_entry.changed_collections:
         builder.add_section('Included Collections' if is_last else 'Changed Collections', 1)
+        builder.add_raw_rst(
+            'If not mentioned explicitly, the changes are reported in the combined changelog'
+            ' below.\n')
         for (
                 collector, collection_version, prev_collection_version
         ) in changelog_entry.changed_collections:
@@ -82,7 +85,6 @@ def append_changelog_changes_collections(builder: RstBuilder,
                         f"{collector.collection}.",
                         changelog.generator,
                         optimize_release_entry(release_entries[0])))
-                    msg += "The changes are reported in the combined changelog below."
             else:
                 metadata = collection_metadata.get_meta(collector.collection)
                 if metadata.changelog_url is not None:
@@ -92,7 +94,7 @@ def append_changelog_changes_collections(builder: RstBuilder,
                     msg += "Unfortunately, this collection does not provide changelog data in a"
                     msg += " format that can be processed by the changelog generator."
 
-            builder.add_list_item(msg)
+            builder.add_list_item(msg.rstrip())
         builder.add_raw_rst('')
 
     return result


### PR DESCRIPTION
Fixes #222.

The first commit implements @dmsimard's suggestion. For example, the `Changed Collections` section of 2.10.4 would change as follows:
```.diff
 Changed Collections
 -------------------
 
+If not mentioned explicitly, the changes are reported in the combined changelog below.
+
 - cisco.aci was upgraded from version 1.1.0 to version 1.1.1.
-  The changes are reported in the combined changelog below.
 - cisco.asa was upgraded from version 1.0.3 to version 1.0.4.
-  The changes are reported in the combined changelog below.
 - cisco.ios was upgraded from version 1.2.0 to version 1.2.1.
-  The changes are reported in the combined changelog below.
 - cisco.iosxr was upgraded from version 1.1.0 to version 1.2.0.
-  The changes are reported in the combined changelog below.
 - cisco.nxos was upgraded from version 1.3.0 to version 1.3.1.
-  The changes are reported in the combined changelog below.
 - cloudscale_ch.cloud was upgraded from version 1.2.0 to version 1.3.0.
-  The changes are reported in the combined changelog below.
 - community.crypto was upgraded from version 1.2.0 to version 1.3.0.
-  The changes are reported in the combined changelog below.
 - community.docker was upgraded to version 1.0.0.
-  The changes are reported in the combined changelog below.
 - community.general was upgraded from version 1.2.0 to version 1.3.0.
-  The changes are reported in the combined changelog below.
 - community.grafana was upgraded from version 1.0.0 to version 1.1.0.
-  The changes are reported in the combined changelog below.
 - community.hrobot was upgraded to version 1.0.0.
-  The changes are reported in the combined changelog below.
 - community.mongodb was upgraded from version 1.1.0 to version 1.1.1.
   There are no changes recorded in the changelog.
 - community.network was upgraded from version 1.2.0 to version 1.3.0.
-  The changes are reported in the combined changelog below.
 - community.okd was upgraded to version 1.0.1.
-  The changes are reported in the combined changelog below.
 - community.postgresql was upgraded to version 1.0.0.
-  The changes are reported in the combined changelog below.
 - community.routeros was upgraded to version 1.0.0.
-  The changes are reported in the combined changelog below.
 - community.vmware was upgraded from version 1.3.0 to version 1.4.0.
-  The changes are reported in the combined changelog below.
 - dellemc.os6 was upgraded from version 1.0.3 to version 1.0.4.
-  The changes are reported in the combined changelog below.
 - hetzner.hcloud was upgraded from version 1.1.0 to version 1.2.0.
-  The changes are reported in the combined changelog below.
 - junipernetworks.junos was upgraded from version 1.2.0 to version 1.2.1.
-  The changes are reported in the combined changelog below.
 - netapp.elementsw was upgraded from version 20.10.0 to version 20.11.0.
   The collection did not have a changelog in this version.
 - netapp.ontap was upgraded from version 20.10.0 to version 20.11.0.
   The collection did not have a changelog in this version.
 - ngine_io.cloudstack was upgraded from version 1.0.1 to version 1.1.0.
-  The changes are reported in the combined changelog below.
 - openvswitch.openvswitch was upgraded from version 1.0.5 to version 1.1.0.
-  The changes are reported in the combined changelog below.
 - ovirt.ovirt was upgraded from version 1.2.1 to version 1.2.3.
-  The changes are reported in the combined changelog below.
 
 Major Changes
 -------------
```