### PR TITLE
Use correct plugin type instead of module in ansible.builtin disclaimer

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -59,7 +59,7 @@
     is part of ``ansible-core`` and included in all Ansible
     installations. In most cases, you can use the short
     {% if plugin_type == 'module' %}module{% else %}plugin{% endif %} name
-    @{ plugin_name.rsplit('.', 1)[-1] }@ even without specifying the ``collections:`` keyword.
+    ``@{ plugin_name.rsplit('.', 1)[-1] }@`` even without specifying the ``collections:`` keyword.
     However, we recommend you use the FQCN for easy linking to the
     {% if plugin_type == 'module' %}module{% else %}plugin{% endif %}
     documentation and to avoid conflicting with other collections that may have


### PR DESCRIPTION
Right now the disclaimer always mentions modules, even on pages for non-modules: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sudo_become.html#ansible-builtin-sudo-substitute-user-do