### PR TITLE
Allow to use HTML blobs for option and result value tables

### DIFF
--- a/.github/workflows/build-simple-docsite.yml
+++ b/.github/workflows/build-simple-docsite.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    name: 'Build simple docsite (extra options: ${{ options }})'
+    name: 'Build simple docsite (extra options: ${{ matrix.options }})'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,7 +35,7 @@ jobs:
 
       - name: Use antsibull-docs sphinx-init
         run: |
-          coverage run -p --source src/antsibull -m antsibull.cli.antsibull_docs sphinx-init --use-current --lenient --dest-dir . ${{ options }}
+          coverage run -p --source src/antsibull -m antsibull.cli.antsibull_docs sphinx-init --use-current --lenient --dest-dir . ${{ matrix.options }}
 
       - name: Patch build.sh to supply code coverage
         run: |

--- a/.github/workflows/build-simple-docsite.yml
+++ b/.github/workflows/build-simple-docsite.yml
@@ -13,7 +13,13 @@ on:
 
 jobs:
   build:
+    name: Build simple docsite (extra options: ${{ options }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        options:
+          - ''
+          - '--use-html-blobs --no-breadcrumbs --no-indexes'
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +35,7 @@ jobs:
 
       - name: Use antsibull-docs sphinx-init
         run: |
-          coverage run -p --source src/antsibull -m antsibull.cli.antsibull_docs sphinx-init --use-current --lenient --dest-dir .
+          coverage run -p --source src/antsibull -m antsibull.cli.antsibull_docs sphinx-init --use-current --lenient --dest-dir . ${{ options }}
 
       - name: Patch build.sh to supply code coverage
         run: |

--- a/.github/workflows/build-simple-docsite.yml
+++ b/.github/workflows/build-simple-docsite.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    name: Build simple docsite (extra options: ${{ options }})
+    name: 'Build simple docsite (extra options: ${{ options }})'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -1,6 +1,6 @@
 ansible_base_url = https://github.com/ansible/ansible/
 breadcrumbs = True
-use_html_blobs = True
+use_html_blobs = False
 doc_parsing_backend = ansible-internal
 chunksize = 4096
 galaxy_url = https://galaxy.ansible.com/

--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -1,5 +1,6 @@
 ansible_base_url = https://github.com/ansible/ansible/
 breadcrumbs = True
+use_html_blobs = True
 doc_parsing_backend = ansible-internal
 chunksize = 4096
 galaxy_url = https://galaxy.ansible.com/

--- a/src/antsibull/app_context.py
+++ b/src/antsibull/app_context.py
@@ -68,7 +68,7 @@ if sys.version_info < (3, 7):
 
 #: Field names in the args and config whose value will be added to the app_ctx
 _FIELDS_IN_APP_CTX = frozenset(('ansible_base_url', 'breadcrumbs', 'galaxy_url', 'indexes',
-                                'logging_cfg', 'pypi_url'))
+                                'logging_cfg', 'pypi_url', 'use_html_blobs'))
 
 #: Field names in the args and config whose value will be added to the lib_ctx
 _FIELDS_IN_LIB_CTX = frozenset(

--- a/src/antsibull/cli/antsibull_docs.py
+++ b/src/antsibull/cli/antsibull_docs.py
@@ -307,7 +307,8 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     # Create a Sphinx site template
     #
     sphinx_init_parser = subparsers.add_parser('sphinx-init',
-                                               parents=[docs_parser],
+                                               parents=[docs_parser, template_parser,
+                                                        whole_site_parser],
                                                description='Generate a Sphinx site template for a'
                                                ' collection docsite')
 

--- a/src/antsibull/cli/antsibull_docs.py
+++ b/src/antsibull/cli/antsibull_docs.py
@@ -180,7 +180,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                  help='Determines whether to use HTML blobs for option and return'
                                  ' value tables. Using HTML blobs reduces memory and CPU time'
                                  ' usage significantly so you can disable this if necessary.'
-                                 ' (default: True)')
+                                 ' (default: False)')
 
     cache_parser = argparse.ArgumentParser(add_help=False)
     # TODO: Remove --ansible-base-cache once the ansible/ansible docs-build test is updated

--- a/src/antsibull/cli/doc_commands/collection.py
+++ b/src/antsibull/cli/doc_commands/collection.py
@@ -24,7 +24,8 @@ def generate_current_docs(indexes: bool, squash_hierarchy: bool) -> int:
         venv, None, app_ctx.extra['dest_dir'], app_ctx.extra['collections'],
         create_indexes=indexes and not squash_hierarchy,
         squash_hierarchy=squash_hierarchy,
-        breadcrumbs=app_ctx.breadcrumbs)
+        breadcrumbs=app_ctx.breadcrumbs,
+        use_html_blobs=app_ctx.use_html_blobs)
 
     return 0
 

--- a/src/antsibull/cli/doc_commands/current.py
+++ b/src/antsibull/cli/doc_commands/current.py
@@ -31,6 +31,7 @@ def generate_docs() -> int:
 
     generate_docs_for_all_collections(
         venv, app_ctx.extra['collection_dir'], app_ctx.extra['dest_dir'],
-        breadcrumbs=app_ctx.breadcrumbs)
+        breadcrumbs=app_ctx.breadcrumbs,
+        use_html_blobs=app_ctx.use_html_blobs)
 
     return 0

--- a/src/antsibull/cli/doc_commands/devel.py
+++ b/src/antsibull/cli/doc_commands/devel.py
@@ -137,6 +137,7 @@ def generate_docs() -> int:
         flog.fields(venv=venv).notice('Finished installing ansible-core')
 
         generate_docs_for_all_collections(venv, collection_dir, app_ctx.extra['dest_dir'],
-                                          breadcrumbs=app_ctx.breadcrumbs)
+                                          breadcrumbs=app_ctx.breadcrumbs,
+                                          use_html_blobs=app_ctx.use_html_blobs)
 
     return 0

