### PR TITLE
Fix more doc build errors

### DIFF
--- a/src/antsibull/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull/data/docsite/macros/parameters.rst.j2
@@ -93,9 +93,9 @@
 {%         set choice = 'no' %}
 {%       endif %}
 {%       if (value['default'] is not list and value['default'] == choice) or (value['default'] is list and choice in value['default']) %}
-      - :ansible-option-default-bold:`@{ choice | rst_escape }@` :ansible-option-default:`← (default)`
+      - :ansible-option-default-bold:`@{ choice | rst_escape(escape_ending_whitespace=true) }@` :ansible-option-default:`← (default)`
 {%       else %}
-      - :ansible-option-choices-entry:`@{ choice | rst_escape }@`
+      - :ansible-option-choices-entry:`@{ choice | rst_escape(escape_ending_whitespace=true) }@`
 {%       endif %}
 {%     endfor %}
 {%   endif %}
@@ -104,7 +104,7 @@
 
       .. rst-class:: ansible-option-line
 
-      :ansible-option-default-bold:`Default:` :ansible-option-default:`@{ value['default'] | tojson | rst_escape | indent(6) }@`
+      :ansible-option-default-bold:`Default:` :ansible-option-default:`@{ value['default'] | tojson | rst_escape(escape_ending_whitespace=true) | indent(6) }@`
 {%   endif %}
 {#   configuration #}
 {%   if plugin_type != 'module' and plugin_type != 'role' and (value['ini'] or value['env'] or value['vars'] or value['cli']) %}

--- a/src/antsibull/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull/data/docsite/macros/parameters.rst.j2
@@ -1,6 +1,6 @@
 {% from 'macros/deprecates.rst.j2' import in_rst as deprecates %}
 
-{% macro in_rst(elements, plugin_name, plugin_type, suboption_key='suboptions') %}
+{% macro in_rst(elements, plugin_name, plugin_type, suboption_key='suboptions', parameter_html_prefix='', parameter_rst_prefix='') %}
 .. rst-class:: ansible-option-table
 
 .. list-table::
@@ -17,11 +17,11 @@
 
         {% for i in range(1, loop.depth) %}<div class="ansible-option-indent"></div>{% endfor %}<div class="ansible-option-cell">
 {% for full_key in value['full_keys'] %}
-        <div class="ansibleOptionAnchor" id="parameter-{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
+        <div class="ansibleOptionAnchor" id="parameter-@{ parameter_html_prefix }@{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {% endfor %}
 
 {% for full_key in value['full_keys'] %}
-      .. _ansible_collections.@{plugin_name}@_@{plugin_type}@__parameter-{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}:
+      .. _ansible_collections.@{plugin_name}@_@{plugin_type}@__parameter-@{ parameter_rst_prefix }@{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}:
 {% endfor %}
 
       .. rst-class:: ansible-option-title
@@ -30,7 +30,7 @@
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#parameter-{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
+        <a class="ansibleOptionLink" href="#parameter-@{ parameter_html_prefix }@{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
 {%   if value['aliases'] %}
 
       .. rst-class:: ansible-option-type-line

--- a/src/antsibull/data/docsite/role.rst.j2
+++ b/src/antsibull/data/docsite/role.rst.j2
@@ -123,7 +123,7 @@ The below requirements are needed on the remote host and/or the local controller
 Parameters
 ^^^^^^^^^^
 
-@{     parameters(ep_doc['options'], plugin_type, plugin_name, suboption_key='options') }@
+@{     parameters(ep_doc['options'], plugin_type, plugin_name, suboption_key='options', parameter_html_prefix=entry_point ~ '--', parameter_rst_prefix=entry_point ~ '__') }@
 {%   endif %}
 
 .. Notes

--- a/src/antsibull/jinja2/filters.py
+++ b/src/antsibull/jinja2/filters.py
@@ -78,11 +78,11 @@ def do_max(seq):
 # for further information.
 
 def _rst_ify_italic(m):
-    return f"\\ :emphasis:`{rst_escape(m.group(1))}`\\ "
+    return f"\\ :emphasis:`{rst_escape(m.group(1), escape_ending_whitespace=True)}`\\ "
 
 
 def _rst_ify_bold(m):
-    return f"\\ :strong:`{rst_escape(m.group(1))}`\\ "
+    return f"\\ :strong:`{rst_escape(m.group(1), escape_ending_whitespace=True)}`\\ "
 
 
 def _rst_ify_module(m):
@@ -110,7 +110,7 @@ def _rst_ify_ref(m):
 
 def _rst_ify_const(m):
     # Escaping does not work in double backticks, so we use the :literal: role instead
-    return f"\\ :literal:`{rst_escape(m.group(1))}`\\ "
+    return f"\\ :literal:`{rst_escape(m.group(1), escape_ending_whitespace=True)}`\\ "
 
 
 def rst_ify(text):
@@ -134,7 +134,7 @@ def rst_ify(text):
     return text
 
 
-def rst_escape(value):
+def rst_escape(value, escape_ending_whitespace=False):
     ''' make sure value is converted to a string, and RST special characters are escaped '''
 
     if not isinstance(value, str):
@@ -146,6 +146,9 @@ def rst_escape(value):
     value = value.replace('_', '\\_')
     value = value.replace('*', '\\*')
     value = value.replace('`', '\\`')
+
+    if escape_ending_whitespace and value.endswith(' '):
+        value = value[:-1] + ' \\ '
 
     return value
 


### PR DESCRIPTION
* When using the `:literal:` role (and similar ones), the last character before the trailing backtick must not be a space; and if it is a space, it needs to be escaped.
* References to role parameters were not unique. Making them unique by inserting the role's entry point name in them.