### PR TITLE
Add sphinx-init antsibull-docs subcommand

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -33,4 +33,4 @@ jobs:
           poetry run coverage combine .coverage.*
           poetry run coverage report
           poetry run coverage xml -i
-          poetry run codecov --token=${{ secrets.CODECOV_TOKEN }}
+          poetry run codecov

--- a/.github/workflows/build-simple-docsite.yml
+++ b/.github/workflows/build-simple-docsite.yml
@@ -54,4 +54,4 @@ jobs:
           coverage combine .coverage.*
           coverage report
           coverage xml -i
-          codecov --token=${{ secrets.CODECOV_TOKEN }}
+          codecov

--- a/.github/workflows/build-simple-docsite.yml
+++ b/.github/workflows/build-simple-docsite.yml
@@ -1,0 +1,45 @@
+# This workflow will build a simple Sphinx-based docsite
+
+name: Build simple docsite
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Run once per week (Monday at 06:00 UTC)
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Use antsibull-docs sphinx-init
+        run: |
+          antsibull-docs sphinx-init --use-current --dest-dir test-docsite/
+
+      - name: Install dependencies
+        run: |
+          pip install ansible-core
+          pip install -r test-docsite/requirements.txt
+
+      - name: Install collections
+        run:
+          ansible-galaxy collection install community.docker community.crypto
+
+      - name: Build docsite
+        run: |
+          test-docsite/build.sh

--- a/.github/workflows/build-simple-docsite.yml
+++ b/.github/workflows/build-simple-docsite.yml
@@ -25,16 +25,21 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .
+          python -m pip install . coverage codecov
 
       - name: Use antsibull-docs sphinx-init
         run: |
-          antsibull-docs sphinx-init --use-current --lenient --dest-dir test-docsite/
+          coverage run -p --source antsibull -m antsibull.cli.antsibull_docs sphinx-init --use-current --lenient --dest-dir .
+
+      - name: Patch build.sh to supply code coverage
+        run: |
+          sed -i build.sh -e 's/antsibull-docs /coverage run -p --source antsibull -m antsibull.cli.antsibull_docs /g'
+          sed -i build.sh -e 's/sphinx-build /coverage run -p --source antsibull --source sphinx_antsibull_ext -m sphinx.cmd.build /g'
 
       - name: Install dependencies
         run: |
           pip install ansible-core
-          pip install -r test-docsite/requirements.txt
+          pip install -r requirements.txt
 
       - name: Install collections
         run:
@@ -42,4 +47,11 @@ jobs:
 
       - name: Build docsite
         run: |
-          test-docsite/build.sh
+          ./build.sh
+
+      - name: Combine and upload coverage stats
+        run: |
+          coverage combine .coverage.*
+          coverage report
+          coverage xml -i
+          codecov --token=${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-simple-docsite.yml
+++ b/.github/workflows/build-simple-docsite.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Use antsibull-docs sphinx-init
         run: |
-          antsibull-docs sphinx-init --use-current --dest-dir test-docsite/
+          antsibull-docs sphinx-init --use-current --lenient --dest-dir test-docsite/
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -36,4 +36,4 @@ jobs:
         run: |
           ./test-pytest.sh
           poetry run coverage xml -i
-          poetry run codecov --token=${{ secrets.CODECOV_TOKEN }}
+          poetry run codecov

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -51,9 +51,6 @@ DEFAULT_PIECES_FILE: str = 'ansible.in'
 def _normalize_docs_options(args: argparse.Namespace) -> None:
     args.dest_dir = os.path.abspath(os.path.realpath(args.dest_dir))
 
-    if args.command == 'sphinx-init':
-        return
-
     # We're going to be writing a deep hierarchy of files into this directory so we need to make
     # sure that the user understands that this needs to be a directory which has been secured
     # against malicious usage:

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -311,6 +311,8 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                     help='Do not use the full hierarchy collections/namespace/name/'
                                     ' in the destination directory. Only valid if there is exactly'
                                     ' one collection specified.')
