### PR TITLE
Fix antsibull-lint on Python 3.9.8, add tests

### DIFF
--- a/.github/workflows/antsibull-lint-tests.yml
+++ b/.github/workflows/antsibull-lint-tests.yml
@@ -1,0 +1,47 @@
+name: Test antsibull-lint subcommands
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Run once per week (Monday at 06:00 UTC)
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . coverage codecov
+
+      - name: Check out community.general's stable-4 branch
+        uses: actions/checkout@v2
+        repository: ansible-collections/community.general
+        ref: stable-4
+        path: community.general
+
+      - name: antsibull-lint collection-docs
+        run: |
+          coverage run -p --source antsibull -m antsibull.cli.antsibull_lint collection-docs community.general
+
+      - name: antsibull-lint changelog-yaml
+        run: |
+          coverage run -p --source antsibull -m antsibull.cli.antsibull_lint changelog-yaml community.general/changelogs/changelog.yaml
+
+      - name: Combine and upload coverage stats
+        run: |
+          coverage combine .coverage.*
+          coverage report
+          coverage xml -i
+          codecov

--- a/.github/workflows/antsibull-lint-tests.yml
+++ b/.github/workflows/antsibull-lint-tests.yml
@@ -27,9 +27,10 @@ jobs:
 
       - name: Check out community.general's stable-4 branch
         uses: actions/checkout@v2
-        repository: ansible-collections/community.general
-        ref: stable-4
-        path: community.general
+        with:
+          repository: ansible-collections/community.general
+          ref: stable-4
+          path: community.general
 
       - name: antsibull-lint collection-docs
         run: |

--- a/antsibull/cli/antsibull_lint.py
+++ b/antsibull/cli/antsibull_lint.py
@@ -149,3 +149,7 @@ def main() -> int:
         return 4
 
     return run(sys.argv)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/antsibull/cli/antsibull_lint.py
+++ b/antsibull/cli/antsibull_lint.py
@@ -50,7 +50,7 @@ def run(args: List[str]) -> int:
         changelog_yaml = subparsers.add_parser('changelog-yaml',
                                                parents=[common],
                                                help='changelogs/changelog.yaml linter')
-        changelog_yaml.set_defaults(command=command_lint_changelog)
+        changelog_yaml.set_defaults(func=command_lint_changelog)
 
         changelog_yaml.add_argument('changelog_yaml_path',
                                     metavar='/path/to/changelog.yaml',
@@ -60,7 +60,7 @@ def run(args: List[str]) -> int:
                                                 parents=[common],
                                                 help='Collection extra docs linter for inclusion'
                                                      ' in docsite')
-        collection_docs.set_defaults(command=command_lint_collection_docs)
+        collection_docs.set_defaults(func=command_lint_collection_docs)
 
         collection_docs.add_argument('collection_root_path',
                                      metavar='/path/to/collection',
@@ -71,12 +71,16 @@ def run(args: List[str]) -> int:
 
         arguments = parser.parse_args(args[1:])
 
+        if getattr(arguments, 'func', None) is None:
+            parser.print_help()
+            return 2
+
         normalize_toplevel_options(arguments)
 
         verbosity = arguments.verbose
         setup_logger(verbosity)
 
-        return arguments.command(arguments)
+        return arguments.func(arguments)
     except SystemExit as e:
         return e.code
     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
@briantist noticed that antsibull-lint fails in some circumstances, and I figured out that this apparently happens with Python 3.9.8, while it works fine with Python 3.9.7. Apparently a change in argparse between these versions causes this.

This PR fixes antsibull-lint so that it works fine with both versions (and hopefully all others too), and adds some basic integration tests (with Python 3.9) with coverage for antsibull-lint.
