### PR TITLE
Add weekly testing to CI, add badges to README

### DIFF
--- a/.github/workflows/build-css.yml
+++ b/.github/workflows/build-css.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Run once per week (Monday at 06:00 UTC)
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Run once per week (Monday at 06:00 UTC)
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Run once per week (Monday at 06:00 UTC)
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # antsibull -- Ansible Build Scripts
 [![Python linting badge](https://github.com/ansible-community/antsibull/workflows/Python%20linting/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%22Python+linting%22+branch%3Amain)
 [![Python testing badge](https://github.com/ansible-community/antsibull/workflows/Python%20testing/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%22Python+testing%22+branch%3Amain)
-[![Build CSS testing badge](https://github.com/ansible-community/antsibull/workflows/Build%20CSS/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%Build+CSS%22+branch%3Amain)
+[![Build CSS testing badge](https://github.com/ansible-community/antsibull/workflows/Build%20CSS/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%22Build+CSS%22+branch%3Amain)
 [![dumb PyPI on GH pages badge](https://github.com/ansible-community/antsibull/workflows/👷%20dumb%20PyPI%20on%20GH%20pages/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%22👷+dumb+PyPI+on+GH+pages%22+branch%3Amain)
 [![Codecov badge](https://img.shields.io/codecov/c/github/ansible-community/antsibull)](https://codecov.io/gh/ansible-community/antsibull)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # antsibull -- Ansible Build Scripts
-[![Python linting badge](https://github.com/ansible-community/antsibull/workflows/Python%20linting/badge.svg?event=push)](https://github.com/ansible-community/antsibull/actions)
-[![Python testing badge](https://github.com/ansible-community/antsibull/workflows/Python%20testing/badge.svg?event=push)](https://github.com/ansible-community/antsibull/actions)
-[![Build CSS testing badge](https://github.com/ansible-community/antsibull/workflows/Build%20CSS/badge.svg?event=push)](https://github.com/ansible-community/antsibull/actions)
-[![dumb PyPI on GH pages badge](https://github.com/ansible-community/antsibull/workflows/👷%20dumb%20PyPI%20on%20GH%20pages/badge.svg?event=push)](https://github.com/ansible-community/antsibull/actions)
+[![Python linting badge](https://github.com/ansible-community/antsibull/workflows/Python%20linting/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%22Python+linting%22+branch%3Amain)
+[![Python testing badge](https://github.com/ansible-community/antsibull/workflows/Python%20testing/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%22Python+testing%22+branch%3Amain)
+[![Build CSS testing badge](https://github.com/ansible-community/antsibull/workflows/Build%20CSS/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%Build+CSS%22+branch%3Amain)
+[![dumb PyPI on GH pages badge](https://github.com/ansible-community/antsibull/workflows/👷%20dumb%20PyPI%20on%20GH%20pages/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull/actions?query=workflow%3A%22👷+dumb+PyPI+on+GH+pages%22+branch%3Amain)
 [![Codecov badge](https://img.shields.io/codecov/c/github/ansible-community/antsibull)](https://codecov.io/gh/ansible-community/antsibull)
 
 Tooling for building various things related to Ansible

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # antsibull -- Ansible Build Scripts
+[![Python linting badge](https://github.com/ansible-community/antsibull/workflows/Python%20linting/badge.svg?event=push)](https://github.com/ansible-community/antsibull/actions)
+[![Python testing badge](https://github.com/ansible-community/antsibull/workflows/Python%20testing/badge.svg?event=push)](https://github.com/ansible-community/antsibull/actions)
+[![Build CSS testing badge](https://github.com/ansible-community/antsibull/workflows/Build%20CSS/badge.svg?event=push)](https://github.com/ansible-community/antsibull/actions)
+[![dumb PyPI on GH pages badge](https://github.com/ansible-community/antsibull/workflows/👷%20dumb%20PyPI%20on%20GH%20pages/badge.svg?event=push)](https://github.com/ansible-community/antsibull/actions)
+[![Codecov badge](https://img.shields.io/codecov/c/github/ansible-community/antsibull)](https://codecov.io/gh/ansible-community/antsibull)
+
 Tooling for building various things related to Ansible
 
 Scripts that are here:


### PR DESCRIPTION
This adds weekly CI runs for Python linting, Python testing, and CSS building. I stuck to weekly (instead of nightly) since we don't need that quick feedback that something stopped working.

I also added badges to the README (CI + codecov) so we have some more motivation to increase test coverage ;-)