### PR TITLE
update ansible-base to ansible-core in plugin template

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -44,10 +44,10 @@
 
 {% if collection == 'ansible.builtin' -%}
 .. note::
-    This module is part of ``ansible-base`` and included in all Ansible
+    This module is part of ``ansible-core`` and included in all Ansible
     installations. In most cases, you can use the short module name
     @{ plugin_name.rsplit('.', 1)[-1] }@ even without specifying the ``collections:`` keyword.
-    Despite that, we recommend you use the FQCN for easy linking to the module
+    However, we recommend you use the FQCN for easy linking to the module
     documentation and to avoid conflicting with other collections that may have
     the same module name.
 {% else %}


### PR DESCRIPTION
@dericcrago mentioned in IRC that the plugin template still referred to `ansible-base` instead of `ansible-core`. 

Updates that reference, plus one small grammar change.
