### PR TITLE
Unrelated improvements/fixes from #238

### DIFF
--- a/antsibull/docs_parsing/ansible_doc.py
+++ b/antsibull/docs_parsing/ansible_doc.py
@@ -208,7 +208,7 @@ async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
                                   collection_names: t.Optional[t.List[str]] = None
                                   ) -> t.Tuple[
                                       t.Mapping[str, t.Mapping[str, t.Any]],
-                                      t.Mapping[str, t.Any]]:
+                                      t.Mapping[str, AnsibleCollectionMetadata]]:
     """
     Retrieve information about all of the Ansible Plugins.
 

--- a/antsibull/docs_parsing/ansible_internal.py
+++ b/antsibull/docs_parsing/ansible_internal.py
@@ -25,7 +25,7 @@ async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
                                   collection_names: t.Optional[t.List[str]] = None
                                   ) -> t.Tuple[
                                       t.Mapping[str, t.Mapping[str, t.Any]],
-                                      t.Mapping[str, t.Any]]:
+                                      t.Mapping[str, AnsibleCollectionMetadata]]:
     """
     Retrieve information about all of the Ansible Plugins.
 

--- a/antsibull/docs_parsing/parsing.py
+++ b/antsibull/docs_parsing/parsing.py
@@ -9,6 +9,7 @@ from .. import app_context
 from ..logging import log
 from .ansible_doc import get_ansible_plugin_info as ansible_doc_get_ansible_plugin_info
 from .ansible_internal import get_ansible_plugin_info as ansible_internal_get_ansible_plugin_info
+from . import AnsibleCollectionMetadata
 
 if t.TYPE_CHECKING:
     from ..venv import VenvRunner, FakeVenvRunner
