### PR TITLE
Increase galaxy page size to reduce number of requests

### DIFF
--- a/antsibull/galaxy.py
+++ b/antsibull/galaxy.py
@@ -7,6 +7,7 @@
 import os.path
 import shutil
 import typing as t
+from urllib.parse import urlencode
 from urllib.parse import urljoin
 
 import semantic_version as semver
@@ -96,6 +97,7 @@ class GalaxyClient:
         """
         collection = collection.replace('.', '/')
         galaxy_url = urljoin(self.galaxy_server, f'api/v2/collections/{collection}/versions/')
+        galaxy_url = galaxy_url + '?' + urlencode({'page_size': 100})
         retval = await self._get_galaxy_versions(galaxy_url)
         return retval
 

--- a/antsibull/galaxy.py
+++ b/antsibull/galaxy.py
@@ -73,7 +73,7 @@ class GalaxyClient:
         :returns: List of the all the versions of the collection.
         """
         params = self.params.copy()
-        params['page_size'] = 100
+        params['page_size'] = '100'
         async with retry_get(self.aio_session, versions_url, params=params,
                              acceptable_error_codes=[404]) as response:
             if response.status == 404:

--- a/antsibull/galaxy.py
+++ b/antsibull/galaxy.py
@@ -7,7 +7,6 @@
 import os.path
 import shutil
 import typing as t
-from urllib.parse import urlencode
 from urllib.parse import urljoin
 
 import semantic_version as semver
@@ -73,7 +72,9 @@ class GalaxyClient:
         :arg version_url: url to the page to retrieve.
         :returns: List of the all the versions of the collection.
         """
-        async with retry_get(self.aio_session, versions_url, params=self.params,
+        params = self.params.copy()
+        params['page_size'] = 100
+        async with retry_get(self.aio_session, versions_url, params=params,
                              acceptable_error_codes=[404]) as response:
             if response.status == 404:
                 raise NoSuchCollection(f'No collection found at: {versions_url}')
@@ -97,7 +98,6 @@ class GalaxyClient:
         """
         collection = collection.replace('.', '/')
         galaxy_url = urljoin(self.galaxy_server, f'api/v2/collections/{collection}/versions/')
-        galaxy_url = galaxy_url + '?' + urlencode({'page_size': 100})
         retval = await self._get_galaxy_versions(galaxy_url)
         return retval
 

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -31,7 +31,7 @@ async def test_get_collection_version_info(http_redirect, ssl_certificate):
         task = asyncio.ensure_future(gc.get_versions('community.general'))
 
         request = await server.receive_request(timeout=5)
-        assert request.path_qs == '/api/v2/collections/community/general/versions/?format=json'
+        assert request.path_qs == '/api/v2/collections/community/general/versions/?page_size=100&format=json'
 
         server.send_response(request, text=json.dumps(SAMPLE_VERSIONS),
                              headers={'Content-Type': 'application/json'})

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -31,7 +31,7 @@ async def test_get_collection_version_info(http_redirect, ssl_certificate):
         task = asyncio.ensure_future(gc.get_versions('community.general'))
 
         request = await server.receive_request(timeout=5)
-        assert request.path_qs == '/api/v2/collections/community/general/versions/?page_size=100&format=json'
+        assert request.path_qs == '/api/v2/collections/community/general/versions/?format=json&page_size=100'
 
         server.send_response(request, text=json.dumps(SAMPLE_VERSIONS),
                              headers={'Content-Type': 'application/json'})


### PR DESCRIPTION
Increate the requested version list page size to 100 (default is 10) to reduce number of queries made. (100 is the maximum size; see https://github.com/ansible/galaxy/blob/devel/galaxy/api/v2/pagination.py#L21)