### PR TITLE
Actually modify thread_max default value

### DIFF
--- a/src/antsibull/schemas/config.py
+++ b/src/antsibull/schemas/config.py
@@ -128,7 +128,7 @@ class ConfigModel(BaseModel):
     # pyre-ignore[8]: https://github.com/samuelcolvin/pydantic/issues/1684
     pypi_url: p.HttpUrl = 'https://pypi.org/'
     use_html_blobs: p.StrictBool = False
-    thread_max: int = 80
+    thread_max: int = 15
 
     _convert_nones = p.validator('process_max', pre=True, allow_reuse=True)(convert_none)
     _convert_bools = p.validator('breadcrumbs', 'indexes', 'use_html_blobs',

--- a/src/antsibull/schemas/context.py
+++ b/src/antsibull/schemas/context.py
@@ -91,6 +91,6 @@ class LibContext(BaseModel):
     doc_parsing_backend: str = 'ansible-internal'
     max_retries: int = 10
     process_max: t.Optional[int] = None
-    thread_max: int = 64
+    thread_max: int = 15
 
     _convert_nones = p.validator('process_max', pre=True, allow_reuse=True)(convert_none)

--- a/tests/units/test_context.py
+++ b/tests/units/test_context.py
@@ -13,7 +13,7 @@ def test_default():
     lib_ctx = ap.lib_ctx.get()
     assert lib_ctx.chunksize == 4096
     assert lib_ctx.process_max is None
-    assert lib_ctx.thread_max == 64
+    assert lib_ctx.thread_max == 15
     assert lib_ctx.max_retries == 10
 
     app_ctx = ap.app_ctx.get()
@@ -33,7 +33,7 @@ def test_create_contexts_with_cfg():
 
     assert lib_ctx.chunksize == 1
     assert lib_ctx.process_max is None
-    assert lib_ctx.thread_max == 64
+    assert lib_ctx.thread_max == 15
     assert lib_ctx.max_retries == 10
 
     assert app_ctx.extra == ContextDict({'unknown': True})
@@ -53,7 +53,7 @@ def test_create_contexts_with_args():
 
     assert lib_ctx.chunksize == 4096
     assert lib_ctx.process_max == 2
-    assert lib_ctx.thread_max == 64
+    assert lib_ctx.thread_max == 15
     assert lib_ctx.max_retries == 10
 
     assert app_ctx.extra == ContextDict({'unknown': True})
@@ -139,7 +139,7 @@ def test_context_overrides():
     lib_ctx = ap.lib_ctx.get()
     assert lib_ctx.chunksize == 4096
     assert lib_ctx.process_max is None
-    assert lib_ctx.thread_max == 64
+    assert lib_ctx.thread_max == 15
     assert lib_ctx.max_retries == 10
 
 
@@ -202,5 +202,5 @@ def test_app_and_lib_context():
     lib_ctx = ap.lib_ctx.get()
     assert lib_ctx.chunksize == 4096
     assert lib_ctx.process_max is None
-    assert lib_ctx.thread_max == 64
+    assert lib_ctx.thread_max == 15
     assert lib_ctx.max_retries == 10


### PR DESCRIPTION
In aed085e49e3cdef65f488cff7a73b7ea47e66e16 on the value of the example config was changed, and not the actual default of max_threads. This PR modifies the actual defaults.