### PR TITLE
Add the --debian flag to build-ansible.sh

### DIFF
--- a/antsibull/data/build-ansible.sh.j2
+++ b/antsibull/data/build-ansible.sh.j2
@@ -14,7 +14,7 @@ else
   BUILDFILE="acd-${MAJOR_MINOR}.build"
   DEPSFILE="acd-${VERSION}.deps"
 fi
-antsibull-build rebuild-single "${VERSION}" --data-dir "${BUILD_DATA_DIR}" --build-file "${BUILDFILE}" --deps-file "${DEPSFILE}" --sdist-dir built
+antsibull-build rebuild-single "${VERSION}" --data-dir "${BUILD_DATA_DIR}" --build-file "${BUILDFILE}" --deps-file "${DEPSFILE}" --sdist-dir built --debian
 
 #pip install twine
 #twine upload "built/ansible-${VERSION}.tar.gz"


### PR DESCRIPTION
The script which is included in the ansible tarball to rebuild from
source needs to have the --debian flag since we now use that in our
release process.