### PR TITLE
Allow collections to add RST files

### DIFF
--- a/antsibull/build_changelog.py
+++ b/antsibull/build_changelog.py
@@ -247,7 +247,7 @@ def dump_items(builder: RstBuilder, items: PluginDumpT) -> None:
 
 def add_plugins(builder: RstBuilder, data: PluginDataT) -> None:
     plugins: PluginDumpT = []
-    for name, prefix, _, release_entry in data:
+    for name, prefix, dummy, release_entry in data:
         if release_entry:
             for plugin_type, plugin_datas in release_entry.plugins.items():
                 for plugin_data in plugin_datas:
@@ -261,7 +261,7 @@ def add_plugins(builder: RstBuilder, data: PluginDataT) -> None:
 
 def add_objects(builder: RstBuilder, data: PluginDataT) -> None:
     objects: PluginDumpT = []
-    for name, prefix, _, release_entry in data:
+    for name, prefix, dummy, release_entry in data:
         if release_entry:
             for object_type, object_datas in release_entry.objects.items():
                 for object_data in object_datas:
@@ -274,7 +274,7 @@ def add_objects(builder: RstBuilder, data: PluginDataT) -> None:
 
 def add_modules(builder: RstBuilder, data: PluginDataT) -> None:
     modules: PluginDumpT = []
-    for name, prefix, _, release_entry in data:
+    for name, prefix, dummy, release_entry in data:
         if release_entry:
             for module in release_entry.modules:
                 namespace = module.get('namespace') or ''
