### PR TITLE
Accomodate for new N/A attribute support value

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -10,6 +10,7 @@
 .. role:: ansible-attribute-support-full
 .. role:: ansible-attribute-support-partial
 .. role:: ansible-attribute-support-none
+.. role:: ansible-attribute-support-na
 
 {# If we can put together source and github repo, we could make the Edit me of github button work.
    See meta.get("source") in Ansible's docs/docsite/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -423,8 +424,8 @@ Attributes
 {%       elif data.support == 'none' %}
     :ansible-attribute-support-none:`@{ data.support }@`
 {%       else %}
-{#         For unknown etc. #}
-    @{ data.support }@
+{#         For 'N/A' #}
+    :ansible-attribute-support-na:`@{ data.support }@`
 {%       endif %}
 {%     endif %}
 

--- a/antsibull/schemas/docs/base.py
+++ b/antsibull/schemas/docs/base.py
@@ -447,7 +447,7 @@ class AttributeSchemaBase(BaseModel, metaclass=abc.ABCMeta):
     # Without this base class, we would hit https://github.com/samuelcolvin/pydantic/issues/1259
     description: t.List[str]
     details: t.List[str] = []
-    support: str = p.Field('str', regex='^(full|partial|none)$')
+    support: str = p.Field('str', regex='^(full|partial|none|N/A)$')
     version_added: str = 'historical'
     version_added_collection: str = COLLECTION_NAME_F
 

--- a/sphinx_antsibull_ext/css/antsibull-minimal.scss
+++ b/sphinx_antsibull_ext/css/antsibull-minimal.scss
@@ -67,6 +67,9 @@ dl.ansible-attributes {
     color: green;
   }
 
+  .ansible-attribute-support-na {
+  }
+
   .ansible-attribute-details {
     font-style: italic;
   }


### PR DESCRIPTION
That was a last-minute addition from https://github.com/ansible/ansible/pull/75751 I forgot to add to #301. (I really wish we'd also got `unknown`, but that will have to wait...)