--- a/src/antsibull/cli/doc_commands/plugin.py
+++ b/src/antsibull/cli/doc_commands/plugin.py
@@ -106,7 +106,8 @@ def generate_docs() -> int:
     asyncio_run(write_plugin_rst(
         '.'.join([namespace, collection]), AnsibleCollectionMetadata.empty(), plugin, plugin_type,
         plugin_info, errors, plugin_tmpl, error_tmpl, '',
-        path_override=output_path))
+        path_override=output_path,
+        use_html_blobs=app_ctx.use_html_blobs))
     flog.debug('Finished writing plugin docs')
 
     return 0

--- a/src/antsibull/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull/cli/doc_commands/sphinx_init.py
@@ -60,9 +60,9 @@ def site_init() -> int:
     use_current = app_ctx.extra['use_current']
     squash_hierarchy = app_ctx.extra['squash_hierarchy']
     lenient = app_ctx.extra['lenient']
-    use_html_blobs = app_ctx.extra['use_html_blobs']
-    breadcrumbs = app_ctx.extra['breadcrumbs']
-    indexes = app_ctx.extra['indexes']
+    use_html_blobs = app_ctx.use_html_blobs
+    breadcrumbs = app_ctx.breadcrumbs
+    indexes = app_ctx.indexes
 
     env = doc_environment(('antsibull.data', 'sphinx_init'))
 

--- a/src/antsibull/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull/cli/doc_commands/sphinx_init.py
@@ -60,6 +60,9 @@ def site_init() -> int:
     use_current = app_ctx.extra['use_current']
     squash_hierarchy = app_ctx.extra['squash_hierarchy']
     lenient = app_ctx.extra['lenient']
+    use_html_blobs = app_ctx.extra['use_html_blobs']
+    breadcrumbs = app_ctx.extra['breadcrumbs']
+    indexes = app_ctx.extra['indexes']
 
     env = doc_environment(('antsibull.data', 'sphinx_init'))
 
@@ -74,6 +77,9 @@ def site_init() -> int:
             squash_hierarchy=squash_hierarchy,
             collections=collections,
             lenient=lenient,
+            use_html_blobs=use_html_blobs,
+            breadcrumbs=breadcrumbs,
+            indexes=indexes,
         ) + '\n'
 
         destination = os.path.join(dest_dir, filename)

--- a/src/antsibull/cli/doc_commands/stable.py
+++ b/src/antsibull/cli/doc_commands/stable.py
@@ -269,7 +269,8 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
                                       collection_names: t.Optional[t.List[str]] = None,
                                       create_indexes: bool = True,
                                       squash_hierarchy: bool = False,
-                                      breadcrumbs: bool = True) -> None:
+                                      breadcrumbs: bool = True,
+                                      use_html_blobs: bool = False) -> None:
     """
     Create documentation for a set of installed collections.
 
@@ -287,6 +288,8 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
                              created.
     :kwarg breadcrumbs: Default True.  Set to False if breadcrumbs for collections should be
         disabled.  This will disable breadcrumbs but save on memory usage.
+    :kwarg use_html_blobs: Default False.  Set to True if HTML blobs should be used instead of
+        RST tables for parameter and return value tables.
     """
     flog = mlog.fields(func='generate_docs_for_all_collections')
     flog.notice('Begin')
