### PR TITLE
Mention the plugin type more prominently

### DIFF
--- a/changelogs/fragments/364-plugin-type.yml
+++ b/changelogs/fragments/364-plugin-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Mention the plugin type more prominently in the documentation (https://github.com/ansible-community/antsibull/pull/364)."

--- a/src/antsibull/data/docsite/plugin-deprecation.rst.j2
+++ b/src/antsibull/data/docsite/plugin-deprecation.rst.j2
@@ -14,5 +14,5 @@
 @{ title }@
 @{ '+' * title|length }@
 
-This is an alias for :ref:`@{ module }@ @{ plugin_type }@ <@{ module }@_@{ plugin_type }@>`.
+This is an alias for the :ref:`@{ module }@ @{ plugin_type }@ <@{ module }@_@{ plugin_type }@>`.
 This name has been **deprecated**. Please update your tasks to use the new name ``@{ module }@`` instead.

--- a/src/antsibull/data/docsite/plugin-deprecation.rst.j2
+++ b/src/antsibull/data/docsite/plugin-deprecation.rst.j2
@@ -6,13 +6,13 @@
 .. _@{ module }@_@{ plugin_type }@_alias_@{ alias }@:
 
 {% if short_description %}
-{%   set title = alias + ' -- ' + short_description | rst_ify %}
+{%   set title = alias ~ ' ' ~ plugin_type ~ ' -- ' ~ short_description | rst_ify %}
 {% else %}
-{%   set title = alias %}
+{%   set title = alias ~ ' ' ~ plugin_type %}
 {% endif %}
 
 @{ title }@
 @{ '+' * title|length }@
 
-This is an alias for :ref:`@{ module }@ <@{ module }@_@{ plugin_type }@>`.
+This is an alias for :ref:`@{ module }@ @{ plugin_type }@ <@{ module }@_@{ plugin_type }@>`.
 This name has been **deprecated**. Please update your tasks to use the new name ``@{ module }@`` instead.

--- a/src/antsibull/data/docsite/plugin-error.rst.j2
+++ b/src/antsibull/data/docsite/plugin-error.rst.j2
@@ -10,7 +10,7 @@
 
 .. Title
 
-{% set title = plugin_name -%}
+{% set title = plugin_name ~ ' ' ~ plugin_type -%}
 
 @{ title }@
 @{ '+' * title|length }@

--- a/src/antsibull/data/docsite/plugin-redirect.rst.j2
+++ b/src/antsibull/data/docsite/plugin-redirect.rst.j2
@@ -8,8 +8,10 @@
 
 .. Title
 
-@{ plugin_name }@
-@{ '+' * plugin_name|length }@
+{% set title = plugin_name ~ ' ' ~ plugin_type -%}
+
+@{ title }@
+@{ '+' * title|length }@
 
 .. Collection note
 

--- a/src/antsibull/data/docsite/plugin.rst.j2
+++ b/src/antsibull/data/docsite/plugin.rst.j2
@@ -275,10 +275,10 @@ See Also
 
 {% for item in doc['seealso'] %}
 {%   if item.module is defined and item.description %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@ module
+   @{ ('M(' + item['module'] + ')') | rst_ify }@
        @{ item['description'] | rst_ify }@
 {%   elif item.module is defined %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@ module
+   @{ ('M(' + item['module'] + ')') | rst_ify }@
       The official documentation on the **@{ item['module'] }@** module.
 {%   elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_

--- a/src/antsibull/data/docsite/plugin.rst.j2
+++ b/src/antsibull/data/docsite/plugin.rst.j2
@@ -58,9 +58,9 @@
 .. Title
 
 {% if doc['short_description'] -%}
-{%   set title = plugin_name + ' -- ' + doc['short_description'] | rst_ify -%}
+{%   set title = plugin_name ~ ' ' ~ plugin_type ~ ' -- ' ~ doc['short_description'] | rst_ify -%}
 {% else -%}
-{%   set title = plugin_name -%}
+{%   set title = plugin_name ~ ' ' ~ plugin_type -%}
 {% endif -%}
 
 @{ title }@
@@ -81,7 +81,7 @@
     the same {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} name.
 {% else %}
 .. note::
-    This plugin is part of the `@{collection}@ collection <https://galaxy.ansible.com/@{collection | replace('.', '/', 1)}@>`_{% if collection_version %} (version @{ collection_version }@){% endif %}.
+    This {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} is part of the `@{collection}@ collection <https://galaxy.ansible.com/@{collection | replace('.', '/', 1)}@>`_{% if collection_version %} (version @{ collection_version }@){% endif %}.
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.
@@ -275,10 +275,10 @@ See Also
 
 {% for item in doc['seealso'] %}
 {%   if item.module is defined and item.description %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@
+   @{ ('M(' + item['module'] + ')') | rst_ify }@ module
        @{ item['description'] | rst_ify }@
 {%   elif item.module is defined %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@
+   @{ ('M(' + item['module'] + ')') | rst_ify }@ module
       The official documentation on the **@{ item['module'] }@** module.
 {%   elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_

--- a/src/antsibull/data/docsite/plugins_by_collection.rst.j2
+++ b/src/antsibull/data/docsite/plugins_by_collection.rst.j2
@@ -4,7 +4,7 @@
 
 {% macro list_plugins(plugin_type) %}
 {%   for name, desc in plugin_maps[plugin_type].items() | sort %}
-* :ref:`@{ name }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ plugin_type }@>` -- @{ desc | rst_ify | indent(width=2) }@
+* :ref:`@{ name }@ @{ plugin_type }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ plugin_type }@>` -- @{ desc | rst_ify | indent(width=2) }@
 {%   endfor %}
 {% endmacro %}
 

--- a/src/antsibull/data/docsite/role.rst.j2
+++ b/src/antsibull/data/docsite/role.rst.j2
@@ -33,9 +33,9 @@
 .. Title
 
 {% if entry_points.main and entry_points.main.short_description -%}
-{%   set title = plugin_name + ' -- ' + entry_points.main.short_description | rst_ify -%}
+{%   set title = plugin_name ~ ' ' ~ plugin_type ~ ' -- ' ~ entry_points.main.short_description | rst_ify -%}
 {% else -%}
-{%   set title = plugin_name -%}
+{%   set title = plugin_name ~ ' ' ~ plugin_type -%}
 {% endif -%}
 
 @{ title }@
@@ -153,10 +153,10 @@ See Also
 
 {%     for item in ep_doc['seealso'] %}
 {%       if item.module is defined and item.description %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@
+   @{ ('M(' + item['module'] + ')') | rst_ify }@ module
        @{ item['description'] | rst_ify }@
 {%       elif item.module is defined %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@
+   @{ ('M(' + item['module'] + ')') | rst_ify }@ module
       The official documentation on the **@{ item['module'] }@** module.
 {%       elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_

--- a/src/antsibull/data/docsite/role.rst.j2
+++ b/src/antsibull/data/docsite/role.rst.j2
@@ -153,10 +153,10 @@ See Also
 
 {%     for item in ep_doc['seealso'] %}
 {%       if item.module is defined and item.description %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@ module
+   @{ ('M(' + item['module'] + ')') | rst_ify }@
        @{ item['description'] | rst_ify }@
 {%       elif item.module is defined %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@ module
+   @{ ('M(' + item['module'] + ')') | rst_ify }@
       The official documentation on the **@{ item['module'] }@** module.
 {%       elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_


### PR DESCRIPTION
Fixes ansible/ansible#75652.

See for example https://ansible.fontein.de/collections/ansible/builtin/index.html#plugin-index: all modules/plugins in the plugin index now have the type next to their name. If you search for 'file', you find both the 'file module' and 'file lookup'.

The pages for these two plugins:
- https://ansible.fontein.de/collections/ansible/builtin/file_module.html
- https://ansible.fontein.de/collections/ansible/builtin/file_lookup.html

The title now mentiones the type as well, so the search results should be better. The plugin type is already mentioned correctly in the "Note" (I've fixed that recently). In the "See Also" section, the plugin type is also mentioned (https://ansible.fontein.de/collections/ansible/builtin/file_module.html#see-also).

The same is also true for roles (https://ansible.fontein.de/collections/sensu/sensu_go/index.html#role-index, https://ansible.fontein.de/collections/sensu/sensu_go/agent_role.html).