### PR TITLE
Fix variable names

### DIFF
--- a/src/antsibull/cli/doc_commands/devel.py
+++ b/src/antsibull/cli/doc_commands/devel.py
@@ -104,7 +104,7 @@ def generate_docs() -> int:
         collection_tarballs = asyncio_run(
             retrieve(collections, tmp_dir,
                      galaxy_server=app_ctx.galaxy_url,
-                     ansible_core_source=app_ctx.extra['ansible_base_source'],
+                     ansible_core_source=app_ctx.extra['ansible_core_source'],
                      collection_cache=app_ctx.extra['collection_cache']))
         # flog.fields(tarballs=collection_tarballs).debug('Download complete')
         flog.notice('Finished retrieving tarballs')

--- a/src/antsibull/cli/doc_commands/stable.py
+++ b/src/antsibull/cli/doc_commands/stable.py
@@ -389,7 +389,7 @@ def generate_docs() -> int:
         collection_tarballs = asyncio_run(
             retrieve(ansible_core_version, collections, tmp_dir,
                      galaxy_server=app_ctx.galaxy_url,
-                     ansible_core_source=app_ctx.extra['ansible_base_source'],
+                     ansible_core_source=app_ctx.extra['ansible_core_source'],
                      collection_cache=app_ctx.extra['collection_cache']))
         # flog.fields(tarballs=collection_tarballs).debug('Download complete')
         flog.notice('Finished retrieving tarballs')


### PR DESCRIPTION
This was missing in #353.

I guess we need a better test coverage for the `stable` and `devel` antsibull-docs subcommands, probably with some specially prepared `ansible-build-data` (so we don't build the whole docsite).