### PR TITLE
base → core

### DIFF
--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -11,7 +11,7 @@ You can use the `antsibull-lint changelog-yaml` tool to validate these files:
 
     antsibull-lint changelog-yaml /path/to/changelog.yaml
 
-(This only works for `changelog.yaml` files in collections, not for the corresponding files in ansible-base, since ansible-base currently does not conform to semantic versioning.)
+(This only works for `changelog.yaml` files in collections, not for the corresponding files in ansible-core, since ansible-core currently does not conform to semantic versioning.)
 
 The tool does not output anything and exits with exit code 0 in case the file is OK, and outputs errors and exits with exit code 3 in case an error was found. Other exit codes indicate problems with the command line or during the execution of the linter.
 
@@ -25,7 +25,7 @@ At the top level, there are two entries:
 1. A string `ancestor`, which can also be `null` or omitted if the changelog has no ancestor.
 2. A dictionary `releases`, which maps version numbers to release information.
 
-If `ancestor` is a string, it must be an existing version of the collection which precedes all versions mentioned in this changelog. This is used when the changelog is truncated, for example when using release branches like for ansible-base. There, the `stable-2.10` branch's changelog contains only changelog entries for 2.10.x releases. Since the first 2.10.0b1 release contains all changes made to `devel` after `stable-2.9` was branched, the ancestor for the 2.10 changelog is `2.9.0b1`, the first release made after branching `stable-2.9`.
+If `ancestor` is a string, it must be an existing version of the collection which precedes all versions mentioned in this changelog. This is used when the changelog is truncated, for example when using release branches like for ansible-core. There, the `stable-2.10` branch's changelog contains only changelog entries for 2.10.x releases. Since the first 2.10.0b1 release contains all changes made to `devel` after `stable-2.9` was branched, the ancestor for the 2.10 changelog is `2.9.0b1`, the first release made after branching `stable-2.9`.
 
 The following shows the outline of a `changelog.yaml` file with four versions:
 
@@ -47,7 +47,7 @@ releases:
 For a release `x.y.z`, the `releases` dictionary contains an entry `x.y.z` mapping to another dictionary. That dictionary can have the following entries:
 
 1. `release_date`: a string in ISO format (`YYYY-MM-DD`) specifying on which date the release was made.
-1. `codename`: a string for the version's codename. Optional; mainly required for ansible-base.
+1. `codename`: a string for the version's codename. Optional; mainly required for ansible-core.
 1. `fragments`: a list of strings mentioning changelog fragment files used for this release. This is not used for compiling a changelog.
 1. `changes`: a dictionary containing all changes. See below.
 1. `modules`: a list of plugin dictionaries. See below.

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -1,4 +1,4 @@
-.. automodule:: antsibull.schemas.base
+.. automodule:: antsibull.schemas.docs.base
 
 There is a dictionary named ANSIBLE_DOC_SCHEMAS to allow you easier access to these
 programmatically.  It is a mapping of plugin types to the ansible_doc schema which handle it.

--- a/src/antsibull/ansible_base.py
+++ b/src/antsibull/ansible_base.py
@@ -2,7 +2,7 @@
 # Author: Toshio Kuratomi <tkuratom@redhat.com>
 # License: GPLv3+
 # Copyright: Ansible Project, 2020
-"""Functions for working with the ansible-base package."""
+"""Functions for working with the ansible-core package."""
 import ast
 import asyncio
 import os
@@ -27,7 +27,7 @@ if t.TYPE_CHECKING:
 
 mlog = log.fields(mod=__name__)
 
-#: URL to checkout ansible-base from.
+#: URL to checkout ansible-core from.
 _ANSIBLE_BASE_URL = str(app_context.AppContext().ansible_base_url)
 #: URL to pypi.
 _PYPI_SERVER_URL = str(app_context.AppContext().pypi_url)
@@ -66,7 +66,7 @@ class AnsibleBasePyPiClient:
     @lru_cache(None)
     async def get_release_info(self) -> t.Dict[str, t.Any]:
         """
-        Retrieve information about releases of the ansible-base/ansible-core package from pypi.
+        Retrieve information about releases of the ansible-core/ansible-core package from pypi.
 
         :returns: The dict which represents the release info keyed by version number.
             To examine the data structure, use::
@@ -90,7 +90,7 @@ class AnsibleBasePyPiClient:
 
     async def get_versions(self) -> t.List[PypiVer]:
         """
-        Get the versions of the ansible-base package on pypi.
+        Get the versions of the ansible-core package on pypi.
 
         :returns: A list of :pypkg:obj:`packaging.versioning.Version`s
             for all the versions on pypi, including prereleases.
@@ -108,7 +108,7 @@ class AnsibleBasePyPiClient:
 
     async def get_latest_version(self) -> PypiVer:
         """
-        Get the latest version of ansible-base uploaded to pypi.
+        Get the latest version of ansible-core uploaded to pypi.
 
         :return: A :pypkg:obj:`packaging.versioning.Version` object representing the latest version
             of the package on pypi.  This may be a pre-release.
@@ -120,7 +120,7 @@ class AnsibleBasePyPiClient:
         """
         Get the release from pypi.
 
-        :arg ansible_base_version: Version of ansible-base to download.
+        :arg ansible_base_version: Version of ansible-core to download.
         :arg download_dir: Directory to download the tarball to.
         :returns: The name of the downloaded tarball.
         """
@@ -193,8 +193,8 @@ def _get_source_version(ansible_base_source: str) -> PypiVer:
 
 def source_is_devel(ansible_base_source: t.Optional[str]) -> bool:
     """
-    :arg ansible_base_source: A path to an Ansible-base checkout or expanded sdist or None.
-        This will be used instead of downloading an ansible-base package if the version matches
+    :arg ansible_base_source: A path to an Ansible-core checkout or expanded sdist or None.
+        This will be used instead of downloading an ansible-core package if the version matches
         with ``ansible_base_version``.
     :returns: True if the source looks like it is for the devel branch.
     """
@@ -216,10 +216,10 @@ def source_is_devel(ansible_base_source: t.Optional[str]) -> bool:
 def source_is_correct_version(ansible_base_source: t.Optional[str],
                               ansible_base_version: PypiVer) -> bool:
     """
