### PR TITLE
Porting guide: mention new collections

### DIFF
--- a/src/antsibull/build_changelog.py
+++ b/src/antsibull/build_changelog.py
@@ -445,6 +445,10 @@ def append_porting_guide(builder: RstBuilder, changelog_entry: ChangelogEntry) -
     maybe_add_title = create_title_adder(
         builder, 'Porting Guide for v{0}'.format(changelog_entry.version_str), 0)
 
+    if changelog_entry.added_collections:
+        next(maybe_add_title)
+        append_added_collections(builder, changelog_entry)
+
     for section in ['known_issues', 'breaking_changes', 'major_changes']:
         append_porting_guide_section(builder, changelog_entry, maybe_add_title, section)
 

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -371,8 +371,7 @@ class ChangelogEntry:
             )
             if prev_version:
                 if not prev_collection_version:
-                    if prev_version != ancestor_version:
-                        self.added_collections.append((collector, collection_version))
+                    self.added_collections.append((collector, collection_version))
                 elif prev_collection_version == collection_version:
                     self.unchanged_collections.append((collector, collection_version))
                     continue


### PR DESCRIPTION
Fixes #361.

Also fixes a bug that new collections added in x.0.0 are not available in the data structure where they should be in.

The result can be seen in https://github.com/ansible-community/ansible-build-data/pull/95.