### PR TITLE
Make ready for Ansible 4, part 2

### DIFF
--- a/antsibull/ansible_base.py
+++ b/antsibull/ansible_base.py
@@ -4,6 +4,7 @@
 # Copyright: Ansible Project, 2020
 """Functions for working with the ansible-base package."""
 import ast
+import asyncio
 import os
 import re
 import tempfile
@@ -16,7 +17,7 @@ import sh
 from packaging.version import Version as PypiVer
 
 from . import app_context
-from .compat import best_get_loop
+from .compat import best_get_loop, create_task
 from .utils.http import retry_get
 
 if t.TYPE_CHECKING:
@@ -41,8 +42,7 @@ class AnsibleBasePyPiClient:
     """Class to retrieve information about AnsibleBase from Pypi."""
 
     def __init__(self, aio_session: 'aiohttp.client.ClientSession',
-                 pypi_server_url: str = _PYPI_SERVER_URL,
-                 package_name: str = 'ansible-base') -> None:
+                 pypi_server_url: str = _PYPI_SERVER_URL) -> None:
         """
         Initialize the AnsibleBasePypi class.
 
@@ -51,23 +51,39 @@ class AnsibleBasePyPiClient:
         """
         self.aio_session = aio_session
         self.pypi_server_url = pypi_server_url
-        self.package_name = package_name
 
-    @lru_cache(None)
-    async def get_info(self) -> t.Dict[str, t.Any]:
+    async def _get_json(self, query_url: str) -> t.Dict[str, t.Any]:
         """
-        Retrieve information about the ansible-base package from pypi.
-
-        :returns: The dict which represents the information about the ansible-base package returned
-            from pypi.  To examine the data structure, use::
-
-                curl https://pypi.org/pypi/ansible-base/json| python3 -m json.tool
+        JSON data from a url with retries and return the data as python data structures.
         """
-        # Retrieve the ansible-base package info from pypi
-        query_url = urljoin(self.pypi_server_url, f'pypi/{self.package_name}/json')
         async with retry_get(self.aio_session, query_url) as response:
             pkg_info = await response.json()
         return pkg_info
+
+    @lru_cache(None)
+    async def get_release_info(self) -> t.Dict[str, t.Any]:
+        """
+        Retrieve information about releases of the ansible-base/ansible-core package from pypi.
+
+        :returns: The dict which represents the release info keyed by version number.
+            To examine the data structure, use::
+
+                curl https://pypi.org/pypi/ansible-core/json| python3 -m json.tool
+
+        .. note:: Returns an aggregate of ansible-base and ansible-core releases.
+        """
+        # Retrieve the ansible-base and ansible-core package info from pypi
+        tasks = []
+        for package_name in ('ansible-core', 'ansible-base'):
+            query_url = urljoin(self.pypi_server_url, f'pypi/{package_name}/json')
+            tasks.append(create_task(self._get_json(query_url)))
+
+        # Note: gather maintains the order of results
+        results = await asyncio.gather(*tasks)
+        release_info = results[1]['releases']  # ansible-base information
+        release_info.update(results[0]['releases'])  # ansible-core information
+
+        return release_info
 
     async def get_versions(self) -> t.List[PypiVer]:
         """
@@ -76,8 +92,8 @@ class AnsibleBasePyPiClient:
         :returns: A list of :pypkg:obj:`packaging.versioning.Version`s
             for all the versions on pypi, including prereleases.
         """
-        pkg_info = await self.get_info()
-        versions = [PypiVer(r) for r in pkg_info['releases']]
+        release_info = await self.get_release_info()
+        versions = [PypiVer(r) for r in release_info]
         versions.sort(reverse=True)
         return versions
 
