### PR TITLE
[WIP] Add <details> directive to Sphinx extension

### DIFF
--- a/antsibull/data/docsite/list_of_collections_by_namespace.rst.j2
+++ b/antsibull/data/docsite/list_of_collections_by_namespace.rst.j2
@@ -2,6 +2,9 @@
 :orphan:
 {% endif %}
 
+.. |equalsign| unicode:: 0x3D   .. equal sign
+   :trim:
+
 .. _list_of_collections_@{ namespace }@:
 
 {% set title = 'Collections in the ' ~ (namespace | title) ~ ' Namespace' | rst_ify -%}

--- a/antsibull/data/docsite/list_of_plugins.rst.j2
+++ b/antsibull/data/docsite/list_of_plugins.rst.j2
@@ -1,5 +1,8 @@
 :orphan:
 
+.. |equalsign| unicode:: 0x3D   .. equal sign
+   :trim:
+
 .. _list_of_@{ plugin_type }@_plugins:
 
 {% if plugin_type == 'module' %}

--- a/antsibull/data/docsite/plugin-deprecation.rst.j2
+++ b/antsibull/data/docsite/plugin-deprecation.rst.j2
@@ -3,6 +3,9 @@
 {# avoids rST "isn't included in any toctree" errors for module docs #}
 :orphan:
 
+.. |equalsign| unicode:: 0x3D   .. equal sign
+   :trim:
+
 .. _@{ module }@_@{ plugin_type }@_alias_@{ alias }@:
 
 {% if short_description %}

--- a/antsibull/data/docsite/plugin-redirect.rst.j2
+++ b/antsibull/data/docsite/plugin-redirect.rst.j2
@@ -2,6 +2,9 @@
 
 :orphan:
 
+.. |equalsign| unicode:: 0x3D   .. equal sign
+   :trim:
+
 .. Anchors
 
 .. _ansible_collections.@{plugin_name}@_@{plugin_type}@:

--- a/antsibull/data/docsite/plugin-tombstone.rst.j2
+++ b/antsibull/data/docsite/plugin-tombstone.rst.j2
@@ -2,6 +2,9 @@
 
 :orphan:
 
+.. |equalsign| unicode:: 0x3D   .. equal sign
+   :trim:
+
 .. Anchors
 
 .. _ansible_collections.@{plugin_name}@_@{plugin_type}@:

--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -2,6 +2,9 @@
 
 :orphan:
 
+.. |equalsign| unicode:: 0x3D   .. equal sign
+   :trim:
+
 {# If we can put together source and github repo, we could make the Edit me of github button work.
    See meta.get("source") in Ansible's docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
    for more information

--- a/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -2,6 +2,9 @@
 :orphan:
 {% endif %}
 
+.. |equalsign| unicode:: 0x3D   .. equal sign
+   :trim:
+
 .. _plugins_in_@{collection_name}@:
 
 @{collection_name.title()}@

--- a/antsibull/data/docsite/role.rst.j2
+++ b/antsibull/data/docsite/role.rst.j2
@@ -2,6 +2,9 @@
 
 :orphan:
 
+.. |equalsign| unicode:: 0x3D   .. equal sign
+   :trim:
+
 {# If we can put together source and github repo, we could make the Edit me of github button work.
    See meta.get("source") in Ansible's docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
    for more information

--- a/antsibull/jinja2/filters.py
+++ b/antsibull/jinja2/filters.py
@@ -31,10 +31,10 @@ _RULER = re.compile(r"\bHORIZONTALLINE\b")
 
 
 def _option_name_html(matcher):
-    parts = matcher.group(1).split('=', 1)
-    if len(parts) == 1:
-        return f'<em>{parts[0]}</em>'
-    return f'<em>{parts[0]}</em>=<code>{parts[1]}</code>'
+    text = matcher.group(1)
+    if '=' not in text and ':' not in text:
+        return f'<code class="ansible-option literal"><strong>{text}</strong></code>'
+    return f'<code class="ansible-option-value literal">{text}</code>'
 
 
 def html_ify(text):
@@ -54,8 +54,10 @@ def html_ify(text):
     text, _counts['link'] = _LINK.subn(r"<a href='\2'>\1</a>", text)
     text, _counts['const'] = _CONST.subn(r"<code>\1</code>", text)
     text, _counts['option-name'] = _SEM_OPTION_NAME.subn(_option_name_html, text)
-    text, _counts['option-value'] = _SEM_OPTION_VALUE.subn(r"<code>\1</code>", text)
-    text, _counts['environment-var'] = _SEM_ENV_VARIABLE.subn(r"<code>\1</code>", text)
+    text, _counts['option-value'] = _SEM_OPTION_VALUE.subn(
+        r"""<code class="ansible-value literal">\1</code>""", text)
+    text, _counts['environment-var'] = _SEM_ENV_VARIABLE.subn(
+        r"""<code class="xref std std-envvar literal">\1</code>""", text)
     text, _counts['ruler'] = _RULER.subn(r"<hr/>", text)
 
     text = text.strip()
@@ -85,13 +87,6 @@ def do_max(seq):
     return max(seq)
 
 
-def _option_name_rst(matcher):
-    parts = matcher.group(1).split('=', 1)
-    if len(parts) == 1:
-        return f'*{parts[0]}*'
-    return f'*{parts[0]}* |equalsign| ``{parts[1]}``'
-
-
 def rst_ify(text):
     ''' convert symbols like I(this is in italics) to valid restructured text '''
 
@@ -107,9 +102,9 @@ def rst_ify(text):
     text, _counts['ref'] = _URL.subn(r"\1", text)
     text, _counts['link'] = _REF.subn(r":ref:`\1 <\2>`", text)
     text, _counts['const'] = _CONST.subn(r"``\1``", text)
-    text, _counts['option-name'] = _SEM_OPTION_NAME.subn(_option_name_rst, text)
-    text, _counts['option-value'] = _SEM_OPTION_VALUE.subn(r"``\1``", text)
-    text, _counts['environment-var'] = _SEM_ENV_VARIABLE.subn(r"``\1``", text)
+    text, _counts['option-name'] = _SEM_OPTION_NAME.subn(r":ansopt:`\1`", text)
+    text, _counts['option-value'] = _SEM_OPTION_VALUE.subn(r":ansval:`\1`", text)
+    text, _counts['environment-var'] = _SEM_ENV_VARIABLE.subn(r":envvar:`\1`", text)
     text, _counts['ruler'] = _RULER.subn(f"\n\n{'-' * 13}\n\n", text)
 
     flog.fields(counts=_counts).info('Number of macros converted to rst equivalents')

--- a/antsibull/lint_extra_docs.py
+++ b/antsibull/lint_extra_docs.py
@@ -11,6 +11,10 @@ import typing as t
 import docutils.utils
 import rstcheck
 
+from docutils.parsers.rst import roles as docutils_roles
+
+from sphinx_antsibull_ext import roles as antsibull_roles
+
 from .extra_docs import (
     find_extra_docs,
     lint_required_conditions,
@@ -46,6 +50,12 @@ def lint_optional_conditions(content: str, path: str, collection_name: str
     return [(result[0], 0, result[1]) for result in results]
 
 
+def _setup_rstcheck():
+    '''Make sure that rstcheck knows about our roles.'''
+    for name, role in antsibull_roles.ROLES.items():
+        docutils_roles.register_local_role(name, role)
+
+
 def lint_collection_extra_docs_files(path_to_collection: str
                                      ) -> t.List[t.Tuple[str, int, int, str]]:
     try:
@@ -56,6 +66,7 @@ def lint_collection_extra_docs_files(path_to_collection: str
     result = []
     all_labels = set()
     docs = find_extra_docs(path_to_collection)
+    _setup_rstcheck()
     for doc in docs:
         try:
             # Load content

--- a/antsibull/lint_extra_docs.py
+++ b/antsibull/lint_extra_docs.py
@@ -11,8 +11,10 @@ import typing as t
 import docutils.utils
 import rstcheck
 
+from docutils.parsers.rst import directives as docutils_directives
 from docutils.parsers.rst import roles as docutils_roles
 
+from sphinx_antsibull_ext import directives as antsibull_directives
 from sphinx_antsibull_ext import roles as antsibull_roles
 
 from .extra_docs import (
@@ -51,7 +53,9 @@ def lint_optional_conditions(content: str, path: str, collection_name: str
 
 
 def _setup_rstcheck():
-    '''Make sure that rstcheck knows about our roles.'''
+    '''Make sure that rstcheck knows about our directives and roles.'''
+    for name, directive in antsibull_directives.DIRECTIVES.items():
+        docutils_directives.register_directive(name, directive)
     for name, role in antsibull_roles.ROLES.items():
         docutils_roles.register_local_role(name, role)
 

--- a/sphinx_antsibull_ext/__init__.py
+++ b/sphinx_antsibull_ext/__init__.py
@@ -15,6 +15,7 @@ __author_email__ = "felix@fontein.de"
 
 
 from .assets import setup_assets
+from .roles import setup_roles
 
 
 def setup(app):
@@ -25,6 +26,9 @@ def setup(app):
 
     # Add assets
     setup_assets(app)
+
+    # Add roles
+    setup_roles(app)
 
     return dict(
         parallel_read_safe=True,

--- a/sphinx_antsibull_ext/__init__.py
+++ b/sphinx_antsibull_ext/__init__.py
@@ -15,6 +15,7 @@ __author_email__ = "felix@fontein.de"
 
 
 from .assets import setup_assets
+from .directives import setup_directives
 from .roles import setup_roles
 
 
@@ -27,7 +28,8 @@ def setup(app):
     # Add assets
     setup_assets(app)
 
-    # Add roles
+    # Add directives and roles
+    setup_directives(app)
     setup_roles(app)
 
     return dict(

--- a/sphinx_antsibull_ext/directives.py
+++ b/sphinx_antsibull_ext/directives.py
@@ -13,7 +13,7 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 
 
-class DetailsDirective(Directive):
+class DetailsDirective(Directive):  # pyre-ignore[11]
     """Details directive.
 
     Creates a HTML <details> element with an optional <summary>.

--- a/sphinx_antsibull_ext/directives.py
+++ b/sphinx_antsibull_ext/directives.py
@@ -1,0 +1,62 @@
+# coding: utf-8
+# Author: Felix Fontein <felix@fontein.de>
+# License: GPLv3+
+# Copyright: Ansible Project, 2021
+'''
+Add useful directives.
+'''
+
+from __future__ import (absolute_import, division, print_function)
+
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+
+class DetailsDirective(Directive):
+    """Details directive.
+
+    Creates a HTML <details> element with an optional <summary>.
+    """
+
+    required_arguments = 0
+    optional_arguments = 1
+    final_argument_whitespace = True
+    option_spec = {}
+    has_content = True
+
+    def run(self):
+        self.assert_has_content()
+        admonition_node = nodes.container(rawsource='\n'.join(self.content))
+        summary_nodes = []
+        if self.arguments:
+            title_text = self.arguments[0]
+            summary_nodes, messages = self.state.inline_text(title_text, self.lineno)
+
+        # Parse the directive contents.
+        self.state.nested_parse(self.content, self.content_offset, admonition_node)
+        result = [
+            nodes.raw('', '<details>', format='html'),
+        ]
+        if summary_nodes:
+            result.append(nodes.raw('', '<summary>', format='html'))
+            result.extend(summary_nodes)
+            result.append(nodes.raw('', '</summary>', format='html'))
+        result.extend([
+            admonition_node,
+            nodes.raw('', '</details>', format='html'),
+        ])
+        return result
+
+
+DIRECTIVES = {
+    'ansible-details': DetailsDirective,
+}
+
+
+def setup_directives(app):
+    '''
+    Setup directives for a Sphinx app object.
+    '''
+    for name, directive in DIRECTIVES.items():
+        app.add_directive(name, directive)

--- a/sphinx_antsibull_ext/roles.py
+++ b/sphinx_antsibull_ext/roles.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+# Author: Felix Fontein <felix@fontein.de>
+# License: GPLv3+
+# Copyright: Ansible Project, 2021
+'''
+Add roles for semantic markup.
+'''
+
+from __future__ import (absolute_import, division, print_function)
+
+
+from docutils import nodes
+
+
+def option_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    """Format Ansible option key, or option key-value.
+
+    Returns 2 part tuple containing list of nodes to insert into the
+    document and a list of system messages.  Both are allowed to be
+    empty.
+
+    :param name: The role name used in the document.
+    :param rawtext: The entire markup snippet, with role.
+    :param text: The text marked with the role.
+    :param lineno: The line number where rawtext appears in the input.
+    :param inliner: The inliner instance that called us.
+    :param options: Directive options for customization.
+    :param content: The directive content for customization.
+    """
+    children = []
+    classes = []
+    if '=' not in text and ':' not in text:
+        children.append(nodes.strong(rawtext, text))
+        rawtext = ''
+        text = ''
+        classes.append('ansible-option')
+    else:
+        classes.append('ansible-option-value')
+    return [nodes.literal(rawtext, text, *children, classes=classes)], []
+
+
+def value_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    """Format Ansible option value.
+
+    Returns 2 part tuple containing list of nodes to insert into the
+    document and a list of system messages.  Both are allowed to be
+    empty.
+
+    :param name: The role name used in the document.
+    :param rawtext: The entire markup snippet, with role.
+    :param text: The text marked with the role.
+    :param lineno: The line number where rawtext appears in the input.
+    :param inliner: The inliner instance that called us.
+    :param options: Directive options for customization.
+    :param content: The directive content for customization.
+    """
+    return [nodes.literal(rawtext, text, classes=['ansible-value'])], []
+
+
+ROLES = {
+    'ansopt': option_role,
+    'ansval': value_role,
+}
+
+
+def setup_roles(app):
+    '''
+    Setup roles for a Sphinx app object.
+    '''
+    for name, role in ROLES.items():
+        app.add_role(name, role)


### PR DESCRIPTION
This allows to write:
```.rst
.. ansible-details::

    Some RST content to hide by default.
```
or
```.rst
.. ansible-details:: A title to show instead of 'Details'

    Some RST content to hide by default.
```
to create `<details>` with optional `<summary>` (the title) ([ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)).

Currently contains #281, I can rebase when needed. The new stuff is all in c43305a15fd11ad2a972e18da55d24e3cffc456a.