### PR TITLE
Disable breadcrumbs.

### DIFF
--- a/antsibull/write_docs.py
+++ b/antsibull/write_docs.py
@@ -35,7 +35,7 @@ CollectionInfoT = t.Mapping[str, t.Mapping[str, t.Mapping[str, str]]]
 PluginCollectionInfoT = t.Mapping[str, t.Mapping[str, t.Mapping[str, str]]]
 
 
-ADD_TOCTREES = True
+ADD_TOCTREES = False
 
 
 async def copy_file(source_path: str, dest_path: str) -> None:


### PR DESCRIPTION
We've run into memory issues on the jenkins builder again.
samccann tested that 7GB is too low but 8GB is enough and will still be
good een if we add 9 more collections with 1.3K+ new plugins.  We're
looking into getting more memory on the jenkins builder but need to
disable breadcrumbs for now, until we get the additional RAM.