### PR TITLE
Fix log format string that contains braces

### DIFF
--- a/antsibull/utils/http.py
+++ b/antsibull/utils/http.py
@@ -48,7 +48,7 @@ class RetryGetManager:
 
         error_codes = []
         for retry in range(self.max_retries):
-            flog.debug('Execute {0}'.format(self.call_string))
+            flog.debug('Execute {0}', self.call_string)
             try:
                 response = await self.aio_session.get(*self.args, **self.kwargs)
                 status_code = response.status


### PR DESCRIPTION
When logging, we pass in a format string and arguments to expand the
string.  That flexibility allows the logging system to omit work
(expanding the format string and, if we code it right, performing costly
calculations that are only needed at certain log levels).

However, that means we must keep the format string free of stray formatting
marks.  In this case, curly braces were getting into the format string.
The solution for this case was to let the logging subsystem expand the
string when needed instead of doing it in our code.