### PR TITLE
Fix ansible-output lexer

### DIFF
--- a/sphinx_antsibull_ext/pygments_lexer.py
+++ b/sphinx_antsibull_ext/pygments_lexer.py
@@ -140,7 +140,7 @@ class AnsibleOutputPrimaryLexer(RegexLexer):
 
         'host-result': [
             (r'\n', token.Text, '#pop'),
-            (r'( +)(ok|changed|failed|skipped|unreachable)(=)([0-9]+)',
+            (r'( +)(ok|changed|failed|skipped|unreachable|rescued|ignored)(=)([0-9]+)',
                 bygroups(token.Text, token.Keyword, token.Punctuation, token.Number.Integer)),
         ],
 


### PR DESCRIPTION
Mirroring #273 in ansible/ansible (https://github.com/ansible/ansible/pull/74798) unearthed a problem with the lexer. This mirrors the fix added to the ansible/ansible PR.