+    sphinx_init_parser.add_argument('--lenient', action='store_true',
+                                    help='Configure Sphinx to not be too strict.')
     sphinx_init_parser.add_argument(nargs='*', dest='collections',
                                     help='One or more collections to document.  If the names are'
                                     ' directories on disk, they will be parsed as expanded'

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -405,3 +405,7 @@ def main() -> int:
         :3: Unexpected problem downloading ansible-base
     """
     return run(sys.argv)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/antsibull/cli/antsibull_docs.py
+++ b/antsibull/cli/antsibull_docs.py
@@ -292,7 +292,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     #
     sphinx_init_parser = subparsers.add_parser('sphinx-init',
                                                parents=[docs_parser],
-                                               description='Generate a Spinx site template for a'
+                                               description='Generate a Sphinx site template for a'
                                                ' collection docsite')
 
     sphinx_init_parser.add_argument('--collection-version', default='@latest',

--- a/antsibull/cli/doc_commands/sphinx_init.py
+++ b/antsibull/cli/doc_commands/sphinx_init.py
@@ -1,0 +1,93 @@
+# Author: Felix Fontein <felix@fontein.de>
+# License: GPLv3+
+# Copyright: Ansible Project, 2021
+"""Entrypoint to the antsibull-docs script."""
+
+import os
+import os.path
+
+from ... import app_context
+from ...jinja2.environment import doc_environment
+from ...logging import log
+
+
+mlog = log.fields(mod=__name__)
+
+
+TEMPLATES = [
+    '.gitignore',
+    'build.sh',
+    'conf.py',
+    'requirements.txt',
+    'rst/index.rst',
+]
+
+
+def write_file(filename: str, content: str) -> None:
+    """
+    Write content into a file.
+    """
+    if os.path.exists(filename):
+        with open(filename, 'r') as f:
+            existing_content = f.read()
+        if existing_content == content:
+            print(f'Skipping {filename}')
+            return
+
+    print(f'Writing {filename}...')
+    with open(filename, 'w') as f:
+        f.write(content)
+
+
+def site_init() -> int:
+    """
+    Initialize a Sphinx site template for a collection docsite.
+
+    Creates a Sphinx configuration file, requirements.txt and a bash script which uses
+    antsibull-docs to build the RST files for the specified collections.
+
+    :returns: A return code for the program.  See :func:`antsibull.cli.antsibull_docs.main` for
+        details on what each code means.
+    """
+    flog = mlog.fields(func='site_init')
+    flog.notice('Begin site init')
+
+    app_ctx = app_context.app_ctx.get()
+
+    dest_dir = app_ctx.extra['dest_dir']
+    collections = app_ctx.extra['collections']
+    collection_version = app_ctx.extra['collection_version']
+    use_current = app_ctx.extra['use_current']
+    squash_hierarchy = app_ctx.extra['squash_hierarchy']
+
+    if not os.path.exists(dest_dir):
+        os.makedirs(dest_dir)
+    elif not os.path.isdir(dest_dir):
+        print(f'Expecting {dest_dir} to be a directory')
+        return 3
+
+    env = doc_environment(('antsibull.data', 'sphinx_init'))
+
+    for filename in TEMPLATES:
+        source = filename.replace('.', '_').replace('/', '_') + '.j2'
+        template = env.get_template(source)
+
+        content = template.render(
+            dest_dir=dest_dir,
+            collection_version=collection_version,
+            use_current=use_current,
+            squash_hierarchy=squash_hierarchy,
+            collections=collections,
+        ) + '\n'
+
+        destination = os.path.join(dest_dir, filename)
+        destination_path = os.path.dirname(destination)
+        if not os.path.exists(destination_path):
+            os.makedirs(destination_path)
+        write_file(destination, content)
+
+        # Make scripts executable
+        if filename.endswith('.sh'):
+            os.chmod(destination, 0o755)
+
+    return 0

--- a/antsibull/cli/doc_commands/sphinx_init.py
+++ b/antsibull/cli/doc_commands/sphinx_init.py
@@ -59,6 +59,7 @@ def site_init() -> int:
     collection_version = app_ctx.extra['collection_version']
     use_current = app_ctx.extra['use_current']
     squash_hierarchy = app_ctx.extra['squash_hierarchy']
+    lenient = app_ctx.extra['lenient']
 
     if os.path.exists(dest_dir) and not os.path.isdir(dest_dir):
         print(f'Expecting {dest_dir} to be a directory')
@@ -77,6 +78,7 @@ def site_init() -> int:
             use_current=use_current,
             squash_hierarchy=squash_hierarchy,
             collections=collections,
+            lenient=lenient,
         ) + '\n'
 
         destination = os.path.join(dest_dir, filename)

--- a/antsibull/cli/doc_commands/sphinx_init.py
+++ b/antsibull/cli/doc_commands/sphinx_init.py
@@ -61,11 +61,6 @@ def site_init() -> int:
     squash_hierarchy = app_ctx.extra['squash_hierarchy']
     lenient = app_ctx.extra['lenient']
 
-    if os.path.exists(dest_dir) and not os.path.isdir(dest_dir):
-        print(f'Expecting {dest_dir} to be a directory')
-        return 3
-    os.makedirs(dest_dir, exist_ok=True)
-
     env = doc_environment(('antsibull.data', 'sphinx_init'))
 
     for filename in TEMPLATES:

--- a/antsibull/cli/doc_commands/sphinx_init.py
+++ b/antsibull/cli/doc_commands/sphinx_init.py
@@ -60,11 +60,10 @@ def site_init() -> int:
     use_current = app_ctx.extra['use_current']
     squash_hierarchy = app_ctx.extra['squash_hierarchy']
 
-    if not os.path.exists(dest_dir):
-        os.makedirs(dest_dir)
-    elif not os.path.isdir(dest_dir):
+    if os.path.exists(dest_dir) and not os.path.isdir(dest_dir):
         print(f'Expecting {dest_dir} to be a directory')
         return 3
+    os.makedirs(dest_dir, exist_ok=True)
 
     env = doc_environment(('antsibull.data', 'sphinx_init'))
 
@@ -81,9 +80,7 @@ def site_init() -> int:
         ) + '\n'
 
         destination = os.path.join(dest_dir, filename)
-        destination_path = os.path.dirname(destination)
-        if not os.path.exists(destination_path):
-            os.makedirs(destination_path)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
         write_file(destination, content)
 
         # Make scripts executable

--- a/antsibull/cli/doc_commands/sphinx_init.py
+++ b/antsibull/cli/doc_commands/sphinx_init.py
@@ -90,4 +90,7 @@ def site_init() -> int:
         if filename.endswith('.sh'):
             os.chmod(destination, 0o755)
 
+    print(f'To build the docsite, go into {dest_dir} and run:')
+    print('    pip install -r requirements.txt  # possibly use a venv')
+    print('    ./build.sh')
     return 0

--- a/antsibull/data/sphinx_init/_gitignore.j2
+++ b/antsibull/data/sphinx_init/_gitignore.j2
@@ -1,0 +1,2 @@
+/temp-rst
+/build

--- a/antsibull/data/sphinx_init/build_sh.j2
+++ b/antsibull/data/sphinx_init/build_sh.j2
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+cd @{ dest_dir }@
+
+# Create collection documentation into temporary directory
+rm -rf temp-rst
+mkdir -p temp-rst
+{% if use_current %}
+{%   if collections | length > 0 %}
+antsibull-docs collection \
+    --use-current \
+    --dest-dir temp-rst \
+{%     if squash_hierarchy %}
+    --squash-hierarchy \
+{%     endif %}
+    @{ ' '.join(collections) }@
+{%   else %}
+antsibull-docs current --dest-dir temp-rst
+{%   endif %}
+{% else %}
+antsibull-docs collection \
+{%     if collection_version != '@latest' %}
+    --collection-version @{ collection_version }@ \
+{%     endif %}
+    --dest-dir temp-rst \
+{%     if squash_hierarchy %}
+    --squash-hierarchy \
+{%     endif %}
+    @{ ' '.join(collections) }@
+{% endif %}
+
+# Copy collection documentation into source directory
+rsync -avc --delete-after temp-rst/collections/ rst/collections/
+
+# Build Sphinx site
+sphinx-build -M html rst build -c .

--- a/antsibull/data/sphinx_init/build_sh.j2
+++ b/antsibull/data/sphinx_init/build_sh.j2
@@ -33,4 +33,8 @@ antsibull-docs collection \
 rsync -avc --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
+{% if lenient %}
+sphinx-build -M html rst build -c .
+{% else %}
 sphinx-build -M html rst build -c . -W --keep-going
+{% endif %}

--- a/antsibull/data/sphinx_init/build_sh.j2
+++ b/antsibull/data/sphinx_init/build_sh.j2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cd @{ dest_dir }@
 

--- a/antsibull/data/sphinx_init/build_sh.j2
+++ b/antsibull/data/sphinx_init/build_sh.j2
@@ -33,4 +33,4 @@ antsibull-docs collection \
 rsync -avc --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
-sphinx-build -M html rst build -c .
+sphinx-build -M html rst build -c . -W --keep-going

--- a/antsibull/data/sphinx_init/conf_py.j2
+++ b/antsibull/data/sphinx_init/conf_py.j2
@@ -1,0 +1,30 @@
+# This file only contains a selection of the most common options. For a full list see the
+# documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+project = 'Ansible collections'
+
+html_short_title = 'Ansible Collections Documentation'
+
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx_antsibull_ext']
+
+pygments_style = 'ansible'
+
+highlight_language = 'YAML+Jinja'
+
+html_theme = 'sphinx_rtd_theme'
+html_show_sphinx = False
+
+display_version = False
+
+html_use_smartypants = True
+html_use_modindex = False
+html_use_index = False
+html_copy_source = False
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/2/', (None, '../python2.inv')),
+    'python3': ('https://docs.python.org/3/', (None, '../python3.inv')),
+    'jinja2': ('http://jinja.palletsprojects.com/', (None, '../jinja2.inv')),
+    'ansible_4': ('https://docs.ansible.com/ansible/4/', (None, '../ansible_4.inv')),
+}

--- a/antsibull/data/sphinx_init/conf_py.j2
+++ b/antsibull/data/sphinx_init/conf_py.j2
@@ -3,6 +3,7 @@
 # http://www.sphinx-doc.org/en/master/config
 
 project = 'Ansible collections'
+copyright = 'Ansible contributors'
 
 html_short_title = 'Ansible Collections Documentation'
 

--- a/antsibull/data/sphinx_init/conf_py.j2
+++ b/antsibull/data/sphinx_init/conf_py.j2
@@ -14,7 +14,7 @@ pygments_style = 'ansible'
 
 highlight_language = 'YAML+Jinja'
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_ansible_theme'
 html_show_sphinx = False
 
 display_version = False

--- a/antsibull/data/sphinx_init/conf_py.j2
+++ b/antsibull/data/sphinx_init/conf_py.j2
@@ -33,4 +33,6 @@ intersphinx_mapping = {
 
 default_role = 'any'
 
+{% if not lenient %}
 nitpicky = True
+{% endif %}

--- a/antsibull/data/sphinx_init/conf_py.j2
+++ b/antsibull/data/sphinx_init/conf_py.j2
@@ -28,7 +28,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/2/', (None, '../python2.inv')),
     'python3': ('https://docs.python.org/3/', (None, '../python3.inv')),
     'jinja2': ('http://jinja.palletsprojects.com/', (None, '../jinja2.inv')),
-    'ansible_4': ('https://docs.ansible.com/ansible/4/', (None, '../ansible_4.inv')),
+    'ansible4': ('https://docs.ansible.com/ansible/4/', (None, '../ansible4.inv')),
 }
 
 default_role = 'any'

--- a/antsibull/data/sphinx_init/conf_py.j2
+++ b/antsibull/data/sphinx_init/conf_py.j2
@@ -5,6 +5,7 @@
 project = 'Ansible collections'
 copyright = 'Ansible contributors'
 
+title = 'Ansible Collections Documentation'
 html_short_title = 'Ansible Collections Documentation'
 
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx_antsibull_ext']
@@ -29,3 +30,7 @@ intersphinx_mapping = {
     'jinja2': ('http://jinja.palletsprojects.com/', (None, '../jinja2.inv')),
     'ansible_4': ('https://docs.ansible.com/ansible/4/', (None, '../ansible_4.inv')),
 }
+
+default_role = 'any'
+
+nitpicky = True

--- a/antsibull/data/sphinx_init/requirements_txt.j2
+++ b/antsibull/data/sphinx_init/requirements_txt.j2
@@ -1,4 +1,4 @@
 antsibull
 ansible-pygments
 sphinx
-sphinx_rtd_theme
+sphinx-ansible-theme

--- a/antsibull/data/sphinx_init/requirements_txt.j2
+++ b/antsibull/data/sphinx_init/requirements_txt.j2
@@ -1,0 +1,4 @@
+antsibull
+ansible-pygments
+sphinx
+sphinx_rtd_theme

--- a/antsibull/data/sphinx_init/rst_index_rst.j2
+++ b/antsibull/data/sphinx_init/rst_index_rst.j2
@@ -1,0 +1,27 @@
+.. _docsite_root_index:
+
+Welcome to my Ansible collection documentation
+==============================================
+
+{% if collections | length == 1 %}
+This docsite contains documentation of @{ collections[0] }@.
+{% elif collections | length > 1 %}
+This docsite contains documentation of @{ ', '.join(collections[:-1]) }@, and @{ collections[-1] }@.
+{% else %}
+This docsite contains documentation of some collections.
+{% endif %}
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Collections:
+
+   collections/index
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Plugin indexes:
+   :glob:
+
+   collections/index_*


### PR DESCRIPTION
See the discussion in the last DaWGs meeting: https://meetbot-raw.fedoraproject.org/ansible-docs/2021-07-27/dawgs_aka_ansible_documentation_working_group.2021-07-27-15.00.log.html

Example usages:
```
# Create docsite for all currently installed collections:
antsibull-docs sphinx-init --use-current --dest-dir docs

# Create docsite for currently installed version of community.crypto:
antsibull-docs sphinx-init --use-current --dest-dir crypto_docs community.crypto

# Create docsite for version 1.0.0 of community.hashi_vault:
antsibull-docs sphinx-init --dest-dir hashi_docs --collection-version 1.0.0 community.hashi_vault
# (The script created by this does not work yet, since this isn't implemented in antsibull-docs)
```
These will create a directory with several files in it, like `requirements.txt`, `build.sh`, `conf.py` and `rst/index.rst`.

CC @briantist