### PR TITLE
Add breadcrumbs to collection index, plugin indexes etc., and add namespace indexes

### DIFF
--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -40,6 +40,7 @@ from ...write_docs import (
     output_indexes,
     output_plugin_indexes,
 )
+from ...utils.transformations import get_collection_namespaces
 
 if t.TYPE_CHECKING:
     import semantic_version as semver
@@ -247,20 +248,6 @@ def get_collection_contents(plugin_content: t.Mapping[str, t.Mapping[str, t.Mapp
             collection_plugins[collection_name][plugin_type] = plugin_data
 
     return collection_plugins
-
-
-def get_collection_namespaces(collection_names: t.Iterable[str]) -> t.Dict[str, t.List[str]]:
-    """
-    Return the plugins which are in each collection.
-
-    :arg collection_names: An iterable of collection names.
-    :returns: Mapping from collection namespaces to list of collection names.
-    """
-    namespaces = defaultdict(list)
-    for collection_name in collection_names:
-        namespace, name = collection_name.split('.', 1)
-        namespaces[namespace].append(name)
-    return namespaces
 
 
 def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],

--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -249,17 +249,15 @@ def get_collection_contents(plugin_content: t.Mapping[str, t.Mapping[str, t.Mapp
     return collection_plugins
 
 
-def get_collection_namespaces(collection_to_something: t.Mapping[str, t.Any]
-                              ) -> t.Dict[str, t.List[str]]:
+def get_collection_namespaces(collection_names: t.Iterable[str]) -> t.Dict[str, t.List[str]]:
     """
     Return the plugins which are in each collection.
 
-    :arg collection_to_something: A map mapping collection names to something.
-        For example the result of ``get_collection_contents()``.
-    :returns: Mapping from collection namespaces to list of collection names
+    :arg collection_names: An iterable of collection names.
+    :returns: Mapping from collection namespaces to list of collection names.
     """
     namespaces = defaultdict(list)
-    for collection_name in collection_to_something:
+    for collection_name in collection_names:
         namespace, name = collection_name.split('.', 1)
         namespaces[namespace].append(name)
     return namespaces
@@ -348,7 +346,7 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
     collection_to_plugin_info = get_collection_contents(plugin_contents)
     flog.debug('Finished getting collection data')
 
-    collection_namespaces = get_collection_namespaces(collection_to_plugin_info)
+    collection_namespaces = get_collection_namespaces(collection_to_plugin_info.keys())
 
     # Only build top-level index if requested
     if create_indexes:

--- a/antsibull/data/docsite/list_of_collections.rst.j2
+++ b/antsibull/data/docsite/list_of_collections.rst.j2
@@ -10,3 +10,11 @@ These are the collections with docs hosted on `docs.ansible.com <https://docs.an
 {% for name in collections | sort %}
 * :ref:`@{ name }@ <plugins_in_@{ name }@>`
 {% endfor %}
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+{% for name in collections | sort %}
+    @{ name.replace('.', '/') }@/index
+{% endfor %}

--- a/antsibull/data/docsite/list_of_collections.rst.j2
+++ b/antsibull/data/docsite/list_of_collections.rst.j2
@@ -15,6 +15,6 @@ These are the collections with docs hosted on `docs.ansible.com <https://docs.an
     :maxdepth: 1
     :hidden:
 
-{% for name in collections | sort %}
-    @{ name.replace('.', '/') }@/index
+{% for namespace in namespaces | sort %}
+    @{ namespace }@/index
 {% endfor %}

--- a/antsibull/data/docsite/list_of_collections_by_namespace.rst.j2
+++ b/antsibull/data/docsite/list_of_collections_by_namespace.rst.j2
@@ -1,0 +1,22 @@
+:orphan:
+
+.. _list_of_collections_@{ namespace }@:
+
+{% set title = 'Collections in the ' ~ (namespace | title) ~ ' Namespace' | rst_ify -%}
+
+@{ title }@
+@{ '=' * title|length }@
+
+These are the collections with docs hosted on `docs.ansible.com <https://docs.ansible.com/>`_ in the **@{ namespace }@** namespace.
+
+{% for name in collections | sort %}
+* :ref:`@{ namespace }@.@{ name }@ <plugins_in_@{ namespace }@.@{ name }@>`
+{% endfor %}
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+{% for name in collections | sort %}
+    @{ name }@/index
+{% endfor %}

--- a/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -19,20 +19,30 @@ These are the plugins in the @{collection_name}@ collection
 
 {% for category, plugins in plugin_maps.items() | sort %}
 
-{% if category == 'module' %}
+{%   if category == 'module' %}
 Modules
 ~~~~~~~
-{% else %}
+{%   else %}
 @{ category | capitalize }@ Plugins
 @{ '~' * ((category | length) + 8) }@
-{% endif %}
+{%   endif %}
 
-{% for name, desc in plugins.items() | sort %}
+{%   for name, desc in plugins.items() | sort %}
 * :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | rst_ify | indent(width=2) }@
-{% endfor %}
+{%   endfor %}
 {% endfor %}
 
 
 .. seealso::
 
     List of :ref:`collections <list_of_collections>` with docs hosted here.
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+{% for category, plugins in plugin_maps.items() | sort %}
+{%   for name, desc in plugins.items() | sort %}
+    @{ name }@_@{ category }@
+{%   endfor %}
+{% endfor %}

--- a/antsibull/utils/transformations.py
+++ b/antsibull/utils/transformations.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Author: Felix Fontein <felix@fontein.de>
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2021
+"""General transformation functions."""
+
+import typing as t
+from collections import defaultdict
+
+
+def get_collection_namespaces(collection_names: t.Iterable[str]) -> t.Dict[str, t.List[str]]:
+    """
+    Return the plugins which are in each collection.
+
+    :arg collection_names: An iterable of collection names.
+    :returns: Mapping from collection namespaces to list of collection names.
+    """
+    namespaces = defaultdict(list)
+    for collection_name in collection_names:
+        namespace, name = collection_name.split('.', 1)
+        namespaces[namespace].append(name)
+    return namespaces


### PR DESCRIPTION
This adds:
1. Collection namespace indexes (example: https://ansible.fontein.de/collections/community/); right now, these directories have no index file (https://docs.ansible.com/ansible/latest/collections/community/).
2. Breadcrumbs, see for example the begining of:
    - https://ansible.fontein.de/collections/
    - https://ansible.fontein.de/collections/community/
    - https://ansible.fontein.de/collections/community/crypto/
    - https://ansible.fontein.de/collections/community/crypto/x509_certificate_module.html

This kind of implements (at least parts of) ansible/proposals#147.