### PR TITLE
Improve build process when previously adding changelog entries

### DIFF
--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -101,7 +101,7 @@ class ChangelogData:
             flatmap=changelogs[0].generator_flatmap)
 
     def add_ansible_release(self, version: str, date: datetime.date, release_summary: str) -> None:
-        add_release(self.config, self.changes, [], [], version, codename=None, date=date)
+        add_release(self.config, self.changes, [], [], version, codename=None, date=date, update_existing=True)
         release_date = self.changes.releases[version]
         if 'changes' not in release_date:
             release_date['changes'] = {}

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -101,7 +101,8 @@ class ChangelogData:
             flatmap=changelogs[0].generator_flatmap)
 
     def add_ansible_release(self, version: str, date: datetime.date, release_summary: str) -> None:
-        add_release(self.config, self.changes, [], [], version, codename=None, date=date, update_existing=True)
+        add_release(self.config, self.changes, [], [], version,
+                    codename=None, date=date, update_existing=True)
         release_date = self.changes.releases[version]
         if 'changes' not in release_date:
             release_date['changes'] = {}


### PR DESCRIPTION
This PR uses a feature added to antsibull-changelog 0.9.0 (ansible-community/antsibull-changelog#51) to make adding changelog entries to new Ansible versions easier. This is needed so that the next release incorporating ansible-community/ansible-build-data#61 can be done without (or more precisely: not with more than usual) manual intervention.