### PR TITLE
Simplify collection metadata loading now that ansible-core 2.12 dropped support for galaxy.yaml.

### DIFF
--- a/antsibull/data/collection-enum.py
+++ b/antsibull/data/collection-enum.py
@@ -187,23 +187,19 @@ def load_collection_meta_galaxy(b_galaxy_path):
 
 def load_collection_meta(b_path):
     b_manifest_path = os.path.join(b_path, b'MANIFEST.json')
+    b_galaxy_path = os.path.join(b_path, b'galaxy.yml')
     if os.path.exists(b_manifest_path):
         data = load_collection_meta_manifest(b_manifest_path)
+    elif os.path.exists(b_galaxy_path):
+        data = load_collection_meta_galaxy(b_galaxy_path)
     else:
-        data = {}
-        b_galaxy_path = os.path.join(b_path, b'galaxy.yml')
-        b_galaxy_alt_path = os.path.join(b_path, b'galaxy.yaml')
-        for path in (b_galaxy_path, b_galaxy_alt_path):
-            if os.path.exists(path):
-                data = load_collection_meta_galaxy(path)
-        if not data:
-            # Fallback in case no galaxy.yml is around. This happens for collections
-            # checked out from source where galaxy.yml is templated on build.
-            data = {
-                'version': None,
-                'namespace': to_native(os.path.basename(os.path.dirname(b_path))),
-                'name': to_native(os.path.basename(b_path)),
-            }
+        # Fallback in case no galaxy.yml is around. This happens for collections
+        # checked out from source where galaxy.yml is templated on build.
+        data = {
+            'version': None,
+            'namespace': to_native(os.path.basename(os.path.dirname(b_path))),
+            'name': to_native(os.path.basename(b_path)),
+        }
     data['path'] = to_native(b_path)
     return data
 


### PR DESCRIPTION
ansible-base 2.10 and ansible-core 2.11 supported galaxy.yaml next to galaxy.yml, while Ansible 2.9 didn't support that, and ansible-core 2.12 no longer supports it either (support was removed in 595413d11346b6f26bb3d9df2d8e05f2747508a3, see changes for `lib/ansible/galaxy/collection/__init__.py`). So let's stop supporting that in the collection enum code (it's unclear whether it was actually used anyway, and for the regular docsite build only MANIFEST.json files will be used anyway since all collectins are installed from Ansible Galaxy and not cloned from git).