### PR TITLE
build-release: Don't always checkout ansible-build-data

### DIFF
--- a/roles/build-release/tasks/main.yaml
+++ b/roles/build-release/tasks/main.yaml
@@ -21,8 +21,9 @@
     repo: "{{ antsibull_data_git_repo }}"
     dest: "{{ antsibull_data_git_dir }}"
     version: "{{ antsibull_data_version }}"
-    # TODO: Building a release means we may create or change files which would be overwritten by force
-    force: "{{ antsibull_data_reset | bool }}"
+    force: true
+  # By setting antsibull_data_reset to false, we can run with an edited or otherwise prepared version of ansible-build-data
+  when: antsibull_data_reset | bool
 
 - name: Set expected path to deps file and release archive
   ansible.builtin.set_fact:


### PR DESCRIPTION
The intent of "antsibull_data_reset" was to allow for a short-circuit
where we may want to build a release, edit something in ansible-build-data
(such as the version of ansible_base) and then build a release again.

Setting the bool under force didn't have the expected outcome: if there
were edits, it would simply error out and stop there if there were local
edits and it would not continue unless we added an ignore_errors.

By moving the conditional up to the task we can proceed as intended.

From a testing perspective, it will also allow us to check out a
specific version of ansible-build-data (i.e, from a PR) and then prepare
that ahead of time before the role runs.