### PR TITLE
Generate role documentation

### DIFF
--- a/antsibull/augment_docs.py
+++ b/antsibull/augment_docs.py
@@ -56,5 +56,10 @@ def augment_docs(plugin_info: t.MutableMapping[str, t.MutableMapping[str, t.Any]
     """
     for plugin_type, plugin_map in plugin_info.items():
         for plugin_name, plugin_record in plugin_map.items():
-            add_full_key(plugin_record['return'], 'contains')
-            add_full_key(plugin_record['doc']['options'], 'suboptions')
+            if 'return' in plugin_record:
+                add_full_key(plugin_record['return'], 'contains')
+            if 'doc' in plugin_record:
+                add_full_key(plugin_record['doc']['options'], 'suboptions')
+            if 'entry_points' in plugin_record:
+                for entry_point in plugin_record['entry_points'].values():
+                    add_full_key(entry_point['options'], 'options')

--- a/antsibull/constants.py
+++ b/antsibull/constants.py
@@ -4,16 +4,21 @@
 # Copyright: Ansible Project, 2020
 """Constant values for use throughout the antsibull codebase."""
 
-from typing import FrozenSet
+from typing import Dict, FrozenSet
 
 
 #: All the types of ansible plugins
 PLUGIN_TYPES: FrozenSet[str] = frozenset(('become', 'cache', 'callback', 'cliconf', 'connection',
                                           'httpapi', 'inventory', 'lookup', 'shell', 'strategy',
-                                          'vars', 'module', 'module_utils',))
+                                          'vars', 'module', 'module_utils', 'role',))
 
 #: The subset of PLUGINS which we build documentation for
 DOCUMENTABLE_PLUGINS: FrozenSet[str] = frozenset(('become', 'cache', 'callback', 'cliconf',
                                                   'connection', 'httpapi', 'inventory', 'lookup',
                                                   'netconf', 'shell', 'vars', 'module',
-                                                  'strategy',))
+                                                  'strategy', 'role',))
+
+
+DOCUMENTABLE_PLUGINS_MIN_VERSION: Dict[str, str] = {
+    'role': '2.11.0',
+}

--- a/antsibull/data/docsite/list_of_plugins.rst.j2
+++ b/antsibull/data/docsite/list_of_plugins.rst.j2
@@ -5,6 +5,9 @@
 {% if plugin_type == 'module' %}
 Index of all Modules
 ====================
+{% elif plugin_type == 'role' %}
+Index of all Roles
+==================
 {% else %}
 Index of all @{ plugin_type | capitalize }@ Plugins
 =============@{ '=' * (plugin_type | length) }@========

--- a/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -32,17 +32,20 @@ Collection version @{ collection_version }@
 Plugin Index
 ------------
 
-{% if plugin_maps %}
+{% if plugin_maps | reject('eq', 'role') | list %}
 These are the plugins in the @{collection_name}@ collection
 {% else %}
 There are no plugins in the @{collection_name}@ collection with automatically generated documentation.
 {% endif %}
 
-{% for category, plugins in plugin_maps.items() | sort %}
+{% for category, plugins in plugin_maps.items() | sort | rejectattr('0', 'eq', 'role') %}
 
 {%   if category == 'module' %}
 Modules
 ~~~~~~~
+{%   elif category == 'role' %}
+Roles
+~~~~~
 {%   else %}
 @{ category | capitalize }@ Plugins
 @{ '~' * ((category | length) + 8) }@
@@ -52,6 +55,18 @@ Modules
 * :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | rst_ify | indent(width=2) }@
 {%   endfor %}
 {% endfor %}
+
+{% if 'role' in plugin_maps %}
+Role Index
+----------
+
+These are the roles in the @{collection_name}@ collection
+
+{%   for name, desc in plugin_maps['role'].items() | sort %}
+* :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_role>` -- @{ desc | rst_ify | indent(width=2) }@
+{%   endfor %}
+
+{% endif %}
 
 
 .. seealso::

--- a/antsibull/data/docsite/role.rst.j2
+++ b/antsibull/data/docsite/role.rst.j2
@@ -1,0 +1,286 @@
+.. Document meta
+
+:orphan:
+
+{# If we can put together source and github repo, we could make the Edit me of github button work.
+   See meta.get("source") in Ansible's docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
+   for more information
+:source: @{ source }@
+-#}
+
+.. Anchors
+
+.. _ansible_collections.@{plugin_name}@_@{plugin_type}@:
+
+.. Anchors: aliases
+
+{# TODO: This assumes that aliases will be short names.
+   If they're FQCN, then we need to change this
+#}
+
+.. Title
+
+{% if entry_points.main and entry_points.main.short_description -%}
+{%   set title = plugin_name + ' -- ' + entry_points.main.short_description | rst_ify -%}
+{% else -%}
+{%   set title = plugin_name -%}
+{% endif -%}
+
+@{ title }@
+@{ '+' * title|length }@
+
+.. Collection note
+
+{% if collection == 'ansible.builtin' -%}
+.. note::
+    This role is part of ``ansible-core`` and included in all Ansible
+    installations.
+{% else %}
+.. note::
+    This role is part of the `@{collection}@ collection <https://galaxy.ansible.com/@{collection | replace('.', '/', 1)}@>`_{% if collection_version %} (version @{ collection_version }@){% endif %}.
+
+    To install it use: :code:`ansible-galaxy collection install @{collection}@`.
+
+    To use it in a playbook, specify: :code:`@{plugin_name}@`.
+{% endif %}
+
+.. contents::
+   :local:
+   :depth: 2
+
+{% for entry_point, ep_doc in entry_points.items() | sort %}
+
+.. Entry point title
+
+{%   if ep_doc['short_description'] -%}
+{%     set title = 'Entry point ``' + entry_point + '`` -- ' + ep_doc['short_description'] | rst_ify -%}
+{%   else -%}
+{%     set title = 'Entry point ``' + entry_point + '``' -%}
+{%   endif -%}
+
+@{ title }@
+@{ '-' * title|length }@
+
+.. version_added
+
+{%   if ep_doc['version_added'] is still_relevant -%}
+.. versionadded:: @{ ep_doc['version_added'] }@ of @{ collection | rst_ify }@
+{%   endif %}
+
+.. Deprecated
+
+{%   if ep_doc['deprecated'] -%}
+DEPRECATED
+^^^^^^^^^^
+{%     if ep_doc['deprecated']['removed_at_date'] %}
+:Removed in: major release after @{ ep_doc['deprecated']['removed_at_date'] | rst_ify }@
+{%     elif ep_doc['deprecated']['removed_in'] %}
+:Removed in: version @{ ep_doc['deprecated']['removed_in'] | rst_ify }@
+{%     else %}
+:Removed in: a future release
+{%     endif %}
+:Why: @{ ep_doc['deprecated']['why'] | rst_ify }@
+:Alternative: @{ ep_doc['deprecated']['alternative'] | rst_ify }@
+{%   endif %}
+
+Synopsis
+^^^^^^^^
+
+.. Description
+
+{%   for desc in ep_doc['description'] -%}
+- @{ desc | rst_ify | indent(width=2) }@
+{%   endfor %}
+
+.. Requirements
+
+{%   if ep_doc['requirements'] -%}
+Requirements
+^^^^^^^^^^^^
+The below requirements are needed on the remote host and/or the local controller node.
+
+{%     for req in ep_doc['requirements'] %}
+- @{ req | rst_ify | indent(width=2) }@
+{%     endfor %}
+
+{%   endif %}
+
+.. Options
+
+{%   if ep_doc['options'] -%}
+
+Parameters
+^^^^^^^^^^
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        {# Pre-compute the nesting depth to allocate columns -#}
+        @{ to_kludge_ns('maxdepth', 1) -}@
+        {% for key, value in ep_doc['options']|dictsort recursive -%}
+            @{ to_kludge_ns('maxdepth', [loop.depth, from_kludge_ns('maxdepth')] | max) -}@
+            {% if value['options'] -%}
+                @{ loop(value['options'].items()) -}@
+            {% endif -%}
+        {% endfor -%}
+        {# Header of the documentation -#}
+        <tr>
+            <th colspan="@{ from_kludge_ns('maxdepth') }@">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+        {% for key, value in ep_doc['options']|dictsort recursive %}
+            <tr>
+                {# indentation based on nesting level #}
+                {% for i in range(1, loop.depth) %}
+                    <td class="elbow-placeholder"></td>
+                {% endfor %}
+                {# parameter name with required and/or introduced label #}
+                <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
+                    <div class="ansibleOptionAnchor" id="parameter-{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
+                    <b>@{ key }@</b>
+                    <a class="ansibleOptionLink" href="#parameter-{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">@{ value['type'] | documented_type }@</span>
+                        {% if value['type'] == 'list' and value['elements'] is not none %} / <span style="color: purple">elements=@{ value['elements'] | documented_type }@</span>{% endif %}
+                        {% if value['required'] %} / <span style="color: red">required</span>{% endif %}
+                    </div>
+                    {% if value['version_added'] is still_relevant %}
+                      <div style="font-style: italic; font-size: small; color: darkgreen">
+                        added in @{value['version_added']}@ of @{ value['version_added_collection'] | escape }@
+                      </div>
+                    {% endif %}
+                    {% if value['deprecated'] %}
+                      <div>
+                        {% if value['deprecated']['removed_at_date'] %}
+                          Removed in: major release after @{ value['deprecated']['removed_at_date'] | escape }@
+                        {% elif value['deprecated']['removed_in'] %}
+                          Removed in: version @{ value['deprecated']['removed_in'] | escape }@
+                        {% else %}
+                          Removed in: a future release
+                        {% endif %}
+                        {% if value['deprecated']['removed_from_collection'] and value['deprecated']['removed_from_collection'] != collection %}
+                          of @{ value['deprecated']['removed_from_collection'] | escape }@
+                        {% endif %}
+                        <br>
+                        Why: @{ value['deprecated']['why'] | escape }@
+                        <br>
+                        Alternative: @{ value['deprecated']['alternative'] | escape }@
+                      </div>
+                    {% endif %}
+                </td>
+                {# default / choices #}
+                <td>
+                    {# Turn boolean values in 'yes' and 'no' values #}
+                    {% if value['default'] is sameas true %}
+                        {% set _x = value.update({'default': 'yes'}) %}
+                    {% elif value['default'] is not none and value['default'] is sameas false %}
+                        {% set _x = value.update({'default': 'no'}) %}
+                    {% endif %}
+                    {% if value['type'] == 'bool' %}
+                        {% set _x = value.update({'choices': ['no', 'yes']}) %}
+                    {% endif %}
+                    {# Show possible choices and highlight details #}
+                    {% if value['choices'] %}
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                            {% for choice in value['choices'] %}
+                                {# Turn boolean values in 'yes' and 'no' values #}
+                                {% if choice is sameas true %}
+                                    {% set choice = 'yes' %}
+                                {% elif choice is sameas false %}
+                                    {% set choice = 'no' %}
+                                {% endif %}
+                                {% if (value['default'] is not list and value['default'] == choice) or (value['default'] is list and choice in value['default']) %}
+                                    <li><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
+                                {% else %}
+                                    <li>@{ choice | escape }@</li>
+                                {% endif %}
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
+                    {# Show default value, when multiple choice or no choices #}
+                    {% if value['default'] is not none and value['default'] not in value['choices'] %}
+                        <b>Default:</b><br/><div style="color: blue">@{ value['default'] | tojson | escape }@</div>
+                    {% endif %}
+                </td>
+                {# description #}
+                <td>
+                    {% for desc in value['description'] %}
+                        <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
+                    {% endfor %}
+                    {% if value['aliases'] %}
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: @{ value['aliases']|join(', ') }@</div>
+                    {% endif %}
+                </td>
+            </tr>
+            {% if value['options'] %}
+                @{ loop(value['options']|dictsort) }@
+            {% endif %}
+        {% endfor %}
+    </table>
+    <br/>
+{%   endif %}
+
+.. Notes
+
+{%   if ep_doc['notes'] -%}
+Notes
+^^^^^
+
+.. note::
+{%     for note in ep_doc['notes'] %}
+   - @{ note | rst_ify | indent(width=5) }@
+{%     endfor %}
+{%   endif %}
+
+.. Seealso
+
+{%   if ep_doc['seealso'] -%}
+See Also
+^^^^^^^^
+
+.. seealso::
+
+{%     for item in ep_doc['seealso'] %}
+{%       if item.module is defined and item.description %}
+   @{ ('M(' + item['module'] + ')') | rst_ify }@
+       @{ item['description'] | rst_ify }@
+{%       elif item.module is defined %}
+   @{ ('M(' + item['module'] + ')') | rst_ify }@
+      The official documentation on the **@{ item['module'] }@** module.
+{%       elif item.name is defined and item.link is defined and item.description %}
+   `@{ item['name'] }@ <@{ item['link'] }@>`_
+       @{ item['description'] | rst_ify }@
+{%       elif item.ref is defined and item.description %}
+   :ref:`@{ item['ref'] }@`
+       @{ item['description'] | rst_ify }@
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+
+{%   if ep_doc['author'] -%}
+Authors
+^^^^^^^
+
+{%     for author_name in ep_doc['author'] %}
+- @{ author_name }@
+{%     endfor %}
+
+{%   endif %}
+
+{% endfor %}
+
+.. Parsing errors
+
+{% if nonfatal_errors %}
+There were some errors parsing the documentation for this role.  Please file a bug with the collection.
+
+The errors were:
+
+{% for error in nonfatal_errors %}
+* ::
+
+@{ error | indent(width=8, first=True) }@
+
+{% endfor %}
+{% endif %}

--- a/antsibull/schemas/docs/__init__.py
+++ b/antsibull/schemas/docs/__init__.py
@@ -13,6 +13,7 @@ from .callback import CallbackDocSchema, CallbackSchema
 from .module import ModuleDocSchema, ModuleSchema
 from .plugin import (PluginDocSchema, PluginExamplesSchema,
                      PluginMetadataSchema, PluginReturnSchema, PluginSchema)
+from .role import RoleSchema
 
 BecomeSchema = PluginSchema
 CacheSchema = PluginSchema
@@ -67,4 +68,5 @@ DOCS_SCHEMAS = {
     'shell': _PLUGIN_SCHEMA_RECORD,
     'strategy': _PLUGIN_SCHEMA_RECORD,
     'vars': _PLUGIN_SCHEMA_RECORD,
+    'role': RoleSchema,
 }

--- a/antsibull/schemas/docs/ansible_doc.py
+++ b/antsibull/schemas/docs/ansible_doc.py
@@ -19,6 +19,7 @@ from .base import BaseModel
 from .callback import CallbackSchema
 from .module import ModuleSchema
 from .plugin import PluginSchema
+from .role import RoleSchema
 
 
 __all__ = ('ANSIBLE_DOC_SCHEMAS', 'AnsibleDocSchema', 'BecomePluginSchema', 'CachePluginSchema',
@@ -61,6 +62,7 @@ class AnsibleDocSchema(BaseModel):
     shell: t.Dict[str, PluginSchema]
     strategy: t.Dict[str, PluginSchema]
     vars: t.Dict[str, PluginSchema]
+    role: t.Dict[str, RoleSchema]
 
 
 class GenericPluginSchema(BaseModel):
@@ -99,6 +101,18 @@ class ModulePluginSchema(BaseModel):
     __root__: t.Dict[str, ModuleSchema]
 
 
+class RolePluginSchema(BaseModel):
+    """
+    Document the output of ``ansible-doc -t role ROLE_NAME``.
+
+    .. note:: Both the model and the dict will be wrapped in an outer dict with your data mapped
+        to the ``__root__`` key. This happens because the toplevel key of ansible-doc's output is
+        a dynamic key which we can't automatically map to an attribute name.
+    """
+
+    __root__: t.Dict[str, RoleSchema]
+
+
 #: Make sure users can access plugins using the plugin type rather than having to guess that
 #: these types use the GenericPluginSchema
 BecomePluginSchema = GenericPluginSchema
@@ -127,6 +141,7 @@ ANSIBLE_DOC_SCHEMAS = {
     'lookup': LookupPluginSchema,
     'module': ModulePluginSchema,
     'netconf': NetConfPluginSchema,
+    'role': RolePluginSchema,
     'shell': ShellPluginSchema,
     'strategy': StrategyPluginSchema,
     'vars': VarsPluginSchema,

--- a/antsibull/schemas/docs/role.py
+++ b/antsibull/schemas/docs/role.py
@@ -1,0 +1,60 @@
+# coding: utf-8
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# Author: Felix Fontein <felix@fontein.de>
+# License: GPLv3+
+# Copyright: Ansible Project, 2021
+"""Schemas for the role documentation data."""
+
+# Ignore Unitialized attribute errors because BaseModel works some magic
+# to initialize the attributes when data is loaded into them.
+# pyre-ignore-all-errors[13]
+
+import typing as t
+
+import pydantic as p
+
+from .base import (
+    BaseModel, DeprecationSchema, OptionsSchema,
+    SeeAlsoModSchema, SeeAlsoRefSchema, SeeAlsoLinkSchema,
+    COLLECTION_NAME_F,
+)
+
+
+class InnerRoleOptionsSchema(OptionsSchema):
+    options: t.Dict[str, 'InnerRoleOptionsSchema'] = {}
+
+    @p.root_validator(pre=True)
+    def allow_description_to_be_optional(cls, values):
+        # Doing this in a validator so that the json-schema will still flag it as an error
+        if 'description' not in values:
+            values['description'] = []
+        return values
+
+
+InnerRoleOptionsSchema.update_forward_refs()
+
+
+class RoleOptionsSchema(OptionsSchema):
+    options: t.Dict[str, 'InnerRoleOptionsSchema'] = {}
+
+
+class RoleEntrypointSchema(BaseModel):
+    """Documentation for role entrypoints."""
+    description: t.List[str]
+    short_description: str
+    author: t.List[str] = []
+    deprecated: DeprecationSchema = p.Field({})
+    notes: t.List[str] = []
+    requirements: t.List[str] = []
+    seealso: t.List[t.Union[SeeAlsoModSchema, SeeAlsoRefSchema, SeeAlsoLinkSchema]] = []
+    todo: t.List[str] = []
+    version_added: str = 'historical'
+
+    options: t.Dict[str, RoleOptionsSchema] = {}
+
+
+class RoleSchema(BaseModel):
+    """Documentation for roles."""
+    collection: str = COLLECTION_NAME_F
+    entry_points: t.Dict[str, RoleEntrypointSchema]
+    path: str

--- a/tests/functional/schema/good_data/one_role.json
+++ b/tests/functional/schema/good_data/one_role.json
@@ -1,0 +1,85 @@
+{
+    "felixfontein.acme.account_key_rollover": {
+        "collection": "felixfontein.acme",
+        "entry_points": {
+            "main": {
+                "author": [
+                    "Felix Fontein (@felixfontein)"
+                ],
+                "description": [
+                    "This is a role which can use any CA supporting the ACME protocol, such as L(Let's Encrypt,https://letsencrypt.org/), L(Buypass,https://www.buypass.com/ssl/products/acme>) or L(ZeroSSL,https://zerossl.com/features/acme/>), to rekey ACME account keys.",
+                    "This role will create a backup copy of the existing account key if requested to do so, re-create the account key, and then roll over the ACME account to the new key."
+                ],
+                "options": {
+                    "acme_certificate_account_algorithm": {
+                        "choices": [
+                            "rsa",
+                            "p-256",
+                            "p-384",
+                            "p-521"
+                        ],
+                        "default": "rsa",
+                        "description": [
+                            "The algorithm used for creating the account key.",
+                            "The default is C(rsa) for an RSA key.",
+                            "Other choices are C(p-256), C(p-384) or C(p-521) for the NIST elliptic curves C(prime256v1), C(secp384r1) and C(secp521r1), respectively."
+                        ],
+                        "type": "str"
+                    },
+                    "acme_certificate_account_key_backup": {
+                        "default": true,
+                        "description": [
+                            "Whether to create a backup of the old account key before rolling over."
+                        ],
+                        "type": "bool"
+                    },
+                    "acme_certificate_account_key_length": {
+                        "default": 4096,
+                        "description": [
+                            "The bit-size to use for RSA private keys.",
+                            "Should not be less than 2048. Also values above 4096 might not be supported by every ACME CA."
+                        ],
+                        "type": "int"
+                    },
+                    "acme_certificate_account_key_sops_encrypted": {
+                        "default": false,
+                        "description": [
+                            "Use L(Mozilla sops,https://github.com/mozilla/sops) to encrypt private key. Needs C(.sops.yaml) file inside the directory containing the account key or somewhere up the directory chain."
+                        ],
+                        "type": "bool"
+                    },
+                    "acme_certificate_acme_account": {
+                        "description": [
+                            "Path to the private ACME account key."
+                        ],
+                        "type": "str"
+                    },
+                    "acme_certificate_acme_account_uri": {
+                        "description": [
+                            "Instead of determining the account URI from the account key, assumes the given account URI."
+                        ],
+                        "type": "str"
+                    },
+                    "acme_certificate_acme_directory": {
+                        "default": "https://acme-v02.api.letsencrypt.org/directory",
+                        "description": [
+                            "The ACME directory to use.",
+                            "Default is C(https://acme-v02.api.letsencrypt.org/directory), which is the current production ACME v2 endpoint of Let's Encrypt."
+                        ],
+                        "type": "str"
+                    },
+                    "acme_certificate_acme_version": {
+                        "default": 2,
+                        "description": [
+                            "The ACME directory's version."
+                        ],
+                        "type": "int"
+                    }
+                },
+                "short_description": "Do account key rollover",
+                "version_added": "0.1.0"
+            }
+        },
+        "path": "/path/to/ansible_collections/felixfontein/acme"
+    }
+}

--- a/tests/functional/schema/good_data/one_role_results.json
+++ b/tests/functional/schema/good_data/one_role_results.json
@@ -1,0 +1,85 @@
+{
+    "felixfontein.acme.account_key_rollover": {
+        "collection": "felixfontein.acme",
+        "entry_points": {
+            "main": {
+                "author": [
+                    "Felix Fontein (@felixfontein)"
+                ],
+                "description": [
+                    "This is a role which can use any CA supporting the ACME protocol, such as L(Let's Encrypt,https://letsencrypt.org/), L(Buypass,https://www.buypass.com/ssl/products/acme>) or L(ZeroSSL,https://zerossl.com/features/acme/>), to rekey ACME account keys.",
+                    "This role will create a backup copy of the existing account key if requested to do so, re-create the account key, and then roll over the ACME account to the new key."
+                ],
+                "options": {
+                    "acme_certificate_account_algorithm": {
+                        "choices": [
+                            "rsa",
+                            "p-256",
+                            "p-384",
+                            "p-521"
+                        ],
+                        "default": "rsa",
+                        "description": [
+                            "The algorithm used for creating the account key.",
+                            "The default is C(rsa) for an RSA key.",
+                            "Other choices are C(p-256), C(p-384) or C(p-521) for the NIST elliptic curves C(prime256v1), C(secp384r1) and C(secp521r1), respectively."
+                        ],
+                        "type": "str"
+                    },
+                    "acme_certificate_account_key_backup": {
+                        "default": true,
+                        "description": [
+                            "Whether to create a backup of the old account key before rolling over."
+                        ],
+                        "type": "bool"
+                    },
+                    "acme_certificate_account_key_length": {
+                        "default": 4096,
+                        "description": [
+                            "The bit-size to use for RSA private keys.",
+                            "Should not be less than 2048. Also values above 4096 might not be supported by every ACME CA."
+                        ],
+                        "type": "int"
+                    },
+                    "acme_certificate_account_key_sops_encrypted": {
+                        "default": false,
+                        "description": [
+                            "Use L(Mozilla sops,https://github.com/mozilla/sops) to encrypt private key. Needs C(.sops.yaml) file inside the directory containing the account key or somewhere up the directory chain."
+                        ],
+                        "type": "bool"
+                    },
+                    "acme_certificate_acme_account": {
+                        "description": [
+                            "Path to the private ACME account key."
+                        ],
+                        "type": "str"
+                    },
+                    "acme_certificate_acme_account_uri": {
+                        "description": [
+                            "Instead of determining the account URI from the account key, assumes the given account URI."
+                        ],
+                        "type": "str"
+                    },
+                    "acme_certificate_acme_directory": {
+                        "default": "https://acme-v02.api.letsencrypt.org/directory",
+                        "description": [
+                            "The ACME directory to use.",
+                            "Default is C(https://acme-v02.api.letsencrypt.org/directory), which is the current production ACME v2 endpoint of Let's Encrypt."
+                        ],
+                        "type": "str"
+                    },
+                    "acme_certificate_acme_version": {
+                        "default": 2,
+                        "description": [
+                            "The ACME directory's version."
+                        ],
+                        "type": "int"
+                    }
+                },
+                "short_description": "Do account key rollover",
+                "version_added": "0.1.0"
+            }
+        },
+        "path": "/path/to/ansible_collections/felixfontein/acme"
+    }
+}


### PR DESCRIPTION
With the role argument spec feature of ansible-core 2.11, it is now possible to document roles in collections!

~~This is a first WIP to implement this. It's also a WIP because it contains #255.~~ There's a lot of special-casing since roles behave quite differently than other plugin types (for example they can have multiple entry points).

You can see the effects here:
1. The menu contains 'Index of all Roles': https://ansible.fontein.de/
2. There's a 'Index of all Roles': https://ansible.fontein.de/collections/index_role.html
3. In the felixfontein.acme collection docs, there's a 'Role Index': https://ansible.fontein.de/collections/felixfontein/acme/index.html#role-index (please ignore the 'Roles' section above, it is created manually with #255)
4. There are role documentations:
    - https://ansible.fontein.de/collections/felixfontein/acme/account_key_rollover_role.html
    - https://ansible.fontein.de/collections/felixfontein/acme/acme_certificate_role.html
    - https://ansible.fontein.de/collections/felixfontein/acme/revoke_old_certificates_role.html
