### PR TITLE
Even more docs improvements

### DIFF
--- a/src/antsibull/data/sphinx_init/build_sh.j2
+++ b/src/antsibull/data/sphinx_init/build_sh.j2
@@ -30,7 +30,7 @@ antsibull-docs collection \
 {% endif %}
 
 # Copy collection documentation into source directory
-rsync -avc --delete-after temp-rst/collections/ rst/collections/
+rsync -cprv --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
 {% if lenient %}

--- a/src/antsibull/jinja2/filters.py
+++ b/src/antsibull/jinja2/filters.py
@@ -148,7 +148,9 @@ def rst_escape(value, escape_ending_whitespace=False):
     value = value.replace('`', '\\`')
 
     if escape_ending_whitespace and value.endswith(' '):
-        value = value[:-1] + ' \\ '
+        value = value + '\\ '
+    if escape_ending_whitespace and value.startswith(' '):
+        value = '\\ ' + value
 
     return value
 


### PR DESCRIPTION
- When the string in `:literal:` (and other roles) starts with a space, we need to insert `\ ` at the beginning of the content.
- The rsync flags in the build.sh script created by `antsibull-docs sphinx-init` modify timestamps, and cause sphinx's change detection to determine that everything needs to be rebuilt. Replacing `-a` by `-pr` improves this situation.