### PR TITLE
WIP: Don't hardcode coverage inside the role

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -22,15 +22,15 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install poetry ansible-core
+          python3 -m pip install poetry ansible
 
       - name: Test building a release with the defaults
         run: |
-          ansible-playbook -vv playbooks/build-single-release.yaml
+          ANSIBLE_CALLBACK_WHITELIST=ansible.posix.profile_tasks ansible-playbook -vv playbooks/build-single-release.yaml
 
-      - name: Combine and upload coverage stats
-        run: |
-          poetry run coverage combine .coverage.*
-          poetry run coverage report
-          poetry run coverage xml -i
-          poetry run codecov
+#      - name: Combine and upload coverage stats
+#        run: |
+#          poetry run coverage combine .coverage.*
+#          poetry run coverage report
+#          poetry run coverage xml -i
+#          poetry run codecov

--- a/roles/build-release/tasks/main.yaml
+++ b/roles/build-release/tasks/main.yaml
@@ -31,7 +31,7 @@
 
 - name: Build a release with new dependencies
   command: >-
-    poetry run coverage run -p --source antsibull -m antsibull.cli.antsibull_build single {{ antsibull_ansible_version }}
+    poetry run antsibull-build single {{ antsibull_ansible_version }}
       --data-dir {{ antsibull_data_dir }}
       --sdist-dir {{ antsibull_sdist_dir }}
       --debian
@@ -53,7 +53,7 @@
 # If the release archive is already there it won't be re-built if we run again
 - name: Build a release with existing deps
   command: >-
-    poetry run coverage run -p --source antsibull -m antsibull.cli.antsibull_build rebuild-single {{ antsibull_ansible_version }}
+    poetry run antsibull-build rebuild-single {{ antsibull_ansible_version }}
       --data-dir {{ antsibull_data_dir }}
       --sdist-dir {{ antsibull_sdist_dir }}
       --build-file {{ antsibull_build_file }}


### PR DESCRIPTION
Coverage is nice, we just don't need to run it all the time.
We can make it a variable or something.

This is also being used to test the performance of the build job with
the upgraded galaxy.