-    :arg ansible_base_source: A path to an Ansible-base checkout or expanded sdist or None.
-        This will be used instead of downloading an ansible-base package if the version matches
+    :arg ansible_base_source: A path to an Ansible-core checkout or expanded sdist or None.
+        This will be used instead of downloading an ansible-core package if the version matches
         with ``ansible_base_version``.
-    :arg ansible_base_version: Version of ansible-base to retrieve.
+    :arg ansible_base_version: Version of ansible-core to retrieve.
     :returns: True if the source is for a compatible version at or newer than the requested version
     """
     if ansible_base_source is None:
@@ -230,7 +230,7 @@ def source_is_correct_version(ansible_base_source: t.Optional[str],
     except Exception:
         return False
 
-    # If the source is a compatible version of ansible-base and it is the same or more recent than
+    # If the source is a compatible version of ansible-core and it is the same or more recent than
     # the requested version then allow this.
     if (source_version.major == ansible_base_version.major
             and source_version.minor == ansible_base_version.minor
@@ -243,14 +243,14 @@ def source_is_correct_version(ansible_base_source: t.Optional[str],
 @lru_cache(None)
 async def checkout_from_git(download_dir: str, repo_url: str = _ANSIBLE_BASE_URL) -> str:
     """
-    Checkout the ansible-base git repo.
+    Checkout the ansible-core git repo.
 
     :arg download_dir: Directory to checkout into.
     :kwarg: repo_url: The url to the git repo.
-    :return: The directory that ansible-base has been checked out to.
+    :return: The directory that ansible-core has been checked out to.
     """
     loop = best_get_loop()
-    ansible_base_dir = os.path.join(download_dir, 'ansible-base')
+    ansible_base_dir = os.path.join(download_dir, 'ansible-core')
     await loop.run_in_executor(None, sh.git, 'clone', repo_url, ansible_base_dir)
 
     return ansible_base_dir
@@ -305,16 +305,16 @@ async def get_ansible_base(aio_session: 'aiohttp.client.ClientSession',
                            tmpdir: str,
                            ansible_base_source: t.Optional[str] = None) -> str:
     """
-    Create an ansible-base directory of the requested version.
+    Create an ansible-core directory of the requested version.
 
     :arg aio_session: :obj:`aiohttp.client.ClientSession` to make http requests with.
-    :arg ansible_base_version: Version of ansible-base to retrieve.  If it is the special string
-        ``@devel``, then we will retrieve ansible-base from its git repository.  If it is the
+    :arg ansible_base_version: Version of ansible-core to retrieve.  If it is the special string
+        ``@devel``, then we will retrieve ansible-core from its git repository.  If it is the
         special string ``@latest``, then we will retrieve the latest version from pypi.
     :arg tmpdir: Temporary directory use as a scratch area for downloading to and the place that the
-        ansible-base directory should be placed in.
-    :kwarg ansible_base_source: If given, a path to an ansible-base checkout or expanded sdist.
-        This will be used instead of downloading an ansible-base package if the version matches
+        ansible-core directory should be placed in.
+    :kwarg ansible_base_source: If given, a path to an ansible-core checkout or expanded sdist.
+        This will be used instead of downloading an ansible-core package if the version matches
         with ``ansible_base_version``.
     """
     if ansible_base_version == '@devel':

--- a/src/antsibull/ansible_core.py
+++ b/src/antsibull/ansible_core.py
@@ -66,7 +66,7 @@ class AnsibleCorePyPiClient:
     @lru_cache(None)
     async def get_release_info(self) -> t.Dict[str, t.Any]:
         """
-        Retrieve information about releases of the ansible-core/ansible-core package from pypi.
+        Retrieve information about releases of the ansible-core/ansible-base package from pypi.
 
         :returns: The dict which represents the release info keyed by version number.
             To examine the data structure, use::

--- a/src/antsibull/ansible_core.py
+++ b/src/antsibull/ansible_core.py
@@ -41,13 +41,13 @@ class CannotBuild(Exception):
     """Raised when we can't figure out how to build a package."""
 
 
-class AnsibleBasePyPiClient:
-    """Class to retrieve information about AnsibleBase from Pypi."""
+class AnsibleCorePyPiClient:
+    """Class to retrieve information about ansible-core from Pypi."""
 
     def __init__(self, aio_session: 'aiohttp.client.ClientSession',
                  pypi_server_url: str = _PYPI_SERVER_URL) -> None:
         """
-        Initialize the AnsibleBasePypi class.
+        Initialize the AnsibleCorePypiClient class.
 
         :arg aio_session: :obj:`aiohttp.client.ClientSession` to make requests to pypi from.
         :kwarg pypi_server_url: URL to the pypi server to use.
@@ -95,7 +95,7 @@ class AnsibleBasePyPiClient:
         :returns: A list of :pypkg:obj:`packaging.versioning.Version`s
             for all the versions on pypi, including prereleases.
         """
-        flog = mlog.fields(func='AnsibleBasePyPiClient.get_versions')
+        flog = mlog.fields(func='AnsibleCorePyPiClient.get_versions')
         flog.debug('Enter')
 
         release_info = await self.get_release_info()
