### PR TITLE
Simplify ansible-core dep w/ compatible operator

### DIFF
--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -173,7 +173,8 @@ setup(
     packages=['ansible_collections'],
     include_package_data=True,
     install_requires=[
-        '{{ ansible_core_package_name }}>={{ ansible_base_version }},<{{ ansible_base_version.major }}.{{ ansible_base_version.minor + 1 }}',{{ collection_deps }}
+        '{{ ansible_core_package_name }} ~= {{ ansible_base_version }}',
+        {{ collection_deps }}
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -173,8 +173,7 @@ setup(
     packages=['ansible_collections'],
     include_package_data=True,
     install_requires=[
-        '{{ ansible_core_package_name }} ~= {{ ansible_base_version }}',
-        {{ collection_deps }}
+        '{{ ansible_core_package_name }} ~= {{ ansible_base_version }}',{{ collection_deps }}
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
The `~=` opeator is similar to `^` in some ecosystems
(NodeJS/Poetry/Rust). It allows to achieve the request of a compatible
release by only allowing the last version segment to be variable.
For example, `~= 2.13.2` is equivalent to `>= 2.13.2, == 2.13.*`.

Ref: https://www.python.org/dev/peps/pep-0440/#compatible-release