### PR TITLE
Render 'choices' in return values

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -479,6 +479,21 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                         </div>
                     {% endfor %}
                     <br/>
+                    {% if value['choices'] %}
+                        <div style="font-size: smaller"><b>Choices:</b>
+                            {% for choice in value['choices'] -%}
+                                {#- Turn boolean values in 'yes' and 'no' values -#}
+                                {%- if choice is sameas true -%}
+                                    {%- set choice = 'yes' -%}
+                                {%- elif choice is sameas false -%}
+                                    {%- set choice = 'no' -%}
+                                {%- endif -%}
+                                <span style="color: blue; word-wrap: break-word; word-break: break-all;">@{ choice | escape }@</span>
+                                {%- if not loop.last %}, {% endif -%}
+                            {%- endfor -%}
+                        </div>
+                        {% if value['sample'] %}<br/>{% endif %}
+                    {% endif %}
                     {% if value['sample'] %}
                         <div style="font-size: smaller"><b>Sample:</b></div>
                         {# TODO: The sample should be escaped, using | escape or | htmlify, but both mess things up beyond repair with dicts #}
@@ -537,6 +552,21 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                         <div>@{ desc | html_ify |indent(4) | trim}@</div>
                     {% endfor %}
                     <br/>
+                    {% if value['choices'] %}
+                        <div style="font-size: smaller"><b>Choices:</b>
+                            {% for choice in value['choices'] -%}
+                                {#- Turn boolean values in 'yes' and 'no' values -#}
+                                {%- if choice is sameas true -%}
+                                    {%- set choice = 'yes' -%}
+                                {%- elif choice is sameas false -%}
+                                    {%- set choice = 'no' -%}
+                                {%- endif -%}
+                                <span style="color: blue; word-wrap: break-word; word-break: break-all;">@{ choice | escape }@</span>
+                                {%- if not loop.last %}, {% endif -%}
+                            {%- endfor -%}
+                        </div>
+                        {% if value['sample'] %}<br/>{% endif %}
+                    {% endif %}
                     {% if value['sample'] %}
                         <div style="font-size: smaller"><b>Sample:</b></div>
                         {# TODO: The sample should be escaped, using |escape or |htmlify, but both mess things up beyond repair with dicts #}


### PR DESCRIPTION
Antsibull part of https://github.com/ansible/ansible/pull/76009: renders `choices` for return values. Example:
![image](https://user-images.githubusercontent.com/5781356/137008435-ef83b7ca-62a4-4eb0-acb5-2261f6cbc568.png)
