### PR TITLE
Improve wait on HTTP retries

### DIFF
--- a/antsibull/utils/http.py
+++ b/antsibull/utils/http.py
@@ -4,6 +4,7 @@
 """General functions for working with aiohttp."""
 
 import asyncio
+import random
 import typing as t
 import warnings
 
@@ -49,6 +50,7 @@ class RetryGetManager:
         error_codes = []
         for retry in range(self.max_retries):
             flog.debug('Execute {0}', self.call_string)
+            wait_factor = 5
             try:
                 response = await self.aio_session.get(*self.args, **self.kwargs, timeout=20)
                 status_code = response.status
@@ -63,6 +65,7 @@ class RetryGetManager:
                 flog.trace()
                 status_code = 'timeout'
                 error_codes.append(status_code)
+                wait_factor = 0.5
             except Exception as error:
                 flog.trace()
                 status_code = str(error)
@@ -77,7 +80,7 @@ class RetryGetManager:
             if failed:
                 break
 
-            await asyncio.sleep(retry * 0.5)
+            await asyncio.sleep(retry * wait_factor + random.uniform(0, 1))
 
         flog.debug('Raise error')
         raise Exception('Repeated error when calling {0}: received status codes {1}'.format(

--- a/antsibull/utils/http.py
+++ b/antsibull/utils/http.py
@@ -4,6 +4,7 @@
 """General functions for working with aiohttp."""
 
 import asyncio
+import math
 import random
 import typing as t
 import warnings
@@ -80,7 +81,7 @@ class RetryGetManager:
             if failed:
                 break
 
-            await asyncio.sleep(retry * wait_factor + random.uniform(0, 1))
+            await asyncio.sleep(math.pow(1.5, retry) * wait_factor + (0.5 + random.uniform(0, 1)))
 
         flog.debug('Raise error')
         raise Exception('Repeated error when calling {0}: received status codes {1}'.format(


### PR DESCRIPTION
- Wait longer (10x) compared to now. Only after timeouts wait for the same amount of time.
- Add a jitter (up to 1 second) so that if multiple requests fail that were started at the same time, their retries will be spread out over time.
