### PR TITLE
Our Jenkins builder has had more RAM allocated so we can enable bread…

### DIFF
--- a/antsibull/write_docs.py
+++ b/antsibull/write_docs.py
@@ -34,7 +34,7 @@ CollectionInfoT = t.Mapping[str, t.Mapping[str, t.Mapping[str, str]]]
 PluginCollectionInfoT = t.Mapping[str, t.Mapping[str, t.Mapping[str, str]]]
 
 
-ADD_TOCTREES = False
+ADD_TOCTREES = True
 
 
 async def write_plugin_rst(collection_name: str, collection_meta: AnsibleCollectionMetadata,


### PR DESCRIPTION
…crumbs across the board.

My testing found that with the current size of the ansible package docs,
a VM with 2 GB of swap and 6 GB of RAM will succeed in building the docs
with breadcrumbs enabled.  4.5GB of RAM will fail.

The jenkins workers have been updated with memory limits of 4GB min, 6GB
max and the build does succeed, at least for now.  If we notice
transient failures, it is likely that the 4GB minimum is not sufficient.
If we start to see constant failure, it may mean that the size of the
docs has grown large enough that we need to increases the maximum as
well.