@@ -99,16 +115,17 @@ class AnsibleBasePyPiClient:
         :arg download_dir: Directory to download the tarball to.
         :returns: The name of the downloaded tarball.
         """
-        pkg_info = await self.get_info()
+        package_name = get_ansible_core_package_name(ansible_base_version)
+        release_info = await self.get_release_info()
 
         pypi_url = tar_filename = ''
-        for release in pkg_info['releases'][ansible_base_version]:
-            if release['filename'].startswith(f'{self.package_name}-{ansible_base_version}.tar.'):
+        for release in release_info[ansible_base_version]:
+            if release['filename'].startswith(f'{package_name}-{ansible_base_version}.tar.'):
                 tar_filename = release['filename']
                 pypi_url = release['url']
                 break
         else:  # for-else: http://bit.ly/1ElPkyg
-            raise UnknownVersion(f'{self.package_name} {ansible_base_version} does not'
+            raise UnknownVersion(f'{package_name} {ansible_base_version} does not'
                                  ' exist on {self.pypi_server_url}')
 
         tar_filename = os.path.join(download_dir, tar_filename)
@@ -124,8 +141,21 @@ class AnsibleBasePyPiClient:
         return tar_filename
 
 
-def get_ansible_core_package_name(ansible_version: PypiVer) -> str:
-    return 'ansible-core' if ansible_version.major >= 4 else 'ansible-base'
+def get_ansible_core_package_name(ansible_base_version: t.Union[str, PypiVer]) -> str:
+    """
+    Returns the name of the minimal ansible package.
+
+    :arg ansible_base_version: The version of the minimal ansible package to retrieve the
+        name for.
+    :returns: 'ansible-core' when the version is 2.11 or higher. Otherwise 'ansible-base'.
+    """
+    if not isinstance(ansible_base_version, PypiVer):
+        ansible_base_version = PypiVer(ansible_base_version)
+
+    if ansible_base_version.major <= 2 and ansible_base_version.minor <= 10:
+        return 'ansible-base'
+
+    return 'ansible-core'
 
 
 def _get_source_version(ansible_base_source: str) -> PypiVer:
@@ -262,7 +292,6 @@ async def create_sdist(source_dir: str, dest_dir: str) -> str:
 
 
 async def get_ansible_base(aio_session: 'aiohttp.client.ClientSession',
-                           ansible_version: PypiVer,
                            ansible_base_version: str,
                            tmpdir: str,
                            ansible_base_source: t.Optional[str] = None) -> str:
@@ -282,6 +311,7 @@ async def get_ansible_base(aio_session: 'aiohttp.client.ClientSession',
     if ansible_base_version == '@devel':
         # is the source usable?
         if source_is_devel(ansible_base_source):
+            # source_is_devel() protects against this.  This assert is to inform the type checker
             assert ansible_base_source is not None
             source_location: str = ansible_base_source
 
@@ -291,8 +321,7 @@ async def get_ansible_base(aio_session: 'aiohttp.client.ClientSession',
         # Create an sdist from the source that can be installed
         install_file = await create_sdist(source_location, tmpdir)
     else:
-        pypi_client = AnsibleBasePyPiClient(
-            aio_session, package_name=get_ansible_core_package_name(ansible_version))
+        pypi_client = AnsibleBasePyPiClient(aio_session)
         if ansible_base_version == '@latest':
             ansible_base_version: PypiVer = await pypi_client.get_latest_version()
         else:

--- a/antsibull/build_ansible_commands.py
+++ b/antsibull/build_ansible_commands.py
@@ -127,7 +127,7 @@ def write_setup(ansible_version: PypiVer,
     setup_tmpl = Template(get_antsibull_data('ansible-setup_py.j2').decode('utf-8'))
     setup_contents = setup_tmpl.render(
         version=ansible_version,
-        ansible_core_package_name=get_ansible_core_package_name(ansible_version),
+        ansible_core_package_name=get_ansible_core_package_name(ansible_base_version),
         ansible_base_version=ansible_base_version,
         collection_deps=collection_deps)
 
@@ -146,11 +146,13 @@ def write_python_build_files(ansible_version: PypiVer,
     write_setup(ansible_version, ansible_base_version, collection_deps, package_dir)
 
 
-def write_debian_directory(ansible_version: PypiVer, package_dir: str) -> None:
+def write_debian_directory(ansible_version: PypiVer,
+                           ansible_base_version: PypiVer,
+                           package_dir: str) -> None:
     debian_dir = os.path.join(package_dir, 'debian')
     os.mkdir(debian_dir, mode=0o700)
     debian_files = ('changelog.j2', 'control.j2', 'copyright', 'rules')
-    ansible_core_package_name = get_ansible_core_package_name(ansible_version)
+    ansible_core_package_name = get_ansible_core_package_name(ansible_base_version)
     for filename in debian_files:
         # Don't use os.path.join here, the get_data docs say it should be
         # slash-separated.
@@ -264,7 +266,8 @@ def build_single_impl(dependency_data: DependencyFileData, add_release: bool = T
         write_python_build_files(app_ctx.extra['ansible_version'], ansible_base_version, '',
                                  package_dir, release_notes, app_ctx.extra['debian'])
         if app_ctx.extra['debian']:
-            write_debian_directory(app_ctx.extra['ansible_version'], package_dir)
+            write_debian_directory(app_ctx.extra['ansible_version'], ansible_base_version,
+                                   package_dir)
         make_dist(package_dir, app_ctx.extra['sdist_dir'])
 
     # Write changelog and porting guide also to destination directory

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -287,6 +287,7 @@ class AnsibleBaseChangelogCollector:
 
 async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
                              base_collector: AnsibleBaseChangelogCollector,
+                             ansible_version: PypiVer,
                              collection_cache: t.Optional[str]):
     lib_ctx = app_context.lib_ctx.get()
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -296,7 +297,7 @@ async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
                                                   collection_cache=collection_cache)
 
                 async def base_downloader(version):
-                    return await get_ansible_base(aio_session, version, tmp_dir)
+                    return await get_ansible_base(aio_session, ansible_version, version, tmp_dir)
 
                 requestors = [
                     await pool.spawn(collector.download(downloader)) for collector in collectors
@@ -491,7 +492,7 @@ def get_changelog(
         CollectionChangelogCollector(collection, versions_per_collection[collection].values())
         for collection in sorted(versions_per_collection.keys())
     ]
-    asyncio.run(collect_changelogs(collectors, base_collector, collection_cache))
+    asyncio.run(collect_changelogs(collectors, base_collector, ansible_version, collection_cache))
 
     changelog = []
 

--- a/antsibull/changelog.py
+++ b/antsibull/changelog.py
@@ -287,7 +287,6 @@ class AnsibleBaseChangelogCollector:
 
 async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
                              base_collector: AnsibleBaseChangelogCollector,
-                             ansible_version: PypiVer,
                              collection_cache: t.Optional[str]):
     lib_ctx = app_context.lib_ctx.get()
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -297,7 +296,7 @@ async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
                                                   collection_cache=collection_cache)
 
                 async def base_downloader(version):
-                    return await get_ansible_base(aio_session, ansible_version, version, tmp_dir)
+                    return await get_ansible_base(aio_session, version, tmp_dir)
 
                 requestors = [
                     await pool.spawn(collector.download(downloader)) for collector in collectors
@@ -492,7 +491,7 @@ def get_changelog(
         CollectionChangelogCollector(collection, versions_per_collection[collection].values())
         for collection in sorted(versions_per_collection.keys())
     ]
-    asyncio.run(collect_changelogs(collectors, base_collector, ansible_version, collection_cache))
+    asyncio.run(collect_changelogs(collectors, base_collector, collection_cache))
 
     changelog = []
 

--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -84,7 +84,7 @@ async def retrieve(ansible_version: PypiVer,
     async with aiohttp.ClientSession() as aio_session:
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
             requestors['_ansible_base'] = await pool.spawn(
-                get_ansible_base(aio_session, ansible_version, ansible_base_version, tmp_dir,
+                get_ansible_base(aio_session, ansible_base_version, tmp_dir,
                                  ansible_base_source=ansible_base_source))
 
             downloader = CollectionDownloader(aio_session, collection_dir,

--- a/antsibull/cli/doc_commands/stable.py
+++ b/antsibull/cli/doc_commands/stable.py
@@ -13,7 +13,6 @@ from concurrent.futures import ProcessPoolExecutor
 
 import aiohttp
 import asyncio_pool
-from packaging.version import Version as PypiVer
 from pydantic import ValidationError
 
 from ... import app_context
@@ -51,8 +50,7 @@ mlog = log.fields(mod=__name__)
 PluginErrorsRT = t.DefaultDict[str, t.DefaultDict[str, t.List[str]]]
 
 
-async def retrieve(ansible_version: PypiVer,
-                   ansible_base_version: str,
+async def retrieve(ansible_base_version: str,
                    collections: t.Mapping[str, str],
                    tmp_dir: str,
                    galaxy_server: str,
@@ -61,7 +59,6 @@ async def retrieve(ansible_version: PypiVer,
     """
     Download ansible-base and the collections.
 
