### PR TITLE
Edit boilerplate text for collection plugins in Ansible package

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -65,6 +65,8 @@
 .. note::
     This plugin is part of the `@{collection}@ collection <https://galaxy.ansible.com/@{collection | replace('.', '/', 1)}@>`_{% if collection_version %} (version @{ collection_version }@){% endif %}.
 
+    It is included in the ``ansible`` package. It is not included in ``ansible-core``.
+
     To install it use: :code:`ansible-galaxy collection install @{collection}@`.
 
     To use it in a playbook, specify: :code:`@{plugin_name}@`.


### PR DESCRIPTION
Addresses https://github.com/ansible-community/antsibull/issues/312
Clarify that collection plugins are included in the `ansible` package but not in `ansible-core`.