### PR TITLE
Update defaults for the build-release role

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install poetry ansible-base
+          python3 -m pip install poetry ansible-core
 
       - name: Test building a release with the defaults
         run: |

--- a/roles/build-release/README.md
+++ b/roles/build-release/README.md
@@ -8,7 +8,7 @@ This role is expected to run directly from an antsibull git repository checkout.
 
 Otherwise:
 
-- ansible-base to run this role
+- ansible-core to run this role
 - poetry to install and run antsibull
 - git to checkout ansible-build-data and ansible repositories
 
@@ -34,9 +34,9 @@ To re-build a specific version with some additional settings and a forked ansibl
   hosts: localhost
   gather_facts: no
   vars:
-    antsibull_ansible_version: 2.10.10
+    antsibull_ansible_version: 4.10.10
     antsibull_data_git_repo: https://github.com/dmsimard/ansible-build-data
-    antsibull_data_version: 2.10.10-branch
+    antsibull_data_version: 4.10.10-branch
     antsibull_force_rebuild: true
   roles:
     - build-release

--- a/roles/build-release/defaults/main.yaml
+++ b/roles/build-release/defaults/main.yaml
@@ -3,7 +3,7 @@
 antsibull_sdist_dir: "{{ playbook_dir | dirname }}/build"
 
 # The build file
-antsibull_build_file: "ansible-2.10.build"
+antsibull_build_file: "ansible-4.build"
 
 # Force a rebuild by deleting an existing release tarball, if it exists
 antsibull_force_rebuild: false
@@ -23,19 +23,19 @@ antsibull_data_reset: true
 antsibull_data_git_dir: "{{ antsibull_sdist_dir }}/ansible-build-data"
 
 # Directory to read .build and .deps files from
-antsibull_data_dir: "{{ antsibull_data_git_dir }}/2.10"
+antsibull_data_dir: "{{ antsibull_data_git_dir }}/4"
 
 # Where to clone the Ansible git repo from so we can run integration tests
 antsibull_ansible_git_repo: "https://github.com/ansible/ansible"
 
 # The git tag (or branch) of the ansible repo to check out
-antsibull_ansible_git_version: "stable-2.10"
+antsibull_ansible_git_version: "stable-2.11"
 
 # Where to clone the Ansible git repo
 antsibull_ansible_git_dir: "{{ antsibull_sdist_dir }}/ansible"
 
 # The version of ansible to build
-antsibull_ansible_version: 2.10.6
+antsibull_ansible_version: 4.4.0
 
 # Where the Ansible release tarball will be installed for test purposes
 antsibull_ansible_venv: "{{ antsibull_sdist_dir }}/venv"

--- a/roles/build-release/tasks/tests.yaml
+++ b/roles/build-release/tasks/tests.yaml
@@ -16,26 +16,28 @@
     virtualenv: "{{ antsibull_ansible_venv }}"
     virtualenv_command: "{{ ansible_python.executable }} -m venv"
 
-# Note: the version of ansible-base doesn't necessarily match the deps file since the version requirement is >=
+# Note: the version of ansible-core doesn't necessarily match the deps file since the version requirement is >=
 - block:
-    - name: Retrieve the expected minimum version of ansible-base
+    # Note: the value is still called _ansible_base_version in the deps file
+    # ex: https://github.com/ansible-community/ansible-build-data/blob/main/4/ansible-4.4.0.deps
+    - name: Retrieve the expected minimum version of ansible-core
       shell: >-
         grep _ansible_base_version {{ antsibull_data_dir }}/{{ _deps_file }} | awk '{print $2}'
       changed_when: false
-      register: _expected_ansible_base
+      register: _expected_ansible_core
 
-    - name: Retrieve the installed version of ansible-base
+    - name: Retrieve the installed version of ansible-core
       shell: >-
-        {{ antsibull_ansible_venv }}/bin/pip show ansible-base | awk '/Version/ {print $2}'
+        {{ antsibull_ansible_venv }}/bin/pip show ansible-core | awk '/Version/ {print $2}'
       changed_when: false
-      register: _installed_ansible_base
+      register: _installed_ansible_core
 
-    - name: Validate the version of ansible-base
+    - name: Validate the version of ansible-core
       ansible.builtin.assert:
         that:
-          - _installed_ansible_base.stdout is version(_expected_ansible_base.stdout, '>=')
-        success_msg: "ansible-base {{ _installed_ansible_base.stdout }} matches (or exceeds) {{ _deps_file }}"
-        fail_msg: "ansible-base {{ _installed_ansible_base.stdout }} does not match {{ _deps_file }}"
+          - _installed_ansible_core.stdout is version(_expected_ansible_core.stdout, '>=')
+        success_msg: "ansible-core {{ _installed_ansible_core.stdout }} matches (or exceeds) {{ _deps_file }}"
+        fail_msg: "ansible-core {{ _installed_ansible_core.stdout }} does not match {{ _deps_file }}"
 
 - block:
     - name: Retrieve expected versions of Ansible and collections


### PR DESCRIPTION
The defaults were outdated with ansible-base having been renamed
ansible-core and versions have since moved on to >=4.x.

Update the defaults so that the job exercises the latest release
instead.