### PR TITLE
Disable deprecation warnings in asynctest

### DIFF
--- a/test-pytest.sh
+++ b/test-pytest.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -e
-poetry run python -m pytest --cov-branch --cov=antsibull --cov=sphinx_antsibull_ext --cov-report term-missing -vv tests "$@"
+poetry run python -W 'ignore:"@coroutine" decorator is deprecated::asynctest.case' \
+	-m pytest --cov-branch --cov=antsibull --cov=sphinx_antsibull_ext --cov-report term-missing -vv tests "$@"


### PR DESCRIPTION
Longer term, we may need to use a different framework to test this, it's
unclear to me if asynctest is continuing to see updates:

https://github.com/Martiusweb/asynctest/issues/158