@@ -353,7 +356,8 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
     asyncio_run(output_all_plugin_rst(collection_to_plugin_info, plugin_info,
                                       nonfatal_errors, dest_dir,
                                       collection_metadata=collection_metadata,
-                                      squash_hierarchy=squash_hierarchy))
+                                      squash_hierarchy=squash_hierarchy,
+                                      use_html_blobs=use_html_blobs))
     flog.debug('Finished writing plugin docs')
 
     asyncio_run(output_extra_docs(dest_dir, extra_docs_data,
@@ -422,6 +426,7 @@ def generate_docs() -> int:
         flog.fields(venv=venv).notice('Finished installing ansible-core')
 
         generate_docs_for_all_collections(venv, collection_dir, app_ctx.extra['dest_dir'],
-                                          breadcrumbs=app_ctx.breadcrumbs)
+                                          breadcrumbs=app_ctx.breadcrumbs,
+                                          use_html_blobs=app_ctx.use_html_blobs)
 
     return 0

--- a/src/antsibull/data/docsite/macros/deprecates.rst.j2
+++ b/src/antsibull/data/docsite/macros/deprecates.rst.j2
@@ -20,3 +20,23 @@ Removed in: a future release
 
 {%   endif %}
 {% endmacro %}
+
+
+{% macro in_html(data, collection) %}
+{%   if data %}
+  <p>
+{%-    if data['removed_at_date'] -%}
+Removed in: major release after @{ data['removed_at_date'] | html_ify }@
+{%-    elif data['removed_in'] -%}
+Removed in: version @{ data['removed_in'] | html_ify }@
+{%-    else -%}
+Removed in: a future release
+{%-    endif -%}
+{%-    if data['removed_from_collection'] and data['removed_from_collection'] != collection %}
+ of @{ data['removed_from_collection'] | html_ify }@
+{%-    endif -%}
+  </p>
+  <p>@{ 'Why: ' ~ data['why'] | html_ify | indent(2) }@</p>
+  <p>@{ 'Alternative: ' ~ data['alternative'] | html_ify | indent(2) }@</p>
+{%   endif %}
+{% endmacro %}

--- a/src/antsibull/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull/data/docsite/macros/parameters.rst.j2
@@ -106,7 +106,7 @@
 
       :ansible-option-default-bold:`Default:` :ansible-option-default:`@{ value['default'] | tojson | rst_escape(escape_ending_whitespace=true) | indent(6) }@`
 {%   endif %}
-{#   configuration #}
+{#   Configuration #}
 {%   if plugin_type != 'module' and plugin_type != 'role' and (value['ini'] or value['env'] or value['vars'] or value['cli']) %}
 
       .. rst-class:: ansible-option-line
@@ -158,7 +158,7 @@
 
         </div>
 {%   if value[suboption_key] %}
-    @{ loop(value[suboption_key]|dictsort) }@
+    @{ loop(value[suboption_key] | dictsort) }@
 {%   endif %}
 {% endfor %}
 {% endmacro %}

--- a/src/antsibull/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull/data/docsite/macros/parameters.rst.j2
@@ -1,4 +1,5 @@
 {% from 'macros/deprecates.rst.j2' import in_rst as deprecates_rst %}
+{% from 'macros/deprecates.rst.j2' import in_html as deprecates_html %}
 
 {% macro in_rst(elements, plugin_name, plugin_type, suboption_key='suboptions', parameter_html_prefix='', parameter_rst_prefix='') %}
 .. rst-class:: ansible-option-table
@@ -161,4 +162,141 @@
     @{ loop(value[suboption_key] | dictsort) }@
 {%   endif %}
 {% endfor %}
+{% endmacro %}
+
+{##################################################################################################################}
+
+{% macro in_html(elements, plugin_name, plugin_type, suboption_key='suboptions', parameter_html_prefix='', parameter_rst_prefix='') %}
+.. raw:: html
+
+  <table class="colwidths-auto ansible-option-table docutils align-default" style="width: 100%">
+  <thead>
+  <tr class="row-odd">
+    <th class="head"><p>Parameter</p></th>
+    <th class="head"><p>Comments</p></th>
+  </tr>
+  </thead>
+  <tbody>
+{% set row_class = cycler('even', 'odd') %}
+{% for key, value in elements | dictsort recursive %}
+{#   parameter name with required and/or introduced label #}
+  <tr class="row-@{ row_class.next() }@">
+    <td>{% for i in range(1, loop.depth) %}<div class="ansible-option-indent"></div>{% endfor %}<div class="ansible-option-cell">
+{%   for full_key in value['full_keys'] %}
+      <div class="ansibleOptionAnchor" id="parameter-@{ parameter_html_prefix }@{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
+{%   endfor %}
+      <p class="ansible-option-title"><strong>@{ key | escape }@</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-@{ parameter_html_prefix }@{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
+{%   if value['aliases'] %}
+      <p class="ansible-option-type-line"><span class="ansible-option-aliases">aliases: @{ value['aliases']|join(', ') }@</p>
+{%   endif %}
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">@{ value['type'] | documented_type }@</span>
+{%   if value['type'] == 'list' and value['elements'] is not none %}
+        / <span class="ansible-option-elements">elements=@{ value['elements'] | documented_type }@</span>
+{%   endif %}
+{%   if value['required'] %}
+        / <span class="ansible-option-required">required</span>
+{%   endif %}
+      </p>
+{%   if value['version_added'] is still_relevant %}
+      <p><span class="ansible-option-versionadded">added in @{value['version_added']}@ of @{ value['version_added_collection'] | escape }@</span></p>
+{%   endif %}
+{%   if plugin_type != 'module' %}
+@{     deprecates_html(value['deprecated'], collection) }@
+{%   endif %}
+    </div></td>
+{#   description #}
+    <td>{% for i in range(1, loop.depth) %}<div class="ansible-option-indent-desc"></div>{% endfor %}<div class="ansible-option-cell">
+{%   for desc in value['description'] %}
+      <p>@{ desc | html_ify | indent(6) }@</p>
+{%   endfor %}
+{#   default / choices #}
+{#   Turn boolean values in 'yes' and 'no' values #}
+{%   if value['default'] is sameas true %}
+{%     set _x = value.update({'default': 'yes'}) %}
+{%   elif value['default'] is not none and value['default'] is sameas false %}
+{%     set _x = value.update({'default': 'no'}) %}
+{%   endif %}
+{%   if value['type'] == 'bool' %}
+{%     set _x = value.update({'choices': ['no', 'yes']}) %}
+{%   endif %}
+{#   Show possible choices and highlight details #}
+{%   if value['choices'] %}
+      <p class="ansible-option-line"><span class="ansible-option-choices">Choices:</span></p>
+      <ul class="simple">
+{%     for choice in value['choices'] %}
+{#       Turn boolean values in 'yes' and 'no' values #}
+{%       if choice is sameas true %}
+{%         set choice = 'yes' %}
+{%       elif choice is sameas false %}
+{%         set choice = 'no' %}
+{%       endif %}
+{%       if (value['default'] is not list and value['default'] == choice) or (value['default'] is list and choice in value['default']) %}
+        <li><p><span class="ansible-option-default-bold">@{ choice | escape }@</span> <span class="ansible-option-default">← (default)</span></p></li>
+{%       else %}
+        <li><p><span class="ansible-option-choices-entry">@{ choice | escape }@</span></p></li>
+{%       endif %}
+{%     endfor %}
+      </ul>
+{%   endif %}
+{#   Show default value, when multiple choice or no choices #}
+{%   if value['default'] is not none and value['default'] not in value['choices'] %}
+      <p class="ansible-option-line"><span class="ansible-option-default-bold">Default:</span> <span class="ansible-option-default">@{ value['default'] | tojson | escape | indent(6) }@</span></p>
+{%   endif %}
+{#   Configuration #}
+{%   if plugin_type != 'module' and plugin_type != 'role' and (value['ini'] or value['env'] or value['vars'] or value['cli']) %}
+      <p class="ansible-option-line"><span class="ansible-option-configuration">Configuration:</span></p>
+      <ul class="simple">
+{%     if value['ini'] %}
+      <li>
+        <p>INI {% if value['ini'] | length == 1 %}entry{% else %}entries{% endif %}</p>
+{%       for ini in value['ini'] %}
+        <div class="highlight-YAML+Jinja notranslate"><div class="highlight"><pre><span class="p p-Indicator">[</span><span class="nv">@{ ini['section'] | escape }@</span><span class="p p-Indicator">]</span>
+  <span class="l l-Scalar l-Scalar-Plain">@{ ini['key'] | escape }@ = @{ value['default'] | default('VALUE') | escape }@</span></pre></div></div>
+{%         if ini['version_added'] is still_relevant %}
+        <p><span class="ansible-option-versionadded">added in @{ini['version_added']}@ of @{ ini['version_added_collection'] | html_ify }@</span></p>
+{%         endif %}
+@{         deprecates_html(ini['deprecated'], collection) }@
+{%       endfor %}
+      </li>
+{%     endif %}
+{%     for env in value['env'] %}
+      <li>
+        <p>Environment variable: @{ env['name'] | escape }@</p>
+{%       if env['version_added'] is still_relevant %}
+        <p><span class="ansible-option-versionadded">added in @{env['version_added']}@ of @{ env['version_added_collection'] | html_ify }@</span></p>
+{%       endif %}
+@{       deprecates_html(env['deprecated'], collection) }@
+      </li>
+{%     endfor %}
+{%     for myvar in value['vars'] %}
+      <li>
+        <p>Variable: @{ myvar['name'] | escape }@</p>
+{%       if myvar['version_added'] is still_relevant %}
+        <p><span class="ansible-option-versionadded">added in @{myvar['version_added']}@ of @{ myvar['version_added_collection'] | html_ify }@</span></p>
+{%       endif %}
+@{       deprecates_html(myvar['deprecated'], collection) }@
+      </li>
+{%     endfor %}
+{%     for mycli in value['cli'] %}
+      <li>
+        <p>CLI argument: @{ mycli['option'] | escape }@</p>
+{%       if mycli['version_added'] is still_relevant %}
+        <p><span class="ansible-option-versionadded">added in @{mycli['version_added']}@ of @{ mycli['version_added_collection'] | html_ify }@</span></p>
+{%       endif %}
+@{       deprecates_html(mycli['deprecated'], collection) }@
+      </li>
+{%     endfor %}
+      </ul>
+{%   endif %}
+    </div></td>
+  </tr>
+{%   if value[suboption_key] %}
+@{     loop(value[suboption_key] | dictsort) }@
+{%   endif %}
+{% endfor %}
+  </tbody>
+  </table>
+
 {% endmacro %}

--- a/src/antsibull/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull/data/docsite/macros/parameters.rst.j2
@@ -1,4 +1,4 @@
-{% from 'macros/deprecates.rst.j2' import in_rst as deprecates %}
+{% from 'macros/deprecates.rst.j2' import in_rst as deprecates_rst %}
 
 {% macro in_rst(elements, plugin_name, plugin_type, suboption_key='suboptions', parameter_html_prefix='', parameter_rst_prefix='') %}
 .. rst-class:: ansible-option-table
@@ -51,7 +51,7 @@
 {%-   if plugin_type != 'module' %}
 
 
-@{     deprecates(value['deprecated'], collection, 6) }@
+@{     deprecates_rst(value['deprecated'], collection, 6) }@
 {%   endif %}
 
 
@@ -125,7 +125,7 @@
 {%         if ini['version_added'] is still_relevant %}
         :ansible-option-versionadded:`added in @{ini['version_added']}@ of @{ ini['version_added_collection'] | rst_ify }@`
 {%         endif %}
-@{         deprecates(ini['deprecated'], collection, 8) }@
+@{         deprecates_rst(ini['deprecated'], collection, 8) }@
 {%       endfor %}
 {%     endif %}
 {%     for env in value['env'] %}
@@ -134,7 +134,7 @@
 
         :ansible-option-versionadded:`added in @{env['version_added']}@ of @{ env['version_added_collection'] | rst_ify }@`
 {%       endif %}
-@{       deprecates(env['deprecated'], collection, 8) }@
+@{       deprecates_rst(env['deprecated'], collection, 8) }@
 {%     endfor %}
 {%     for myvar in value['vars'] %}
       - Variable: @{ myvar['name'] | rst_escape }@
@@ -142,7 +142,7 @@
 
         :ansible-option-versionadded:`added in @{myvar['version_added']}@ of @{ myvar['version_added_collection'] | rst_ify }@`
 {%       endif %}
-@{       deprecates(myvar['deprecated'], collection, 8) }@
+@{       deprecates_rst(myvar['deprecated'], collection, 8) }@
 {%     endfor %}
 {%     for mycli in value['cli'] %}
       - CLI argument: @{ mycli['option'] | rst_escape }@
@@ -150,7 +150,7 @@
 
         :ansible-option-versionadded:`added in @{mycli['version_added']}@ of @{ mycli['version_added_collection'] | rst_ify }@`
 {%       endif %}
-@{       deprecates(mycli['deprecated'], collection, 8) }@
+@{       deprecates_rst(mycli['deprecated'], collection, 8) }@
 {%     endfor %}
 {%   endif %}
 

--- a/src/antsibull/data/docsite/macros/returnvalues.rst.j2
+++ b/src/antsibull/data/docsite/macros/returnvalues.rst.j2
@@ -88,3 +88,77 @@
 {%   endif %}
 {% endfor %}
 {% endmacro %}
+
+{##################################################################################################################}
+
+{% macro in_html(elements, plugin_name, plugin_type) %}
+.. raw:: html
+
+  <table class="colwidths-auto ansible-option-table docutils align-default" style="width: 100%">
+  <thead>
+  <tr class="row-odd">
+    <th class="head"><p>Key</p></th>
+    <th class="head"><p>Description</p></th>
+  </tr>
+  </thead>
+  <tbody>
+{% set row_class = cycler('even', 'odd') %}
+{% for key, value in elements | dictsort recursive %}
+{#   return value name #}
+  <tr class="row-@{ row_class.next() }@">
+    <td>{% for i in range(1, loop.depth) %}<div class="ansible-option-indent"></div>{% endfor %}<div class="ansible-option-cell">
+{%   for full_key in value['full_keys'] %}
+      <div class="ansibleOptionAnchor" id="return-{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
+{%   endfor %}
+      <p class="ansible-option-title"><strong>@{ key | escape }@</strong></p>
+      <a class="ansibleOptionLink" href="#return-{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">@{ value['type'] | documented_type }@</span>
+{%   if value['type'] == 'list' and value['elements'] is not none %}
+        / <span class="ansible-option-elements">elements=@{ value['elements'] | documented_type }@</span>
+{%   endif %}
+      </p>
+{%   if value['version_added'] is still_relevant %}
+      <p><span class="ansible-option-versionadded">added in @{value['version_added']}@ of @{ value['version_added_collection'] | escape }@</span></p>
+{%   endif %}
+    </div></td>
+{#   description #}
+    <td>{% for i in range(1, loop.depth) %}<div class="ansible-option-indent-desc"></div>{% endfor %}<div class="ansible-option-cell">
+{%   for desc in value['description'] %}
+      <p>@{ desc | html_ify | indent(6) }@</p>
+{%   endfor %}
+{%   if value['returned'] %}
+      <p class="ansible-option-line"><span class="ansible-option-returned-bold">Returned:</span> @{ value['returned'] | html_ify | indent(6) }@</p>
+{%   endif %}
+{#   Show possible choices and highlight details #}
+{%   if value['choices'] %}
+      <p class="ansible-option-line"><span class="ansible-option-choices">Can only return:</span></p>
+      <ul class="simple">
+{%     for choice in value['choices'] %}
+{#       Turn boolean values in 'yes' and 'no' values #}
+{%       if choice is sameas true %}
+{%         set choice = 'yes' %}
+{%       elif choice is sameas false %}
+{%         set choice = 'no' %}
+{%       endif %}
+{%       if (value['default'] is not list and value['default'] == choice) or (value['default'] is list and choice in value['default']) %}
+        <li><p><span class="ansible-option-default-bold">@{ choice | escape }@</span> <span class="ansible-option-default">← (default)</span></p></li>
+{%       else %}
+        <li><p><span class="ansible-option-choices-entry">@{ choice | escape }@</span></p></li>
+{%       endif %}
+{%     endfor %}
+      </ul>
+{%   endif %}
+{%   if value['sample'] is not none %}
+      <p class="ansible-option-line ansible-option-sample"><span class="ansible-option-sample-bold">Sample:</span> @{ value['sample'] | tojson | escape | indent(6) }@</p>
+{%   endif %}
+    </div></td>
+  </tr>
+{%   if value['contains'] %}
+@{     loop(value['contains'] | dictsort) }@
+{%   endif %}
+{% endfor %}
+  </tbody>
+  </table>
+
+{% endmacro %}

--- a/src/antsibull/data/docsite/macros/returnvalues.rst.j2
+++ b/src/antsibull/data/docsite/macros/returnvalues.rst.j2
@@ -9,7 +9,7 @@
   * - Key
     - Description
 {% for key, value in elements | dictsort recursive %}
-{#   parameter name with required and/or introduced label #}
+{#   return value name #}
 
   * - .. raw:: html
 
@@ -37,7 +37,7 @@
 {%-   if value['version_added'] is still_relevant %}
 
 
-      :ansible-option-versionadded:`added in @{value['version_added']}@ of @{ value['version_added_collection'] | escape }@`
+      :ansible-option-versionadded:`added in @{value['version_added']}@ of @{ value['version_added_collection'] | rst_escape }@`
 {%   endif %}
 {#   description #}
 

--- a/src/antsibull/data/docsite/plugin.rst.j2
+++ b/src/antsibull/data/docsite/plugin.rst.j2
@@ -1,5 +1,5 @@
-{% from 'macros/parameters.rst.j2' import in_rst as parameters %}
-{% from 'macros/returnvalues.rst.j2' import in_rst as return_docs %}
+{% from 'macros/parameters.rst.j2' import in_rst as parameters_rst %}
+{% from 'macros/returnvalues.rst.j2' import in_rst as return_docs_rst %}
 .. Document meta
 
 :orphan:
@@ -163,7 +163,7 @@ The below requirements are needed on the local controller node that executes thi
 Parameters
 ----------
 
-@{   parameters(doc['options'], plugin_type, plugin_name, suboption_key='suboptions') }@
+@{   parameters_rst(doc['options'], plugin_type, plugin_name, suboption_key='suboptions') }@
 {% endif %}
 
 .. Attributes
@@ -308,7 +308,7 @@ Returned Facts
 --------------
 Facts returned by this module are added/updated in the ``hostvars`` host facts and can be referenced by name just like any other host fact. They do not need to be registered in order to use them.
 
-@{   return_docs(returnfacts, plugin_name, plugin_type) }@
+@{   return_docs_rst(returnfacts, plugin_name, plugin_type) }@
 {% endif %}
 
 .. Return values
@@ -318,7 +318,7 @@ Return Values
 -------------
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this @{ plugin_type }@:
 
-@{   return_docs(returndocs, plugin_name, plugin_type) }@
+@{   return_docs_rst(returndocs, plugin_name, plugin_type) }@
 {% endif %}
 
 ..  Status (Presently only deprecated)

--- a/src/antsibull/data/docsite/plugin.rst.j2
+++ b/src/antsibull/data/docsite/plugin.rst.j2
@@ -1,5 +1,7 @@
 {% from 'macros/parameters.rst.j2' import in_rst as parameters_rst %}
+{% from 'macros/parameters.rst.j2' import in_html as parameters_html %}
 {% from 'macros/returnvalues.rst.j2' import in_rst as return_docs_rst %}
+{% from 'macros/returnvalues.rst.j2' import in_html as return_docs_html %}
 .. Document meta
 
 :orphan:
@@ -163,7 +165,11 @@ The below requirements are needed on the local controller node that executes thi
 Parameters
 ----------
 
-@{   parameters_rst(doc['options'], plugin_type, plugin_name, suboption_key='suboptions') }@
+{%   if use_html_blobs %}
+@{     parameters_html(doc['options'], plugin_type, plugin_name, suboption_key='suboptions') }@
+{%   else %}
+@{     parameters_rst(doc['options'], plugin_type, plugin_name, suboption_key='suboptions') }@
+{%   endif %}
 {% endif %}
 
 .. Attributes
@@ -308,7 +314,11 @@ Returned Facts
 --------------
 Facts returned by this module are added/updated in the ``hostvars`` host facts and can be referenced by name just like any other host fact. They do not need to be registered in order to use them.
 
-@{   return_docs_rst(returnfacts, plugin_name, plugin_type) }@
+{%   if use_html_blobs %}
+@{     return_docs_html(returnfacts, plugin_name, plugin_type) }@
+{%   else %}
+@{     return_docs_rst(returnfacts, plugin_name, plugin_type) }@
+{%   endif %}
 {% endif %}
 
 .. Return values
@@ -318,7 +328,11 @@ Return Values
 -------------
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this @{ plugin_type }@:
 
-@{   return_docs_rst(returndocs, plugin_name, plugin_type) }@
+{%   if use_html_blobs %}
+@{     return_docs_html(returndocs, plugin_name, plugin_type) }@
+{%   else %}
+@{     return_docs_rst(returndocs, plugin_name, plugin_type) }@
+{%   endif %}
 {% endif %}
 
 ..  Status (Presently only deprecated)

--- a/src/antsibull/data/docsite/role.rst.j2
+++ b/src/antsibull/data/docsite/role.rst.j2
@@ -1,4 +1,5 @@
 {% from 'macros/parameters.rst.j2' import in_rst as parameters_rst %}
+{% from 'macros/parameters.rst.j2' import in_html as parameters_html %}
 .. Document meta
 
 :orphan:
@@ -123,7 +124,11 @@ The below requirements are needed on the remote host and/or the local controller
 Parameters
 ^^^^^^^^^^
 
-@{     parameters_rst(ep_doc['options'], plugin_type, plugin_name, suboption_key='options', parameter_html_prefix=entry_point ~ '--', parameter_rst_prefix=entry_point ~ '__') }@
+{%     if use_html_blobs %}
+@{       parameters_html(ep_doc['options'], plugin_type, plugin_name, suboption_key='options', parameter_html_prefix=entry_point ~ '--', parameter_rst_prefix=entry_point ~ '__') }@
+{%     else %}
+@{       parameters_rst(ep_doc['options'], plugin_type, plugin_name, suboption_key='options', parameter_html_prefix=entry_point ~ '--', parameter_rst_prefix=entry_point ~ '__') }@
+{%     endif %}
 {%   endif %}
 
 .. Notes

--- a/src/antsibull/data/docsite/role.rst.j2
+++ b/src/antsibull/data/docsite/role.rst.j2
@@ -1,4 +1,4 @@
-{% from 'macros/parameters.rst.j2' import in_rst as parameters %}
+{% from 'macros/parameters.rst.j2' import in_rst as parameters_rst %}
 .. Document meta
 
 :orphan:
@@ -123,7 +123,7 @@ The below requirements are needed on the remote host and/or the local controller
 Parameters
 ^^^^^^^^^^
 
-@{     parameters(ep_doc['options'], plugin_type, plugin_name, suboption_key='options', parameter_html_prefix=entry_point ~ '--', parameter_rst_prefix=entry_point ~ '__') }@
+@{     parameters_rst(ep_doc['options'], plugin_type, plugin_name, suboption_key='options', parameter_html_prefix=entry_point ~ '--', parameter_rst_prefix=entry_point ~ '__') }@
 {%   endif %}
 
 .. Notes

--- a/src/antsibull/data/sphinx_init/build_sh.j2
+++ b/src/antsibull/data/sphinx_init/build_sh.j2
@@ -9,33 +9,33 @@ mkdir -p temp-rst
 {%   if collections | length > 0 %}
 antsibull-docs collection \
     --use-current \
-    --dest-dir temp-rst \
 {%     if squash_hierarchy %}
     --squash-hierarchy \
 {%     endif %}
+    --{% if not use_html_blobs %}no-{% endif %}use-html-blobs \
+    --{% if not breadcrumbs %}no-{% endif %}breadcrumbs \
+    --{% if not indexes %}no-{% endif %}indexes \
+    --dest-dir temp-rst \
     @{ ' '.join(collections) }@
 {%   else %}
-antsibull-docs current --dest-dir temp-rst
+antsibull-docs current \
+    --{% if not use_html_blobs %}no-{% endif %}use-html-blobs \
+    --{% if not breadcrumbs %}no-{% endif %}breadcrumbs \
+    --{% if not indexes %}no-{% endif %}indexes \
+    --dest-dir temp-rst
 {%   endif %}
 {% else %}
 antsibull-docs collection \
 {%     if collection_version != '@latest' %}
     --collection-version @{ collection_version }@ \
 {%     endif %}
-    --dest-dir temp-rst \
 {%     if squash_hierarchy %}
     --squash-hierarchy \
 {%     endif %}
-{%     if use_html_blobs %}
-    --use-html-blobs \
-{%     endif %}
-{%     if not breadcrumbs %}
-    --no-breadcrumbs \
-{%     endif %}
-{%     if not indexes %}
-    --no-indexes \
-{%     endif %}
-
+    --{% if not use_html_blobs %}no-{% endif %}use-html-blobs \
+    --{% if not breadcrumbs %}no-{% endif %}breadcrumbs \
+    --{% if not indexes %}no-{% endif %}indexes \
+    --dest-dir temp-rst \
     @{ ' '.join(collections) }@
 {% endif %}
 

--- a/src/antsibull/data/sphinx_init/build_sh.j2
+++ b/src/antsibull/data/sphinx_init/build_sh.j2
@@ -26,6 +26,16 @@ antsibull-docs collection \
 {%     if squash_hierarchy %}
     --squash-hierarchy \
 {%     endif %}
+{%     if use_html_blobs %}
+    --use-html-blobs \
+{%     endif %}
+{%     if not breadcrumbs %}
+    --no-breadcrumbs \
+{%     endif %}
+{%     if not indexes %}
+    --no-indexes \
+{%     endif %}
+
     @{ ' '.join(collections) }@
 {% endif %}
 

--- a/src/antsibull/jinja2/filters.py
+++ b/src/antsibull/jinja2/filters.py
@@ -42,7 +42,8 @@ def html_ify(text):
     text, _counts['url'] = _URL.subn(r"<a href='\1'>\1</a>", text)
     text, _counts['ref'] = _REF.subn(r"<span class='module'>\1</span>", text)
     text, _counts['link'] = _LINK.subn(r"<a href='\2'>\1</a>", text)
-    text, _counts['const'] = _CONST.subn(r"<code class='docutils literal notranslate'>\1</code>", text)
+    text, _counts['const'] = _CONST.subn(
+        r"<code class='docutils literal notranslate'>\1</code>", text)
     text, _counts['ruler'] = _RULER.subn(r"<hr/>", text)
 
     text = text.strip()

--- a/src/antsibull/jinja2/filters.py
+++ b/src/antsibull/jinja2/filters.py
@@ -42,7 +42,7 @@ def html_ify(text):
     text, _counts['url'] = _URL.subn(r"<a href='\1'>\1</a>", text)
     text, _counts['ref'] = _REF.subn(r"<span class='module'>\1</span>", text)
     text, _counts['link'] = _LINK.subn(r"<a href='\2'>\1</a>", text)
-    text, _counts['const'] = _CONST.subn(r"<code>\1</code>", text)
+    text, _counts['const'] = _CONST.subn(r"<code class='docutils literal notranslate'>\1</code>", text)
     text, _counts['ruler'] = _RULER.subn(r"<hr/>", text)
 
     text = text.strip()

--- a/src/antsibull/schemas/config.py
+++ b/src/antsibull/schemas/config.py
@@ -127,7 +127,7 @@ class ConfigModel(BaseModel):
     process_max: t.Optional[int] = None
     # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
     pypi_url: p.HttpUrl = 'https://pypi.org/'
-    use_html_blobs: p.StrictBool = True
+    use_html_blobs: p.StrictBool = False
     thread_max: int = 80
 
     _convert_nones = p.validator('process_max', pre=True, allow_reuse=True)(convert_none)

--- a/src/antsibull/schemas/config.py
+++ b/src/antsibull/schemas/config.py
@@ -127,8 +127,9 @@ class ConfigModel(BaseModel):
     process_max: t.Optional[int] = None
     # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
     pypi_url: p.HttpUrl = 'https://pypi.org/'
+    use_html_blobs: p.StrictBool = True
     thread_max: int = 80
 
     _convert_nones = p.validator('process_max', pre=True, allow_reuse=True)(convert_none)
-    _convert_bools = p.validator('breadcrumbs', 'indexes',
+    _convert_bools = p.validator('breadcrumbs', 'indexes', 'use_html_blobs',
                                  pre=True, allow_reuse=True)(convert_bool)

--- a/src/antsibull/schemas/context.py
+++ b/src/antsibull/schemas/context.py
@@ -48,6 +48,8 @@ class AppContext(BaseModel):
         schema's checking, normalization, and default setting.
     :ivar ansible_base_url: Url to the ansible-core git repo.
     :ivar breadcrumbs: If True, build with breadcrumbs on the plugin pages (this takes more memory).
+    :ivar use_html_blobs: If True, use HTML blobs instead of RST tables for option and return value
+        tables (this takes less memory).
     :ivar galaxy_url: URL of the galaxy server to get collection info from
     :ivar indexes: If True, create index pages for all collections and all plugins in a collection.
     :ivar logging_cfg: Configuration of the application logging
@@ -64,8 +66,9 @@ class AppContext(BaseModel):
     logging_cfg: LoggingModel = LoggingModel.parse_obj(DEFAULT_LOGGING_CONFIG)
     # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
     pypi_url: p.HttpUrl = 'https://pypi.org/'
+    use_html_blobs: p.StrictBool = True
 
-    _convert_bools = p.validator('breadcrumbs', 'indexes',
+    _convert_bools = p.validator('breadcrumbs', 'indexes', 'use_html_blobs',
                                  pre=True, allow_reuse=True)(convert_bool)
 
 

--- a/src/antsibull/schemas/context.py
+++ b/src/antsibull/schemas/context.py
@@ -66,7 +66,7 @@ class AppContext(BaseModel):
     logging_cfg: LoggingModel = LoggingModel.parse_obj(DEFAULT_LOGGING_CONFIG)
     # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
     pypi_url: p.HttpUrl = 'https://pypi.org/'
-    use_html_blobs: p.StrictBool = True
+    use_html_blobs: p.StrictBool = False
 
     _convert_bools = p.validator('breadcrumbs', 'indexes', 'use_html_blobs',
                                  pre=True, allow_reuse=True)(convert_bool)

--- a/src/antsibull/write_docs.py
+++ b/src/antsibull/write_docs.py
@@ -20,6 +20,9 @@ from .extra_docs import CollectionExtraDocsInfoT
 from .docs_parsing import AnsibleCollectionMetadata
 
 
+HTML_BLOBS = True
+
+
 mlog = log.fields(mod=__name__)
 
 #: Mapping of plugins to nonfatal errors.  This is the type to use when accepting the plugin.
@@ -120,6 +123,7 @@ async def write_plugin_rst(collection_name: str, collection_meta: AnsibleCollect
             plugin_contents = _render_template(
                 plugin_tmpl,
                 plugin_name + '_' + plugin_type,
+                use_html_blobs=HTML_BLOBS,
                 collection=collection_name,
                 collection_version=collection_meta.version,
                 plugin_type=plugin_type,
@@ -130,6 +134,7 @@ async def write_plugin_rst(collection_name: str, collection_meta: AnsibleCollect
             plugin_contents = _render_template(
                 plugin_tmpl,
                 plugin_name + '_' + plugin_type,
+                use_html_blobs=HTML_BLOBS,
                 collection=collection_name,
                 collection_version=collection_meta.version,
                 plugin_type=plugin_type,

--- a/src/antsibull/write_docs.py
+++ b/src/antsibull/write_docs.py
@@ -20,9 +20,6 @@ from .extra_docs import CollectionExtraDocsInfoT
 from .docs_parsing import AnsibleCollectionMetadata
 
 
-HTML_BLOBS = True
-
-
 mlog = log.fields(mod=__name__)
 
 #: Mapping of plugins to nonfatal errors.  This is the type to use when accepting the plugin.
@@ -72,7 +69,8 @@ async def write_plugin_rst(collection_name: str, collection_meta: AnsibleCollect
                            plugin_record: t.Dict[str, t.Any], nonfatal_errors: t.Sequence[str],
                            plugin_tmpl: Template, error_tmpl: Template, dest_dir: str,
                            path_override: t.Optional[str] = None,
-                           squash_hierarchy: bool = False) -> None:
+                           squash_hierarchy: bool = False,
+                           use_html_blobs: bool = False) -> None:
     """
     Write the rst page for one plugin.
 
@@ -92,6 +90,8 @@ async def write_plugin_rst(collection_name: str, collection_meta: AnsibleCollect
     :arg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
                            Undefined behavior if documentation for multiple collections are
                            created.
+    :arg use_html_blobs: If set to ``True``, will use HTML blobs for parameter and return value
+                         tables instead of using RST tables.
     """
     flog = mlog.fields(func='write_plugin_rst')
     flog.debug('Enter')
@@ -123,7 +123,7 @@ async def write_plugin_rst(collection_name: str, collection_meta: AnsibleCollect
             plugin_contents = _render_template(
                 plugin_tmpl,
                 plugin_name + '_' + plugin_type,
-                use_html_blobs=HTML_BLOBS,
+                use_html_blobs=use_html_blobs,
                 collection=collection_name,
                 collection_version=collection_meta.version,
                 plugin_type=plugin_type,
@@ -134,7 +134,7 @@ async def write_plugin_rst(collection_name: str, collection_meta: AnsibleCollect
             plugin_contents = _render_template(
                 plugin_tmpl,
                 plugin_name + '_' + plugin_type,
-                use_html_blobs=HTML_BLOBS,
+                use_html_blobs=use_html_blobs,
                 collection=collection_name,
                 collection_version=collection_meta.version,
                 plugin_type=plugin_type,
@@ -240,7 +240,8 @@ async def output_all_plugin_rst(collection_to_plugin_info: CollectionInfoT,
                                 nonfatal_errors: PluginErrorsT,
                                 dest_dir: str,
                                 collection_metadata: t.Mapping[str, AnsibleCollectionMetadata],
-                                squash_hierarchy: bool = False) -> None:
+                                squash_hierarchy: bool = False,
+                                use_html_blobs: bool = False) -> None:
     """
     Output rst files for each plugin.
 
@@ -254,6 +255,8 @@ async def output_all_plugin_rst(collection_to_plugin_info: CollectionInfoT,
     :arg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
                            Undefined behavior if documentation for multiple collections are
                            created.
+    :arg use_html_blobs: If set to ``True``, will use HTML blobs for parameter and return value
+                         tables instead of using RST tables.
     """
     # Setup the jinja environment
     env = doc_environment(('antsibull.data', 'docsite'))
@@ -279,7 +282,8 @@ async def output_all_plugin_rst(collection_to_plugin_info: CollectionInfoT,
                                          plugin_info[plugin_type].get(plugin_name),
                                          nonfatal_errors[plugin_type][plugin_name],
                                          plugin_type_tmpl, error_tmpl,
-                                         dest_dir, squash_hierarchy=squash_hierarchy)))
+                                         dest_dir, squash_hierarchy=squash_hierarchy,
+                                         use_html_blobs=use_html_blobs)))
 
         # Write docs for each plugin
         await asyncio.gather(*writers)


### PR DESCRIPTION
Instead of RST tables. But almost generates the same HTML as the RST tables do, so everything still looks like new and is responsive :)

The main downside of this is that `R(...)` does not work in those tables (i.e. as before).

The behavior can be turned off (similar to breadcrumbs).

See https://ansible.fontein.de/ for how the result looks.