@@ -351,7 +351,7 @@ def append_changelog(builder: RstBuilder,
     for section, section_title in DEFAULT_SECTIONS:
         maybe_add_section_title = create_title_adder(builder, section_title, 1)
 
-        for name, _, _, release_entry in data:
+        for name, dummy, dummy, release_entry in data:
             if not release_entry or release_entry.has_no_changes([section]):
                 continue
 

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -240,7 +240,7 @@ class AnsibleBaseChangelogCollector:
         path = await base_downloader(str(version))
         if os.path.isdir(path):
             changelog: t.Optional[ChangelogData] = None
-            for root, _, files in os.walk(path):
+            for root, dummy, files in os.walk(path):
                 if 'changelog.yaml' in files:
                     with open(os.path.join(root, 'changelog.yaml'), 'rb') as f:
                         changelog = f.read()
@@ -496,7 +496,7 @@ def get_changelog(
     changelog = []
 
     sorted_versions = collect_versions(versions, ansible_changelog.config)
-    for index, (version_str, _) in enumerate(sorted_versions):
+    for index, (version_str, dummy) in enumerate(sorted_versions):
         version, deps = versions[version_str]
         prev_version = None
         if index + 1 < len(sorted_versions):

--- a/antsibull/cli/antsibull_lint.py
+++ b/antsibull/cli/antsibull_lint.py
@@ -24,6 +24,7 @@ from antsibull_changelog.lint import lint_changelog_yaml
 from antsibull_changelog.logger import setup_logger
 
 from ..args import get_toplevel_parser, normalize_toplevel_options
+from ..lint_extra_docs import lint_collection_extra_docs_files
 
 
 def run(args: List[str]) -> int:
@@ -55,6 +56,16 @@ def run(args: List[str]) -> int:
                                     metavar='/path/to/changelog.yaml',
                                     help='path to changelogs/changelog.yaml')
 
+        collection_docs = subparsers.add_parser('collection-docs',
+                                                parents=[common],
+                                                help='Collection extra docs linter for inclusion'
+                                                     ' in docsite')
+        collection_docs.set_defaults(command=command_lint_collection_docs)
+
+        collection_docs.add_argument('collection_root_path',
+                                     metavar='/path/to/collection',
+                                     help='path to collection (directory that includes galaxy.yml)')
+
         if HAS_ARGCOMPLETE:
             argcomplete.autocomplete(parser)
 
@@ -83,6 +94,24 @@ def command_lint_changelog(args: Any) -> int:
     :arg args: Parsed arguments
     """
     errors = lint_changelog_yaml(args.changelog_yaml_path)
+
+    messages = sorted(set(
+        '%s:%d:%d: %s' % (error[0], error[1], error[2], error[3])
+        for error in errors))
+
+    for message in messages:
+        print(message)
+
+    return 3 if messages else 0
+
+
+def command_lint_collection_docs(args: Any) -> int:
+    """
+    Validate docs/docsite/rst/ in a collection.
+
+    :arg args: Parsed arguments
+    """
+    errors = lint_collection_extra_docs_files(args.collection_root_path)
 
     messages = sorted(set(
         '%s:%d:%d: %s' % (error[0], error[1], error[2], error[3])

--- a/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -14,10 +14,29 @@ Collection version @{ collection_version }@
 .. toctree::
     :maxdepth: 1
 
+{% for section in extra_docs_sections %}
+@{section.title}@
+@{ '-' * (section.title | length) }@
+
+{%   if section.toctree %}
+.. toctree::
+    :maxdepth: 1
+
+{%     for toctree_entry in section.toctree %}
+    @{toctree_entry}@
+{%     endfor %}
+{%   endif %}
+
+{% endfor %}
+
 Plugin Index
 ------------
 
+{% if plugin_maps %}
 These are the plugins in the @{collection_name}@ collection
+{% else %}
+There are no plugins in the @{collection_name}@ collection with automatically generated documentation.
+{% endif %}
 
 {% for category, plugins in plugin_maps.items() | sort %}
 

--- a/antsibull/extra_docs.py
+++ b/antsibull/extra_docs.py
@@ -1,0 +1,232 @@
+# coding: utf-8
+# Author: Felix Fontein <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2021
+
+import asyncio
+import os
+import os.path
+import re
+import typing as t
+
+import aiofiles
+import asyncio_pool
+
+from . import app_context
+from .logging import log
+from .yaml import load_yaml_file
+
+
+mlog = log.fields(mod=__name__)
+
+_RST_LABEL_DEFINITION = re.compile(r'''^\.\. _([^:]+):''')
+
+
+class ExtraDocsIndexError(Exception):
+    pass
+
+
+class Section:
+    title: str
+    toctree: t.List[str]
+
+    def __init__(self, title: str, toctree: t.List[str]):
+        self.title = title
+        self.toctree = toctree
+
+
+#: A tuple consisting of a list of sections and a list of RST documents as tuples
+#: (relative path in docs/docsite/rst, content).
+CollectionExtraDocsInfoT = t.Tuple[t.List[Section], t.List[t.Tuple[str, str]]]
+
+
+def find_extra_docs(path_to_collection: str) -> t.List[t.Tuple[str, str]]:
+    '''Enumerate all extra docs RST files for a collection path.
+
+    :arg path_to_collection: Path to a collection.
+    :arg collection_name: Dotted collection name.
+    :returns: A list of tuples (absolute path, relative path in docs/docsite/rst)
+    '''
+    docs_dir = os.path.join(path_to_collection, 'docs', 'docsite', 'rst')
+    if not os.path.isdir(docs_dir):
+        return []
+    result = []
+    for dirname, dirs, files in os.walk(docs_dir):
+        for file in files:
+            if file.endswith('.rst'):
+                path = os.path.join(dirname, file)
+                result.append((path, os.path.normpath(os.path.relpath(path, docs_dir))))
+    return result
+
+
+def get_label_prefix(collection_name: str) -> str:
+    '''Create RST label prefix for the given collection name.
+
+    :arg collection_name: Dotted collection name.
+    :returns: A RST label prefix
+    '''
+    return f'ansible_collections.{collection_name}.docsite.'
+
+
+def lint_required_conditions(content: str, collection_name: str
+                             ) -> t.Tuple[t.List[str], t.List[t.Tuple[int, int, str]]]:
+    '''Check a extra docs RST file's content for whether it satisfied the required conditions.
+
+    :arg content: Content of a RST document.
+    :arg collection_name: Dotted collection name.
+    :returns: A tuple consisting of a list of RST labels and a list of error messages
+              (with line and column numbers).
+    '''
+    labels: t.Set[str] = set()
+    errors: t.List[t.Tuple[int, int, str]] = []
+    label_prefix = get_label_prefix(collection_name)
+    # Check label definitions
+    for row, line in enumerate(content.splitlines()):
+        m = _RST_LABEL_DEFINITION.match(line)
+        if m:
+            label = m.group(1)
+            if not label.startswith(label_prefix):
+                errors.append((
+                    row + 1,
+                    0,
+                    f'Label "{label}" does not start with expected prefix "{label_prefix}"'))
+            else:
+                labels.add(label)
+    return sorted(labels), errors
+
+
+def load_toctree(yaml_section: t.Dict[str, t.Any], section_index: int = 0
+                 ) -> t.Tuple[t.List[str], t.List[str]]:
+    errors: t.List[str] = []
+    toctree: t.List[str] = []
+    if 'toctree' in yaml_section:
+        for toctree_index, toctree_name in enumerate(yaml_section['toctree']):
+            if not isinstance(toctree_name, str):
+                errors.append(
+                    f'Toctree entry #{toctree_index} in section #{section_index}'
+                    f' is not a string')
+                continue
+            toctree.append(toctree_name)
+    return toctree, errors
+
+
+def load_section(yaml_section: t.Dict[str, t.Any], section_index: int = 0
+                 ) -> t.Tuple[t.Optional[Section], t.List[str]]:
+    errors: t.List[str] = []
+    missing = False
+    for required_key in ('title', ):
+        if required_key not in yaml_section:
+            errors.append(
+                f'Section #{section_index} has no "{required_key}" entry')
+            missing = True
+    if missing:
+        return None, errors
+    toctree, toctree_errors = load_toctree(yaml_section, section_index)
+    errors.extend(toctree_errors)
+    if not toctree:
+        errors.append(
+            f'Section #{section_index} has no content')
+        return None, errors
+    return Section(yaml_section['title'], toctree), errors
+
+
+def load_extra_docs_index(index_path: str) -> t.Tuple[t.List[Section], t.List[str]]:
+    '''Load a collection's extra-docs.yml file.
+
+    :arg index_path: Path to extra-docs.yml (does not need to exist).
+    :returns: A tuple consisting of a list of sections and a list of error messages.
+    :raises: ExtraDocsIndexError if extra-docs.yml does not exist
+    '''
+    sections: t.List[Section] = []
+    errors: t.List[str] = []
+
+    if not os.path.isfile(index_path):
+        raise ExtraDocsIndexError('extra-docs.yml does not exist')
+
+    try:
+        index = load_yaml_file(index_path)
+        if index.get('sections'):
+            for section_index, yaml_section in enumerate(index['sections']):
+                if not isinstance(yaml_section, dict):
+                    errors.append(f'Section #{section_index} must be a mapping')
+                    continue
+                section, section_errors = load_section(yaml_section, section_index)
+                if section is not None:
+                    sections.append(section)
+                errors.extend(section_errors)
+    except Exception as exc:
+        errors.append(str(exc))
+
+    return sections, errors
+
+
+async def load_collection_extra_docs(collection_name: str,
+                                     collection_path: str,
+                                     path_prefix: str = 'docsite/'
+                                     ) -> CollectionExtraDocsInfoT:
+    '''Given a collection name and collection metadata, load extra docs data.
+
+    :arg collection_name: Dotted collection name.
+    :arg collection_path: Path to the collection.
+    :arg path_prefix: Prefix to add to relative paths, and toctree entries.
+    :returns: A tuple consisting of a list of sections and a list of RST documents as tuples
+              (relative path in docs/docsite/rst, content).
+    '''
+    flog = mlog.fields(func='load_collection_extra_docs')
+    flog.debug('Enter')
+
+    index_path = os.path.join(collection_path, 'docs', 'docsite', 'extra-docs.yml')
+    try:
+        sections, dummy = load_extra_docs_index(index_path)
+    except ExtraDocsIndexError:
+        sections = []
+
+    for section in sections:
+        for i, toctree in enumerate(section.toctree):
+            section.toctree[i] = path_prefix + toctree
+    documents = []
+    for doc in find_extra_docs(collection_path):
+        try:
+            # Load content
+            async with aiofiles.open(doc[0], 'r', encoding='utf-8') as f:
+                content = await f.read()
+
+            # Lint content
+            dummy, errors = lint_required_conditions(content, collection_name)
+
+            # When no errors were found, add to output
+            if not errors:
+                documents.append((path_prefix + doc[1], content))
+        except Exception:
+            pass
+
+    flog.debug('Leave')
+    return sections, documents
+
+
+async def load_collections_extra_docs(collection_paths: t.Mapping[str, str]
+                                      ) -> t.Mapping[str, CollectionExtraDocsInfoT]:
+    '''Load extra docs data.
+
+    :arg collection_paths: Mapping of collection_name to the collection's path.
+    :returns: A mapping of collection_name to CollectionExtraDocsInfoT.
+    '''
+    flog = mlog.fields(func='load_collections_extra_docs')
+    flog.debug('Enter')
+
+    loaders = {}
+    lib_ctx = app_context.lib_ctx.get()
+
+    async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
+        for collection_name, collection_path in collection_paths.items():
+            loaders[collection_name] = await pool.spawn(
+                load_collection_extra_docs(collection_name, collection_path))
+
+        responses = await asyncio.gather(*loaders.values())
+
+    # Note: Python dicts have always had a stable order as long as you don't modify the dict.
+    # So loaders (implicitly, the keys) and responses have a matching order here.
+    result = dict(zip(loaders, responses))
+
+    flog.debug('Leave')
+    return result

--- a/antsibull/lint_extra_docs.py
+++ b/antsibull/lint_extra_docs.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+# Author: Felix Fontein <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2021
+
+import os
+import os.path
+import re
+import typing as t
+
+import docutils.utils
+import rstcheck
+
+from .extra_docs import (
+    find_extra_docs,
+    lint_required_conditions,
+    load_extra_docs_index,
+    ExtraDocsIndexError,
+)
+from .yaml import load_yaml_file
+
+
+_RST_LABEL_DEFINITION = re.compile(r'''^\.\. _([^:]+):''')
+
+
+def load_collection_name(path_to_collection: str) -> str:
+    '''Load collection name (namespace.name) from collection's galaxy.yml.'''
+    galaxy_yml_path = os.path.join(path_to_collection, 'galaxy.yml')
+    if not os.path.isfile(galaxy_yml_path):
+        raise Exception(f'Cannot find file {galaxy_yml_path}')
+
+    galaxy_yml = load_yaml_file(galaxy_yml_path)
+    collection_name = '{namespace}.{name}'.format(**galaxy_yml)
+    return collection_name
+
+
+def lint_optional_conditions(content: str, path: str, collection_name: str
+                             ) -> t.List[t.Tuple[int, int, str]]:
+    '''Check a extra docs RST file's content for whether it satisfied the required conditions.
+
+    Return a list of errors.
+    '''
+    results = rstcheck.check(
+        content, filename=path,
+        report_level=docutils.utils.Reporter.WARNING_LEVEL)
+    return [(result[0], 0, result[1]) for result in results]
+
+
+def lint_collection_extra_docs_files(path_to_collection: str
+                                     ) -> t.List[t.Tuple[str, int, int, str]]:
+    try:
+        collection_name = load_collection_name(path_to_collection)
+    except Exception:
+        return [(
+            path_to_collection, 0, 0, 'Cannot identify collection with galaxy.yml at this path')]
+    result = []
+    all_labels = set()
+    docs = find_extra_docs(path_to_collection)
+    for doc in docs:
+        try:
+            # Load content
+            with open(doc[0], 'r', encoding='utf-8') as f:
+                content = f.read()
+            # Rstcheck
+            errors = lint_optional_conditions(content, doc[0], collection_name)
+            result.extend((doc[0], line, col, msg) for (line, col, msg) in errors)
+            # Lint labels
+            labels, errors = lint_required_conditions(content, collection_name)
+            all_labels.update(labels)
+            result.extend((doc[0], line, col, msg) for (line, col, msg) in errors)
+        except Exception as e:
+            result.append((doc[0], 0, 0, str(e)))
+    index_path = os.path.join(path_to_collection, 'docs', 'docsite', 'extra-docs.yml')
+    try:
+        sections, errors = load_extra_docs_index(index_path)
+        result.extend((index_path, 0, 0, error) for error in errors)
+    except ExtraDocsIndexError as exc:
+        if len(docs) > 0:
+            # Only report the missing index_path as an error if we found documents
+            result.append((index_path, 0, 0, str(exc)))
+    return result


### PR DESCRIPTION
The RST files have to be in `docs/docsite/rst/` (and subdirs), need to use labels of the form `ansible_collections.{namespace}.{name}.docsite.` (RST files not satisfying that are ignored), and there needs to be a `index.yml` which allows to add sections to the main collection page and allows to say which files show up in the toctree for that section (also allows to directly reference things).

Example branches:
- https://github.com/ansible-collections/community.docker/compare/main...felixfontein:scenario-guide
- https://github.com/felixfontein/ansible-tools/compare/docs

These result in:
- https://ansible.fontein.de/collections/community/docker/ (note the scenario guide!)
- https://ansible.fontein.de/collections/felixfontein/tools/ (note the first three sections on filters and tests, which are undocumentable plugin types and thus are usually not shown at all!)

There's a lint tool for collection owners (`antsibull-lint collection-docs /path/to/collection`), it checks RST labels and also runs `rstcheck`.

The PR also contains a commit which ensures that "empty" collections (which have no documentable plugins) are shown in the index, and will obtain docs. Example: https://ansible.fontein.de/collections/felixfontein/acme/ (that collection only has roles; ~~I'll add docsite RST files for these eventually, currently I only have MD files~~ it now has role docs as well)
