### PR TITLE
Add CLI information to output

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -317,6 +317,34 @@ Parameters
                                 {% endif %}
                             </div>
                         {% endfor %}
+                        {% for mycli in value['cli'] %}
+                            <div>
+                                cli: @{ mycli['option'] }@
+                                {% if mycli['version_added'] is still_relevant %}
+                                  <div style="font-style: italic; font-size: small; color: darkgreen">
+                                    added in @{mycli['version_added']}@ of @{ mycli['version_added_collection'] | escape }@
+                                  </div>
+                                {% endif %}
+                                {% if mycli['deprecated'] %}
+                                  <div>
+                                    {% if mycli['deprecated']['removed_at_date'] %}
+                                      Removed in: major release after @{ mycli['deprecated']['removed_at_date'] | escape }@
+                                    {% elif mycli['deprecated']['removed_in'] %}
+                                      Removed in: version @{ mycli['deprecated']['removed_in'] | escape }@
+                                    {% else %}
+                                      Removed in: a future release
+                                    {% endif %}
+                                    {% if mycli['deprecated']['removed_from_collection'] and mycli['deprecated']['removed_from_collection'] != collection %}
+                                      of @{ mycli['deprecated']['removed_from_collection'] | escape }@
+                                    {% endif %}
+                                    <br>
+                                    Why: @{ mycli['deprecated']['why'] | escape }@
+                                    <br>
+                                    Alternative: @{ mycli['deprecated']['alternative'] | escape }@
+                                  </div>
+                                {% endif %}
+                            </div>
+                        {% endfor %}
                     </td>
                 {% endif %}
                 {# description #}


### PR DESCRIPTION
Follow-up to #306, resolves ansible/ansible#74838. Shows the CLI options next to ini/env/var:

![SSH connection docs page with new CLI information](https://user-images.githubusercontent.com/5781356/134239137-f4088253-2486-4635-ae23-b27a77561368.png)