@@ -22,7 +23,7 @@ async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
                                   collection_names: t.Optional[t.List[str]] = None
                                   ) -> t.Tuple[
                                     t.Mapping[str, t.Mapping[str, t.Any]],
-                                    t.Mapping[str, t.Any]]:
+                                    t.Mapping[str, AnsibleCollectionMetadata]]:
     """
     Retrieve information about all of the Ansible Plugins.
 

--- a/antsibull/schemas/base.py
+++ b/antsibull/schemas/base.py
@@ -152,7 +152,8 @@ COLLECTION_NAME_F = p.Field(default='', regex='^([^.]+\\.[^.]+)$')
 REQUIRED_COLLECTION_NAME_OR_EMPTY_STR_F = p.Field('', regex='^([^.]+\\.[^.]+)?$')
 
 #: Constrained string listing the possible types of a return field
-RETURN_TYPE_F = p.Field('str', regex='^(bool|complex|dict|float|int|list|str|path|raw)$')
+RETURN_TYPE_F = p.Field('str', regex='^(any|bits|bool|bytes|complex|dict|float|int|json'
+                        '|jsonarg|list|path|sid|str|pathspec|pathlist)$')
 
 
 def is_json_value(value: t.Any) -> bool:
@@ -234,6 +235,16 @@ def normalize_option_type_names(obj):
 
     if obj in ('tmp', 'temppath'):
         return 'tmppath'
+
+    return obj
+
+
+def normalize_return_type_names(obj):
+    """Normalize common mispellings of return type names."""
+    obj = normalize_option_type_names(obj)
+
+    if obj == 'raw':
+        return 'any'
 
     return obj
 

--- a/antsibull/schemas/base.py
+++ b/antsibull/schemas/base.py
@@ -134,7 +134,7 @@ REQUIRED_ENV_VAR_F = p.Field(..., regex='[A-Z_]+')
 
 #: option types are a set of strings that represent the types handled by argspec.
 OPTION_TYPE_F = p.Field('str', regex='^(bits|bool|bytes|dict|float|int|json|jsonarg|list'
-                        '|path|raw|sid|str)$')
+                        '|path|raw|sid|str|tmp|temppath|tmppath|pathspec|pathlist)$')
 
 #: Constrained string type for version numbers
 REQUIRED_VERSION_F = p.Field(..., regex='^([0-9][0-9.]+)$')
@@ -152,7 +152,7 @@ COLLECTION_NAME_F = p.Field(default='', regex='^([^.]+\\.[^.]+)$')
 REQUIRED_COLLECTION_NAME_OR_EMPTY_STR_F = p.Field('', regex='^([^.]+\\.[^.]+)?$')
 
 #: Constrained string listing the possible types of a return field
-RETURN_TYPE_F = p.Field('str', regex='^(bool|complex|dict|float|int|list|str)$')
+RETURN_TYPE_F = p.Field('str', regex='^(bool|complex|dict|float|int|list|str|path|raw)$')
 
 
 def is_json_value(value: t.Any) -> bool:

--- a/antsibull/schemas/base.py
+++ b/antsibull/schemas/base.py
@@ -134,7 +134,7 @@ REQUIRED_ENV_VAR_F = p.Field(..., regex='[A-Z_]+')
 
 #: option types are a set of strings that represent the types handled by argspec.
 OPTION_TYPE_F = p.Field('str', regex='^(bits|bool|bytes|dict|float|int|json|jsonarg|list'
-                        '|path|raw|sid|str|tmp|temppath|tmppath|pathspec|pathlist)$')
+                        '|path|raw|sid|str|tmppath|pathspec|pathlist)$')
 
 #: Constrained string type for version numbers
 REQUIRED_VERSION_F = p.Field(..., regex='^([0-9][0-9.]+)$')
@@ -231,6 +231,9 @@ def normalize_option_type_names(obj):
 
     if obj == 'lists':
         return 'list'
+
+    if obj in ('tmp', 'temppath'):
+        return 'tmppath'
 
     return obj
 

--- a/antsibull/schemas/plugin.py
+++ b/antsibull/schemas/plugin.py
@@ -12,7 +12,7 @@ import typing as t
 
 import pydantic as p
 
-from .base import (OPTION_TYPE_F, REQUIRED_ENV_VAR_F, RETURN_TYPE_F,
+from .base import (REQUIRED_ENV_VAR_F, RETURN_TYPE_F,
                    COLLECTION_NAME_F, BaseModel, DeprecationSchema, DocSchema,
                    LocalConfig, OptionsSchema, list_from_scalars, is_json_value,
                    normalize_return_type_names, transform_return_docs)

--- a/antsibull/schemas/plugin.py
+++ b/antsibull/schemas/plugin.py
@@ -15,7 +15,7 @@ import pydantic as p
 from .base import (OPTION_TYPE_F, REQUIRED_ENV_VAR_F, RETURN_TYPE_F,
                    COLLECTION_NAME_F, BaseModel, DeprecationSchema, DocSchema,
                    LocalConfig, OptionsSchema, list_from_scalars, is_json_value,
-                   normalize_option_type_names, transform_return_docs)
+                   normalize_return_type_names, transform_return_docs)
 
 _SENTINEL = object()
 
@@ -47,7 +47,7 @@ class ReturnSchema(BaseModel):
 
     description: t.List[str]
     choices: t.List[str] = []
-    elements: str = OPTION_TYPE_F
+    elements: str = RETURN_TYPE_F
     returned: str = 'success'
     sample: t.Any = ''  # JSON value
     type: str = RETURN_TYPE_F
@@ -66,7 +66,7 @@ class ReturnSchema(BaseModel):
 
     @p.validator('type', 'elements', pre=True)
     def normalize_types(cls, obj):
-        return normalize_option_type_names(obj)
+        return normalize_return_type_names(obj)
 
     @p.root_validator(pre=True)
     def remove_example(cls, values):


### PR DESCRIPTION
#238 contains two commits that are unrelated to #238:
1. df49de707642b8530ff9f7c003eb0ab5c2b4e2dd adjusts the schema definition to accept more option and return types. The new lists are unions of the plugin and module lists from ansible/ansible#71734
2. c3cb33749ea9070a0861fd8fc5ad64ff6d1596b8 improves typing information.