-    :arg ansible_version: Verison of Ansible.
     :arg ansible_base_version: Version of ansible-base/-core to download.
     :arg collections: Map of collection names to collection versions to download.
     :arg tmp_dir: The directory to download into
@@ -377,14 +374,14 @@ def generate_docs() -> int:
     # Parse the deps file
     flog.fields(deps_file=app_ctx.extra['deps_file']).info('Parse deps file')
     deps_file = DepsFile(app_ctx.extra['deps_file'])
-    ansible_version, ansible_base_version, collections = deps_file.parse()
+    dummy_, ansible_base_version, collections = deps_file.parse()
     flog.debug('Finished parsing deps file')
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         # Retrieve ansible-base and the collections
         flog.fields(tmp_dir=tmp_dir).info('created tmpdir')
         collection_tarballs = asyncio_run(
-            retrieve(PypiVer(ansible_version), ansible_base_version, collections, tmp_dir,
+            retrieve(ansible_base_version, collections, tmp_dir,
                      galaxy_server=app_ctx.galaxy_url,
                      ansible_base_source=app_ctx.extra['ansible_base_source'],
                      collection_cache=app_ctx.extra['collection_cache']))

--- a/antsibull/data/ansible-setup_py.j2
+++ b/antsibull/data/ansible-setup_py.j2
@@ -37,10 +37,10 @@ def detect_bad_upgrade():
                 pip uninstall ansible
                 pip install ansible
 
-            If you have a broken installation, perhaps because ansible-base was installed before
+            If you have a broken installation, perhaps because {{ ansible_core_package_name }} was installed before
             ansible was upgraded, try this to resolve it:
 
-                pip install --force-reinstall ansible ansible-base
+                pip install --force-reinstall ansible {{ ansible_core_package_name }}
 
             If ansible is installed in a different location than you will be installing it now
             (for example, if the old version is installed by a system package manager to
@@ -71,10 +71,10 @@ def detect_bad_upgrade():
                 pip uninstall ansible
                 pip install ansible
 
-            If you have a broken installation, perhaps because ansible-base was installed before
+            If you have a broken installation, perhaps because {{ ansible_core_package_name }} was installed before
             ansible was upgraded, try this to resolve it:
 
-                pip install --force-reinstall ansible ansible-base
+                pip install --force-reinstall ansible {{ ansible_core_package_name }}
 
             If ansible is installed in a different location than you will be installing it now
             (for example, if the old version is installed by a system package manager to
@@ -125,7 +125,7 @@ setup(
     packages=['ansible_collections'],
     include_package_data=True,
     install_requires=[
-        'ansible-base>={{ ansible_base_version }},<{{ ansible_base_version.major }}.{{ ansible_base_version.minor + 1 }}',{{ collection_deps }}
+        '{{ ansible_core_package_name }}>={{ ansible_base_version }},<{{ ansible_base_version.major }}.{{ ansible_base_version.minor + 1 }}',{{ collection_deps }}
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/antsibull/data/ansible-setup_py.j2
+++ b/antsibull/data/ansible-setup_py.j2
@@ -30,12 +30,22 @@ def detect_bad_upgrade():
 
             {0}
 
+{% if ansible_core_package_name == 'ansible-core' %}
+            is of an unknown version.  Since upgrading directly from ansible-2.x or ansible-3 or
+            ansible-base to ansible-4 or newer with pip is known to cause problems, please uninstall
+            the old version and install the new version:
+
+                pip uninstall ansible       # if installed
+                pip uninstall ansible-base  # if installed
+                pip install ansible
+{% else %}
             is of an unknown version.  Since upgrading directly from ansible-2.9 or less to
             ansible-2.10 with pip is known to cause problems, please uninstall the old version and
             install the new version:
 
                 pip uninstall ansible
                 pip install ansible
+{% endif %}
 
             If you have a broken installation, perhaps because {{ ansible_core_package_name }} was installed before
             ansible was upgraded, try this to resolve it:
@@ -55,8 +65,46 @@ def detect_bad_upgrade():
 
             """.format(current_filename))
     else:
+{% if ansible_core_package_name == 'ansible-core' %}
+        if current_version >= (2, 11):
+            return False
+
+        if current_version == (2, 10):
+            print("""\n
+                ### ERROR ###
+
+                Upgrading directly from ansible-2.10, ansible-3 or ansible-base-2.10 to ansible-4
+                or greater with pip is known to cause problems.  Please uninstall the old version found at:
+
+                {0}
+
+                and install the new version:
+
+                    pip uninstall ansible       # if installed
+                    pip uninstall ansible-base  # if installed
+                    pip install ansible
+
+                If you have a broken installation, perhaps because {{ ansible_core_package_name }} was installed before
+                ansible was upgraded, try this to resolve it:
+
+                    pip install --force-reinstall ansible {{ ansible_core_package_name }}
+
+                If ansible is installed in a different location than you will be installing it now
+                (for example, if the old version is installed by a system package manager to
+                /usr/lib/python3.8/site-packages/ansible but you are installing the new version into
+                ~/.local/lib/python3.8/site-packages/ansible with `pip install --user ansible`)
+                or you want to install anyways and cleanup any breakage afterwards, then you may set
+                the ANSIBLE_SKIP_CONFLICT_CHECK environment variable to ignore this check:
+
+                    ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install --user ansible
+
+                ### END ERROR ###
+
+                """.format(current_filename))
+{% else %}
         if current_version >= (2, 10):
             return False
+{% endif %}
 
         print("""\n
             ### ERROR ###

--- a/antsibull/data/ansible-setup_py.j2
+++ b/antsibull/data/ansible-setup_py.j2
@@ -31,7 +31,7 @@ def detect_bad_upgrade():
             {0}
 
 {% if ansible_core_package_name == 'ansible-core' %}
-            is of an unknown version.  Since upgrading directly from ansible-2.x or ansible-3 or
+            is of an unknown version.  Since upgrading directly from ansible-2.x, ansible-3, or
             ansible-base to ansible-4 or newer with pip is known to cause problems, please uninstall
             the old version and install the new version:
 
@@ -73,7 +73,7 @@ def detect_bad_upgrade():
             print("""\n
                 ### ERROR ###
 
-                Upgrading directly from ansible-2.10, ansible-3 or ansible-base-2.10 to ansible-4
+                Upgrading directly from ansible-2.10, ansible-3, or ansible-base-2.10 to ansible-4
                 or greater with pip is known to cause problems.  Please uninstall the old version found at:
 
                 {0}

--- a/antsibull/data/debian/control.j2
+++ b/antsibull/data/debian/control.j2
@@ -11,9 +11,9 @@ Vcs-Git: https://github.com/ansible-community/antsibull.git
 
 Package: ansible
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, ansible-base
+Depends: ${python3:Depends}, ${misc:Depends}, {{ ansible_core_package_name }}
 #Suggests: python-ansible-doc
-Description: ansible collections for ansible-base
+Description: ansible collections for {{ ansible_core_package_name }}
 
 #Package: python-ansible-doc
 #Architecture: all

--- a/antsibull/new_ansible.py
+++ b/antsibull/new_ansible.py
@@ -11,7 +11,7 @@ import asyncio_pool
 import semantic_version as semver
 
 from . import app_context
-from .ansible_base import AnsibleBasePyPiClient
+from .ansible_base import AnsibleBasePyPiClient, get_ansible_core_package_name
 from .changelog import ChangelogData
 from .dependency_files import BuildFile, parse_pieces_file
 from .galaxy import GalaxyClient
@@ -21,7 +21,7 @@ def display_exception(loop, context):
     print(context.get('exception'))
 
 
-async def get_version_info(collections, pypi_server_url):
+async def get_version_info(collections, pypi_server_url, ansible_core_package_name):
     loop = asyncio.get_running_loop()
     loop.set_exception_handler(display_exception)
 
@@ -29,7 +29,9 @@ async def get_version_info(collections, pypi_server_url):
     async with aiohttp.ClientSession() as aio_session:
         lib_ctx = app_context.lib_ctx.get()
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
-            pypi_client = AnsibleBasePyPiClient(aio_session, pypi_server_url=pypi_server_url)
+            pypi_client = AnsibleBasePyPiClient(
+                aio_session, pypi_server_url=pypi_server_url,
+                package_name=ansible_core_package_name)
             requestors['_ansible_base'] = await pool.spawn(pypi_client.get_versions())
             galaxy_client = GalaxyClient(aio_session)
 
@@ -76,7 +78,9 @@ def new_ansible_command():
     app_ctx = app_context.app_ctx.get()
     collections = parse_pieces_file(
         os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['pieces_file']))
-    dependencies = asyncio.run(get_version_info(collections, app_ctx.pypi_url))
+    ansible_core_package_name = get_ansible_core_package_name(app_ctx.extra['ansible_version'])
+    dependencies = asyncio.run(get_version_info(
+        collections, app_ctx.pypi_url, ansible_core_package_name=ansible_core_package_name))
 
     ansible_base_version = dependencies.pop('_ansible_base')[0]
     dependencies = find_latest_compatible(ansible_base_version, dependencies)

--- a/tests/units/test_ansible_base.py
+++ b/tests/units/test_ansible_base.py
@@ -1,0 +1,18 @@
+from packaging.version import  Version
+import pytest
+
+import antsibull.ansible_base as ab
+
+
+@pytest.mark. parametrize('version', ('2.9', '2.9.10', '1.0', '1', '0.7', '2.10', '2.10.0',
+                                      '2.10.8', '2.10.12'))
+def test_get_core_package_name_returns_ansible_base(version):
+    assert ab.get_ansible_core_package_name(version) == 'ansible-base'
+    assert ab.get_ansible_core_package_name(Version(version)) == 'ansible-base'
+
+
+@pytest.mark.parametrize('version', ('2.11', '2.11.0', '2.11.8', '2.11.12', '2.13',
+                                     '2.11.0a1', '3', '3.7.10'))
+def test_get_core_package_name_returns_ansible_core(version):
+    assert ab.get_ansible_core_package_name(version) == 'ansible-core'
+    assert ab.get_ansible_core_package_name(Version(version)) == 'ansible-core'


### PR DESCRIPTION
Together with ansible-community/ansible-build-data#64, this allows to build Ansible 4.0.0:
```
antsibull-build new-ansible --data-dir ../ansible-build-data/4/ 4.0.0
antsibull-build single --data-dir ../ansible-build-data/4/ --collection-cache cache --debian 4.0.0
```