@@ -330,7 +330,7 @@ async def get_ansible_core(aio_session: 'aiohttp.client.ClientSession',
         # Create an sdist from the source that can be installed
         install_file = await create_sdist(source_location, tmpdir)
     else:
-        pypi_client = AnsibleBasePyPiClient(aio_session)
+        pypi_client = AnsibleCorePyPiClient(aio_session)
         if ansible_core_version == '@latest':
             ansible_core_version: PypiVer = await pypi_client.get_latest_version()
         else:

--- a/src/antsibull/ansible_core.py
+++ b/src/antsibull/ansible_core.py
@@ -28,7 +28,7 @@ if t.TYPE_CHECKING:
 mlog = log.fields(mod=__name__)
 
 #: URL to checkout ansible-core from.
-_ANSIBLE_BASE_URL = str(app_context.AppContext().ansible_base_url)
+_ANSIBLE_CORE_URL = str(app_context.AppContext().ansible_base_url)
 #: URL to pypi.
 _PYPI_SERVER_URL = str(app_context.AppContext().pypi_url)
 
@@ -241,7 +241,7 @@ def source_is_correct_version(ansible_base_source: t.Optional[str],
 
 
 @lru_cache(None)
-async def checkout_from_git(download_dir: str, repo_url: str = _ANSIBLE_BASE_URL) -> str:
+async def checkout_from_git(download_dir: str, repo_url: str = _ANSIBLE_CORE_URL) -> str:
     """
     Checkout the ansible-core git repo.
 
@@ -300,7 +300,7 @@ async def create_sdist(source_dir: str, dest_dir: str) -> str:
     return os.path.join(dist_dir, dist_files[0])
 
 
-async def get_ansible_base(aio_session: 'aiohttp.client.ClientSession',
+async def get_ansible_core(aio_session: 'aiohttp.client.ClientSession',
                            ansible_base_version: str,
                            tmpdir: str,
                            ansible_base_source: t.Optional[str] = None) -> str:

--- a/src/antsibull/app_context.py
+++ b/src/antsibull/app_context.py
@@ -39,7 +39,7 @@ example:
 
     def do_something():
         app_ctx = app_context.app_ctx.get()
-        base_filename = download_python_package('ansible-base', server_url=app_ctx.pypi_url)
+        base_filename = download_python_package('ansible-core', server_url=app_ctx.pypi_url)
         return base_filename
 
     def run(args):

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -21,7 +21,7 @@ from packaging.version import Version as PypiVer
 from semantic_version import Version as SemVer, SimpleSpec as SemVerSpec
 
 from . import app_context
-from .ansible_base import get_ansible_core_package_name
+from .ansible_core import get_ansible_core_package_name
 from .build_changelog import ReleaseNotes
 from .changelog import ChangelogData, get_changelog
 from .collections import install_separately, install_together

--- a/src/antsibull/build_changelog.py
+++ b/src/antsibull/build_changelog.py
@@ -200,15 +200,15 @@ def append_changelog_changes_base(builder: RstBuilder,
     builder.add_section(base_name, 1)
 
     builder.add_raw_rst(f"Ansible {changelog_entry.version} contains {base_name} "
-                        f"version {changelog_entry.ansible_base_version}.")
-    if changelog_entry.prev_ansible_base_version:
-        if changelog_entry.prev_ansible_base_version == changelog_entry.ansible_base_version:
+                        f"version {changelog_entry.ansible_core_version}.")
+    if changelog_entry.prev_ansible_core_version:
+        if changelog_entry.prev_ansible_core_version == changelog_entry.ansible_core_version:
             builder.add_raw_rst(f"This is the same version of {base_name} as in "
                                 "the previous Ansible release.\n")
             return []
 
         builder.add_raw_rst(f"This is a newer version than version "
-                            f"{changelog_entry.prev_ansible_base_version} contained in the "
+                            f"{changelog_entry.prev_ansible_core_version} contained in the "
                             f"previous Ansible release.\n")
 
     changelog = changelog_entry.base_collector.changelog
@@ -217,8 +217,8 @@ def append_changelog_changes_base(builder: RstBuilder,
 
     release_entries = changelog.generator.collect(
         squash=True,
-        after_version=changelog_entry.prev_ansible_base_version,
-        until_version=changelog_entry.ansible_base_version)
+        after_version=changelog_entry.prev_ansible_core_version,
+        until_version=changelog_entry.ansible_core_version)
 
     if not release_entries:
         builder.add_raw_rst(f"{base_name} did not have a changelog in this version.")
@@ -429,8 +429,8 @@ def append_porting_guide_section(builder: RstBuilder, changelog_entry: Changelog
     check_changelog(
         'Ansible-core' if is_core else 'Ansible-base',
         changelog_entry.base_collector.changelog,
-        changelog_entry.ansible_base_version,
-        changelog_entry.prev_ansible_base_version)
+        changelog_entry.ansible_core_version,
+        changelog_entry.prev_ansible_core_version)
     for (
             collector, collection_version, prev_collection_version
     ) in changelog_entry.changed_collections:

--- a/src/antsibull/build_changelog.py
+++ b/src/antsibull/build_changelog.py
@@ -357,7 +357,7 @@ def append_changelog(builder: RstBuilder,
     append_removed_collections(builder, changelog_entry)
     append_added_collections(builder, changelog_entry)
 
-    # Adds Ansible-base section
+    # Adds Ansible-core section
     data.extend(append_changelog_changes_base(builder, changelog_entry))
     builder.add_raw_rst('')
 
@@ -540,7 +540,7 @@ class ReleaseNotes:
                     continue
                 builder.add_raw_rst(line)
             if not found_empty:
-                print('WARNING: cannot find TOC of ansible-base porting guide!')
+                print('WARNING: cannot find TOC of ansible-core porting guide!')
 
     @staticmethod
     def _get_porting_guide_bytes(changelog: Changelog) -> bytes:
@@ -599,15 +599,15 @@ class ReleaseNotes:
 
         builder.add_raw_rst('.. contents::\n  :local:\n  :depth: 2\n')
 
-        # Determine ansible-base/-core version in previous major release
+        # Determine ansible-core version in previous major release
         prev_base_version = ''
         if any(entry.is_ancestor for entry in changelog.entries):
-            # If there is an ancestor, the earliest ansible-base/-core version will be the
+            # If there is an ancestor, the earliest ansible-core version will be the
             # version used in the previous major release.
             prev_base_version = changelog.base_collector.earliest
             prev_base_version = f"{prev_base_version.major}.{prev_base_version.minor}"
 
-        # Determine whether to include ansible-base/-core porting guide or not
+        # Determine whether to include ansible-core porting guide or not
         if changelog.ansible_version.major == 2 or base_version != prev_base_version:
             builder.add_raw_rst(
                 # noqa: E501

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -219,7 +219,7 @@ class CollectionChangelogCollector:
             missing_versions -= {missing_version}
 
 
-class AnsibleBaseChangelogCollector:
+class AnsibleCoreChangelogCollector:
     versions: t.List[PypiVer]
     earliest: PypiVer
     latest: PypiVer
@@ -287,7 +287,7 @@ class AnsibleBaseChangelogCollector:
 
 
 async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
-                             base_collector: AnsibleBaseChangelogCollector,
+                             base_collector: AnsibleCoreChangelogCollector,
                              collection_cache: t.Optional[str]):
     lib_ctx = app_context.lib_ctx.get()
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -318,7 +318,7 @@ class ChangelogEntry:
     base_versions: t.Dict[PypiVer, str]
     versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]]
 
-    base_collector: AnsibleBaseChangelogCollector
+    base_collector: AnsibleCoreChangelogCollector
     ansible_changelog: ChangelogData
     collectors: t.List[CollectionChangelogCollector]
 
@@ -335,7 +335,7 @@ class ChangelogEntry:
                  ancestor_version: t.Optional[PypiVer],
                  base_versions: t.Dict[PypiVer, str],
                  versions_per_collection: t.Dict[str, t.Dict[PypiVer, str]],
-                 base_collector: AnsibleBaseChangelogCollector,
+                 base_collector: AnsibleCoreChangelogCollector,
                  ansible_changelog: ChangelogData,
                  collectors: t.List[CollectionChangelogCollector]):
         self.version = version
@@ -424,7 +424,7 @@ class Changelog:
     ansible_version: PypiVer
     ansible_ancestor_version: t.Optional[PypiVer]
     entries: t.List[ChangelogEntry]
-    base_collector: AnsibleBaseChangelogCollector
+    base_collector: AnsibleCoreChangelogCollector
     ansible_changelog: ChangelogData
     collection_collectors: t.List[CollectionChangelogCollector]
     collection_metadata: CollectionsMetadata
@@ -433,7 +433,7 @@ class Changelog:
                  ansible_version: PypiVer,
                  ansible_ancestor_version: t.Optional[PypiVer],
                  entries: t.List[ChangelogEntry],
-                 base_collector: AnsibleBaseChangelogCollector,
+                 base_collector: AnsibleCoreChangelogCollector,
                  ansible_changelog: ChangelogData,
                  collection_collectors: t.List[CollectionChangelogCollector],
                  collection_metadata: CollectionsMetadata):
@@ -487,7 +487,7 @@ def get_changelog(
         for collection_name, collection_version in deps.deps.items():
             versions_per_collection[collection_name][version] = collection_version
 
-    base_collector = AnsibleBaseChangelogCollector(base_versions.values())
+    base_collector = AnsibleCoreChangelogCollector(base_versions.values())
     collectors = [
         CollectionChangelogCollector(collection, versions_per_collection[collection].values())
         for collection in sorted(versions_per_collection.keys())

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -33,7 +33,7 @@ from .galaxy import CollectionDownloader
 
 class ChangelogData:
     '''
-    Data for a single changelog (for a collection, for ansible-base, for Ansible)
+    Data for a single changelog (for a collection, for ansible-core, for Ansible)
     '''
 
     paths: PathsConfig

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -26,7 +26,7 @@ from antsibull_changelog.changelog_generator import ChangelogGenerator
 from antsibull_changelog.utils import collect_versions
 
 from . import app_context
-from .ansible_base import get_ansible_base
+from .ansible_core import get_ansible_core
 from .dependency_files import DepsFile, DependencyFileData
 from .galaxy import CollectionDownloader
 
@@ -297,7 +297,7 @@ async def collect_changelogs(collectors: t.List[CollectionChangelogCollector],
                                                   collection_cache=collection_cache)
 
                 async def base_downloader(version):
-                    return await get_ansible_base(aio_session, version, tmp_dir)
+                    return await get_ansible_core(aio_session, version, tmp_dir)
 
                 requestors = [
                     await pool.spawn(collector.download(downloader)) for collector in collectors

--- a/src/antsibull/cli/antsibull_build.py
+++ b/src/antsibull/cli/antsibull_build.py
@@ -231,7 +231,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
 
     new_parser = subparsers.add_parser('new-ansible', parents=[build_write_data_parser],
                                        description='Generate a new build description from the'
-                                       ' latest available versions of ansible-base and the'
+                                       ' latest available versions of ansible-core and the'
                                        ' included collections')
     new_parser.add_argument('--pieces-file', default=None,
                             help='File containing a list of collections to include.  This is'

--- a/src/antsibull/cli/antsibull_docs.py
+++ b/src/antsibull/cli/antsibull_docs.py
@@ -324,10 +324,10 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
 
     if '--ansible-base-cache' in args:
         flog.warning('The CLI parameter, `--ansible-base-cache` has been renamed to'
-                     ' `--ansible-core-source.  Please use that instead')
+                     ' `--ansible-core-source`.  Please use that instead')
     if '--ansible-base-source' in args:
         flog.warning('The CLI parameter, `--ansible-base-source` has been renamed to'
-                     ' `--ansible-core-source.  Please use that instead')
+                     ' `--ansible-core-source`.  Please use that instead')
 
     if '--skip-indexes' in args:
         flog.warning('The CLI parameter, `--skip-indexes` has been renamed to'

--- a/src/antsibull/cli/antsibull_docs.py
+++ b/src/antsibull/cli/antsibull_docs.py
@@ -174,8 +174,10 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
 
     cache_parser = argparse.ArgumentParser(add_help=False)
     # TODO: Remove --ansible-base-cache once the ansible/ansible docs-build test is updated
-    cache_parser.add_argument('--ansible-base-source', '--ansible-base-cache', default=None,
-                              help='Checkout or expanded tarball of the ansible-base package.  If'
+    # TODO: Eventually remove --ansible-base-source
+    cache_parser.add_argument('--ansible-core-source', '--ansible-base-source',
+                              '--ansible-base-cache', default=None,
+                              help='Checkout or expanded tarball of the ansible-core package.  If'
                               ' this is a git checkout it must be the HEAD of the branch you are'
                               ' building for. If it is an expanded tarball, the __version__ will'
                               ' be checked to make sure it is compatible with and the same or'
@@ -322,7 +324,10 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
 
     if '--ansible-base-cache' in args:
         flog.warning('The CLI parameter, `--ansible-base-cache` has been renamed to'
-                     ' `--ansible-base-source.  Please use that instead')
+                     ' `--ansible-core-source.  Please use that instead')
+    if '--ansible-base-source' in args:
+        flog.warning('The CLI parameter, `--ansible-base-source` has been renamed to'
+                     ' `--ansible-core-source.  Please use that instead')
 
     if '--skip-indexes' in args:
         flog.warning('The CLI parameter, `--skip-indexes` has been renamed to'

--- a/src/antsibull/cli/antsibull_docs.py
+++ b/src/antsibull/cli/antsibull_docs.py
@@ -399,7 +399,7 @@ def main() -> int:
         :0: Success
         :1: Unhandled error.  See the Traceback for more information.
         :2: There was a problem with the command line arguments
-        :3: Unexpected problem downloading ansible-base
+        :3: Unexpected problem downloading ansible-core
     """
     return run(sys.argv)
 

--- a/src/antsibull/cli/doc_commands/devel.py
+++ b/src/antsibull/cli/doc_commands/devel.py
@@ -13,7 +13,7 @@ import asyncio_pool
 
 from .stable import generate_docs_for_all_collections
 from ... import app_context
-from ...ansible_base import get_ansible_base
+from ...ansible_core import get_ansible_core
 from ...collections import install_together
 from ...compat import asyncio_run
 from ...dependency_files import parse_pieces_file
@@ -57,7 +57,7 @@ async def retrieve(collections: t.List[str],
     async with aiohttp.ClientSession() as aio_session:
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
             requestors['_ansible_base'] = await pool.spawn(
-                get_ansible_base(aio_session, '@devel', tmp_dir,
+                get_ansible_core(aio_session, '@devel', tmp_dir,
                                  ansible_base_source=ansible_base_source))
 
             downloader = CollectionDownloader(aio_session, collection_dir,

--- a/src/antsibull/cli/doc_commands/devel.py
+++ b/src/antsibull/cli/doc_commands/devel.py
@@ -99,7 +99,7 @@ def generate_docs() -> int:
     flog.debug('Finished parsing deps file')
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        # Retrieve ansible-base and the collections
+        # Retrieve ansible-core and the collections
         flog.fields(tmp_dir=tmp_dir).info('created tmpdir')
         collection_tarballs = asyncio_run(
             retrieve(collections, tmp_dir,

--- a/src/antsibull/cli/doc_commands/stable.py
+++ b/src/antsibull/cli/doc_commands/stable.py
@@ -16,7 +16,7 @@ import asyncio_pool
 from pydantic import ValidationError
 
 from ... import app_context
-from ...ansible_base import get_ansible_base
+from ...ansible_core import get_ansible_core
 from ...augment_docs import augment_docs
 from ...collections import install_together
 from ...compat import asyncio_run, best_get_loop
@@ -85,7 +85,7 @@ async def retrieve(ansible_base_version: str,
     async with aiohttp.ClientSession() as aio_session:
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
             requestors['_ansible_base'] = await pool.spawn(
-                get_ansible_base(aio_session, ansible_base_version, tmp_dir,
+                get_ansible_core(aio_session, ansible_base_version, tmp_dir,
                                  ansible_base_source=ansible_base_source))
 
             downloader = CollectionDownloader(aio_session, collection_dir,

--- a/src/antsibull/cli/doc_commands/stable.py
+++ b/src/antsibull/cli/doc_commands/stable.py
@@ -63,7 +63,7 @@ async def retrieve(ansible_base_version: str,
     """
     Download ansible-core and the collections.
 
-    :arg ansible_base_version: Version of ansible-base/-core to download.
+    :arg ansible_base_version: Version of ansible-core to download.
     :arg collections: Map of collection names to collection versions to download.
     :arg tmp_dir: The directory to download into.
     :arg galaxy_server: URL to the galaxy server.
@@ -273,7 +273,7 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
     """
     Create documentation for a set of installed collections.
 
-    :arg venv: The venv in which ansible-base is installed.
+    :arg venv: The venv in which ansible-core is installed.
     :arg collection_dir: The directory in which the collections have been installed.
                          If ``None``, the collections are assumed to be in the current
                          search path for Ansible.
@@ -384,7 +384,7 @@ def generate_docs() -> int:
     flog.debug('Finished parsing deps file')
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        # Retrieve ansible-base and the collections
+        # Retrieve ansible-core and the collections
         flog.fields(tmp_dir=tmp_dir).info('created tmpdir')
         collection_tarballs = asyncio_run(
             retrieve(ansible_base_version, collections, tmp_dir,

--- a/src/antsibull/cli/doc_commands/stable.py
+++ b/src/antsibull/cli/doc_commands/stable.py
@@ -54,27 +54,27 @@ mlog = log.fields(mod=__name__)
 PluginErrorsRT = t.DefaultDict[str, t.DefaultDict[str, t.List[str]]]
 
 
-async def retrieve(ansible_base_version: str,
+async def retrieve(ansible_core_version: str,
                    collections: t.Mapping[str, str],
                    tmp_dir: str,
                    galaxy_server: str,
-                   ansible_base_source: t.Optional[str] = None,
+                   ansible_core_source: t.Optional[str] = None,
                    collection_cache: t.Optional[str] = None) -> t.Dict[str, 'semver.Version']:
     """
     Download ansible-core and the collections.
 
-    :arg ansible_base_version: Version of ansible-core to download.
+    :arg ansible_core_version: Version of ansible-core to download.
     :arg collections: Map of collection names to collection versions to download.
     :arg tmp_dir: The directory to download into.
     :arg galaxy_server: URL to the galaxy server.
-    :kwarg ansible_base_source: If given, a path to an ansible-core checkout or expanded sdist.
+    :kwarg ansible_core_source: If given, a path to an ansible-core checkout or expanded sdist.
         This will be used instead of downloading an ansible-core package if the version matches
-        with ``ansible_base_version``.
+        with ``ansible_core_version``.
     :kwarg collection_cache: If given, a path to a directory containing collection tarballs.
         These tarballs will be used instead of downloading new tarballs provided that the
         versions match the criteria (latest compatible version known to galaxy).
     :returns: Map of collection name to directory it is in.  ansible-core will
-        use the special key, `_ansible_base`.
+        use the special key, `_ansible_core`.
     """
     collection_dir = os.path.join(tmp_dir, 'collections')
     os.mkdir(collection_dir, mode=0o700)
@@ -84,9 +84,9 @@ async def retrieve(ansible_base_version: str,
     lib_ctx = app_context.lib_ctx.get()
     async with aiohttp.ClientSession() as aio_session:
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
-            requestors['_ansible_base'] = await pool.spawn(
-                get_ansible_core(aio_session, ansible_base_version, tmp_dir,
-                                 ansible_base_source=ansible_base_source))
+            requestors['_ansible_core'] = await pool.spawn(
+                get_ansible_core(aio_session, ansible_core_version, tmp_dir,
+                                 ansible_core_source=ansible_core_source))
 
             downloader = CollectionDownloader(aio_session, collection_dir,
                                               galaxy_server=galaxy_server,
@@ -380,27 +380,27 @@ def generate_docs() -> int:
     # Parse the deps file
     flog.fields(deps_file=app_ctx.extra['deps_file']).info('Parse deps file')
     deps_file = DepsFile(app_ctx.extra['deps_file'])
-    dummy_, ansible_base_version, collections = deps_file.parse()
+    dummy_, ansible_core_version, collections = deps_file.parse()
     flog.debug('Finished parsing deps file')
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         # Retrieve ansible-core and the collections
         flog.fields(tmp_dir=tmp_dir).info('created tmpdir')
         collection_tarballs = asyncio_run(
-            retrieve(ansible_base_version, collections, tmp_dir,
+            retrieve(ansible_core_version, collections, tmp_dir,
                      galaxy_server=app_ctx.galaxy_url,
-                     ansible_base_source=app_ctx.extra['ansible_base_source'],
+                     ansible_core_source=app_ctx.extra['ansible_base_source'],
                      collection_cache=app_ctx.extra['collection_cache']))
         # flog.fields(tarballs=collection_tarballs).debug('Download complete')
         flog.notice('Finished retrieving tarballs')
 
         # Get the ansible-core location
         try:
-            ansible_base_path = collection_tarballs.pop('_ansible_base')
+            ansible_core_path = collection_tarballs.pop('_ansible_core')
         except KeyError:
             print('ansible-core did not download successfully')
             return 3
-        flog.fields(ansible_base_path=ansible_base_path).info('ansible-core location')
+        flog.fields(ansible_core_path=ansible_core_path).info('ansible-core location')
 
         # Install the collections to a directory
 
@@ -418,7 +418,7 @@ def generate_docs() -> int:
 
         # Create venv for ansible-core
         venv = VenvRunner('ansible-core-venv', tmp_dir)
-        venv.install_package(ansible_base_path)
+        venv.install_package(ansible_core_path)
         flog.fields(venv=venv).notice('Finished installing ansible-core')
 
         generate_docs_for_all_collections(venv, collection_dir, app_ctx.extra['dest_dir'],

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -176,7 +176,7 @@ setup(
     packages=['ansible_collections'],
     include_package_data=True,
     install_requires=[
-        '{{ ansible_core_package_name }} ~= {{ ansible_base_version }}',{{ collection_deps }}
+        '{{ ansible_core_package_name }} ~= {{ ansible_core_version }}',{{ collection_deps }}
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/src/antsibull/data/docsite/plugin-redirect.rst.j2
+++ b/src/antsibull/data/docsite/plugin-redirect.rst.j2
@@ -15,7 +15,7 @@
 
 {% if collection == 'ansible.builtin' -%}
 .. note::
-    This redirect is part of ``ansible-base`` and included in all Ansible
+    This redirect is part of ``ansible-core`` and included in all Ansible
     installations. In most cases, you can use the short module name
     @{ plugin_name.rsplit('.', 1)[-1] }@ even without specifying the ``collections:`` keyword.
     Despite that, we recommend you use the FQCN for easy linking to the module

--- a/src/antsibull/data/docsite/plugin-tombstone.rst.j2
+++ b/src/antsibull/data/docsite/plugin-tombstone.rst.j2
@@ -15,7 +15,7 @@
 
 {% if collection == 'ansible.builtin' -%}
 .. note::
-    This module was part of ``ansible-base`` and was included in all Ansible installations.
+    This module was part of ``ansible-core`` and was included in all Ansible installations.
 {% else %}
 .. note::
     This plugin was part of the `@{collection}@ collection <https://galaxy.ansible.com/@{collection | replace('.', '/', 1)}@>`_{% if collection_version %} (version @{ collection_version }@){% endif %}.

--- a/src/antsibull/dependency_files.py
+++ b/src/antsibull/dependency_files.py
@@ -15,8 +15,9 @@ don't want to install backwards incompatible collections until the next major An
 
 from typing import TYPE_CHECKING, Dict, List, Mapping, NamedTuple, Optional
 
+from packaging.version import Version as PypiVer
+
 if TYPE_CHECKING:
-    from packaging.version import Version as PypiVer
     from semantic_version import Version as SemVer
 
 
@@ -128,7 +129,7 @@ class DepsFile:
 
         with open(self.filename, 'w') as f:
             f.write(f'_ansible_version: {ansible_version}\n')
-            if ansible_version.major > 5:
+            if PypiVer(ansible_version).major > 5:
                 f.write(f'_ansible_core_version: {ansible_core_version}\n')
             else:
                 f.write(f'_ansible_base_version: {ansible_core_version}\n')

--- a/src/antsibull/dependency_files.py
+++ b/src/antsibull/dependency_files.py
@@ -91,7 +91,7 @@ class DepsFile:
         _ansible_version: X1.Y1.Z1
         _ansible_base_version: X2.Y2.Z2
 
-    These are, respectively, the ansible version that was built and the ansible-base version which
+    These are, respectively, the ansible version that was built and the ansible-core version which
     it was built against.  Note that the ansible release will depend on a compatible version of that
     ansible base version, not an exact dependency on that precise version.
     """

--- a/src/antsibull/docs_parsing/ansible_doc.py
+++ b/src/antsibull/docs_parsing/ansible_doc.py
@@ -69,7 +69,7 @@ def _process_plugin_results(plugin_type: str,
 
         stdout = ansible_doc_results.stdout.decode('utf-8', errors='surrogateescape')
 
-        # ansible-doc returns plugins shipped with ansible-base using no namespace and collection.
+        # ansible-doc returns plugins shipped with ansible-core using no namespace and collection.
         # For now, we fix these entries to use the ansible.builtin collection here.  The reason we
         # do it here instead of as part of a general normalization step is that other plugins
         # (site-specific ones from ANSIBLE_LIBRARY, for instance) will also be returned with no
@@ -114,7 +114,7 @@ async def _get_plugin_info(plugin_type: str, ansible_doc: 'sh.Command',
 
                 plugin_name:  # This is the canonical name for the plugin and includes
                               # namespace.collection_name unless the plugin comes from
-                              # ansible-base.
+                              # ansible-core.
                     {information from ansible-doc --json.  See the ansible-doc documentation for
                      more info.}
     :kwarg max_workers: The maximum number of threads that should be run in parallel by this

--- a/src/antsibull/docs_parsing/routing.py
+++ b/src/antsibull/docs_parsing/routing.py
@@ -218,7 +218,7 @@ async def load_collection_routing(collection_name: str,
         }
 
     if collection_name == 'ansible.builtin':
-        # ansible-base/-core has a special directory structure we currently do not want
+        # ansible-core has a special directory structure we currently do not want
         # (or need) to handle
         return plugin_routing_out
 

--- a/src/antsibull/new_ansible.py
+++ b/src/antsibull/new_ansible.py
@@ -23,7 +23,7 @@ def display_exception(loop, context):
 
 async def get_version_info(collections, pypi_server_url):
     """
-    Return the versions of all the collections and ansible-base/ansible-core
+    Return the versions of all the collections and ansible-core
     """
     loop = asyncio.get_running_loop()
     loop.set_exception_handler(display_exception)
@@ -55,7 +55,7 @@ def version_is_compatible(ansible_base_version, collection, version):
 
 
 def find_latest_compatible(ansible_base_version, raw_dependency_versions):
-    # Note: ansible-base compatibility is not currently implemented.  It will be a piece of
+    # Note: ansible-core compatibility is not currently implemented.  It will be a piece of
     # collection metadata that is present in the collection but may not be present in galaxy.  We'll
     # have to figure that out once the pieces are finalized
 

--- a/src/antsibull/new_ansible.py
+++ b/src/antsibull/new_ansible.py
@@ -11,7 +11,7 @@ import asyncio_pool
 import semantic_version as semver
 
 from . import app_context
-from .ansible_base import AnsibleBasePyPiClient
+from .ansible_core import AnsibleBasePyPiClient
 from .changelog import ChangelogData
 from .dependency_files import BuildFile, parse_pieces_file
 from .galaxy import GalaxyClient

--- a/src/antsibull/new_ansible.py
+++ b/src/antsibull/new_ansible.py
@@ -11,7 +11,7 @@ import asyncio_pool
 import semantic_version as semver
 
 from . import app_context
-from .ansible_core import AnsibleBasePyPiClient
+from .ansible_core import AnsibleCorePyPiClient
 from .changelog import ChangelogData
 from .dependency_files import BuildFile, parse_pieces_file
 from .galaxy import GalaxyClient
@@ -32,7 +32,7 @@ async def get_version_info(collections, pypi_server_url):
     async with aiohttp.ClientSession() as aio_session:
         lib_ctx = app_context.lib_ctx.get()
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
-            pypi_client = AnsibleBasePyPiClient(aio_session, pypi_server_url=pypi_server_url)
+            pypi_client = AnsibleCorePyPiClient(aio_session, pypi_server_url=pypi_server_url)
             requestors['_ansible_core'] = await pool.spawn(pypi_client.get_versions())
             galaxy_client = GalaxyClient(aio_session)
 

--- a/src/antsibull/tarball.py
+++ b/src/antsibull/tarball.py
@@ -2,7 +2,7 @@
 # Author: Toshio Kuratomi <tkuratom@redhat.com>
 # License: GPLv3+
 # Copyright: Ansible Project, 2020
-"""Functions for working with the ansible-base package."""
+"""Functions for working with tarballs."""
 import re
 
 import sh

--- a/tests/functional/test_dependency_files.py
+++ b/tests/functional/test_dependency_files.py
@@ -16,11 +16,24 @@ SIMPLE_TEST_DEPS = {'community.general': SemVer('1.0.0'),
                     'community.routeros': SemVer('2.0.0-a2'),
                     }
 
-@pytest.mark.parametrize('dependencies, file_contents', ((SIMPLE_TEST_DEPS, SIMPLE_TEST_FILE),))
-def test_build_file_write(tmpdir, dependencies, file_contents):
+SIMPLE_TEST_FILE_2 = """_ansible_version: 6
+_ansible_core_version: 2.13.0rc1
+community.general: >=1.0.0,<2.0.0
+community.routeros: >=2.0.0-a2,<3.0.0
+"""
+
+SIMPLE_TEST_DEPS_2 = {'community.general': SemVer('1.0.0'),
+                    'community.routeros': SemVer('2.0.0-a2'),
+                    }
+
+@pytest.mark.parametrize('ansible_ver, core_ver, dependencies, file_contents', (
+    ('4.0.0', '2.11.0rc1', SIMPLE_TEST_DEPS, SIMPLE_TEST_FILE),
+    ('6.0.0', '2.13.0rc1', SIMPLE_TEST_DEPS_2, SIMPLE_TEST_FILE_2),
+))
+def test_build_file_write(tmpdir, ansible_ver, core_ver, dependencies, file_contents):
     filename = tmpdir / 'test.build'
     bf = BuildFile(filename)
-    bf.write(PypiVer('4.0.0'), '2.11.0rc1', dependencies)
+    bf.write(PypiVer(ansible_ver), core_ver, dependencies)
 
     with open(filename) as f:
         assert f.read() == file_contents

--- a/tests/units/test_ansible_base.py
+++ b/tests/units/test_ansible_base.py
@@ -1,18 +1,18 @@
 from packaging.version import  Version
 import pytest
 
-import antsibull.ansible_base as ab
+import antsibull.ansible_core as ac
 
 
 @pytest.mark. parametrize('version', ('2.9', '2.9.10', '1.0', '1', '0.7', '2.10', '2.10.0',
                                       '2.10.8', '2.10.12'))
 def test_get_core_package_name_returns_ansible_base(version):
-    assert ab.get_ansible_core_package_name(version) == 'ansible-base'
-    assert ab.get_ansible_core_package_name(Version(version)) == 'ansible-base'
+    assert ac.get_ansible_core_package_name(version) == 'ansible-base'
+    assert ac.get_ansible_core_package_name(Version(version)) == 'ansible-base'
 
 
 @pytest.mark.parametrize('version', ('2.11', '2.11.0', '2.11.8', '2.11.12', '2.13',
                                      '2.11.0a1', '3', '3.7.10'))
 def test_get_core_package_name_returns_ansible_core(version):
-    assert ab.get_ansible_core_package_name(version) == 'ansible-core'
-    assert ab.get_ansible_core_package_name(Version(version)) == 'ansible-core'
+    assert ac.get_ansible_core_package_name(version) == 'ansible-core'
+    assert ac.get_ansible_core_package_name(Version(version)) == 'ansible-core'

--- a/tests/units/test_parse_pieces.py
+++ b/tests/units/test_parse_pieces.py
@@ -28,8 +28,29 @@ dellemc.os10: 1.0.2
 """
 
 PARSED_DEPS_ANSIBLE_VERSION = '2.10.5'
-PARSED_DEPS_ANSIBLE_BASE_VERSION = '2.10.4'
+PARSED_DEPS_ANSIBLE_CORE_VERSION = '2.10.4'
 PARSED_DEPS_DEPS = {
+    'ansible.netcommon': '1.4.1',
+    'ansible.posix': '1.1.1',
+    'ansible.windows': '1.3.0',
+    'dellemc.os10': '1.0.2'
+}
+
+DEPS_2 = """
+_ansible_version: 2.10.5
+# this is a comment
+_ansible_base_version: 2.10.4
+    # supported by ansible
+    ansible.netcommon: 1.4.1
+    ansible.posix: 1.1.1
+    ansible.windows: 1.3.0
+# third parties
+dellemc.os10: 1.0.2
+"""
+
+PARSED_DEPS_2_ANSIBLE_VERSION = '2.10.5'
+PARSED_DEPS_2_ANSIBLE_CORE_VERSION = '2.10.4'
+PARSED_DEPS_2_DEPS = {
     'ansible.netcommon': '1.4.1',
     'ansible.posix': '1.1.1',
     'ansible.windows': '1.3.0',
@@ -49,8 +70,29 @@ dellemc.os10: >=1.0.0,<1.1.0
 """
 
 PARSED_BUILD_ANSIBLE_VERSION = '2.10'
-PARSED_BUILD_ANSIBLE_BASE_VERSION = '2.10.1'
+PARSED_BUILD_ANSIBLE_CORE_VERSION = '2.10.1'
 PARSED_BUILD_DEPS = {
+    'ansible.netcommon': '>=1.2.0,<2.0.0',
+    'ansible.posix': '>=1.1.0,<2.0.0',
+    'ansible.windows': '>=1.0.0,<2.0.0',
+    'dellemc.os10': '>=1.0.0,<1.1.0'
+}
+
+BUILD_2 = """
+_ansible_version: 2.10
+# this is a comment
+_ansible_base_version: 2.10.1
+    # supported by ansible
+    ansible.netcommon: >=1.2.0,<2.0.0
+    ansible.posix: >=1.1.0,<2.0.0
+    ansible.windows: >=1.0.0,<2.0.0
+# third parties
+dellemc.os10: >=1.0.0,<1.1.0
+"""
+
+PARSED_BUILD_2_ANSIBLE_VERSION = '2.10'
+PARSED_BUILD_2_ANSIBLE_CORE_VERSION = '2.10.1'
+PARSED_BUILD_2_DEPS = {
     'ansible.netcommon': '>=1.2.0,<2.0.0',
     'ansible.posix': '>=1.1.0,<2.0.0',
     'ansible.windows': '>=1.0.0,<2.0.0',
@@ -69,8 +111,17 @@ def test_deps_file_parse(tmp_path):
         f.write(DEPS)
     parsed_deps = df.DepsFile(deps_filename).parse()
     assert parsed_deps.ansible_version == PARSED_DEPS_ANSIBLE_VERSION
-    assert parsed_deps.ansible_base_version == PARSED_DEPS_ANSIBLE_BASE_VERSION
+    assert parsed_deps.ansible_core_version == PARSED_DEPS_ANSIBLE_CORE_VERSION
     assert parsed_deps.deps == PARSED_DEPS_DEPS
+
+def test_deps_file_2_parse(tmp_path):
+    deps_filename = tmp_path / 'deps.in'
+    with open(deps_filename, 'w') as f:
+        f.write(DEPS_2)
+    parsed_deps = df.DepsFile(deps_filename).parse()
+    assert parsed_deps.ansible_version == PARSED_DEPS_2_ANSIBLE_VERSION
+    assert parsed_deps.ansible_core_version == PARSED_DEPS_2_ANSIBLE_CORE_VERSION
+    assert parsed_deps.deps == PARSED_DEPS_2_DEPS
 
 def test_build_file_parse(tmp_path):
     build_filename = tmp_path / 'build.in'
@@ -78,5 +129,14 @@ def test_build_file_parse(tmp_path):
         f.write(BUILD)
     parsed_build = df.DepsFile(build_filename).parse()
     assert parsed_build.ansible_version == PARSED_BUILD_ANSIBLE_VERSION
-    assert parsed_build.ansible_base_version == PARSED_BUILD_ANSIBLE_BASE_VERSION
+    assert parsed_build.ansible_core_version == PARSED_BUILD_ANSIBLE_CORE_VERSION
     assert parsed_build.deps == PARSED_BUILD_DEPS
+
+def test_build_file_2_parse(tmp_path):
+    build_filename = tmp_path / 'build.in'
+    with open(build_filename, 'w') as f:
+        f.write(BUILD_2)
+    parsed_build = df.DepsFile(build_filename).parse()
+    assert parsed_build.ansible_version == PARSED_BUILD_2_ANSIBLE_VERSION
+    assert parsed_build.ansible_core_version == PARSED_BUILD_2_ANSIBLE_CORE_VERSION
+    assert parsed_build.deps == PARSED_BUILD_2_DEPS

--- a/tests/units/test_parse_pieces.py
+++ b/tests/units/test_parse_pieces.py
@@ -39,7 +39,7 @@ PARSED_DEPS_DEPS = {
 DEPS_2 = """
 _ansible_version: 2.10.5
 # this is a comment
-_ansible_base_version: 2.10.4
+_ansible_core_version: 2.10.4
     # supported by ansible
     ansible.netcommon: 1.4.1
     ansible.posix: 1.1.1
@@ -81,7 +81,7 @@ PARSED_BUILD_DEPS = {
 BUILD_2 = """
 _ansible_version: 2.10
 # this is a comment
-_ansible_base_version: 2.10.1
+_ansible_core_version: 2.10.1
     # supported by ansible
     ansible.netcommon: >=1.2.0,<2.0.0
     ansible.posix: >=1.1.0,<2.0.0


### PR DESCRIPTION
It's time to update the code to stop mentioning ansible-base whereever possible.

This deprecates the `--ansible-base-source` option to antsibull-docs, and renames it to `--ansible-core-source`. It also accepts the `_ansible_core_version` key next to `_ansible_base_version` for .deps and .build files, and starts writing `_ansible_core_version` for Ansible 6.