### PR TITLE
Add plugin installation check to boilerplate text

### DIFF
--- a/antsibull/data/docsite/plugin.rst.j2
+++ b/antsibull/data/docsite/plugin.rst.j2
@@ -68,9 +68,11 @@
 .. note::
     This plugin is part of the `@{collection}@ collection <https://galaxy.ansible.com/@{collection | replace('.', '/', 1)}@>`_{% if collection_version %} (version @{ collection_version }@){% endif %}.
 
-    It is included in the ``ansible`` package. It is not included in ``ansible-core``.
+    You might already have this collection installed if you are using the ``ansible`` package.
+    It is not included in ``ansible-core``.
+    To check whether it is installed, run :code:`ansible-galaxy collection list`.
 
-    To install it use: :code:`ansible-galaxy collection install @{collection}@`.
+    To install it, use: :code:`ansible-galaxy collection install @{collection}@`.
 
     To use it in a playbook, specify: :code:`@{plugin_name}@`.
 {% endif %}


### PR DESCRIPTION
Addresses https://github.com/ansible-community/antsibull/issues/312

Action from [DaWGs meeting 2021-10-19](https://github.com/ansible/community/issues/579#issuecomment-945632120)

Reword boilerplate text for collection plugins: add a command to check whether the collection is installed.