### PR TITLE
Move module list to beginning of collection template

### DIFF
--- a/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -40,13 +40,13 @@ There are no plugins in the @{collection_name}@ collection with automatically ge
 
 {% for category, plugins in plugin_maps.items() | sort | rejectattr('0', 'eq', 'role') %}
 
-{%   if category == 'module' %}
+{%  if category == 'module' %}
 Modules
 ~~~~~~~
 {%   for name, desc in plugins.items() | sort %}
   * :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | rst_ify | indent(width=2) }@
 {%   endfor %}
-{%   else %}
+{%  else %}
 {%   if category == 'role' %}
 Roles
 ~~~~~
@@ -58,7 +58,7 @@ Roles
 {%   for name, desc in plugins.items() | sort %}
 * :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | rst_ify | indent(width=2) }@
 {%   endfor %}
-{%   endif %}
+{%  endif %}
 {% endfor %}
 
 {% if 'role' in plugin_maps %}

--- a/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -43,7 +43,11 @@ There are no plugins in the @{collection_name}@ collection with automatically ge
 {%   if category == 'module' %}
 Modules
 ~~~~~~~
-{%   elif category == 'role' %}
+{%   for name, desc in plugins.items() | sort %}
+  * :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | rst_ify | indent(width=2) }@
+{%   endfor %}
+{%   else %}
+{%   if category == 'role' %}
 Roles
 ~~~~~
 {%   else %}
@@ -54,6 +58,7 @@ Roles
 {%   for name, desc in plugins.items() | sort %}
 * :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ category }@>` -- @{ desc | rst_ify | indent(width=2) }@
 {%   endfor %}
+{%   endif %}
 {% endfor %}
 
 {% if 'role' in plugin_maps %}


### PR DESCRIPTION
Fixes #331 

Edit the collections template to list modules at the beginning. 
Plugins and roles will be at the end of the doc.
