### PR TITLE
Remove some Python 2 compatibility which isn't needed since we always required Python 3.6.1+

### DIFF
--- a/src/antsibull/jinja2/tests.py
+++ b/src/antsibull/jinja2/tests.py
@@ -1,9 +1,6 @@
 # Copyright: (c) 2019, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
-
 import warnings
 from distutils.version import LooseVersion
 from functools import partial

--- a/src/antsibull/vendored/collections.py
+++ b/src/antsibull/vendored/collections.py
@@ -4,10 +4,6 @@
 # https://opensource.org/licenses/BSD-2-Clause)
 """Collection of low-level utility functions."""
 
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
-
-
 from collections.abc import Hashable, Mapping, Sequence
 
 

--- a/src/sphinx_antsibull_ext/__init__.py
+++ b/src/sphinx_antsibull_ext/__init__.py
@@ -6,8 +6,6 @@
 Antsibull minimal Sphinx extension which adds some features from the Ansible doc site.
 '''
 
-from __future__ import (absolute_import, division, print_function)
-
 __version__ = "0.1.1"
 __license__ = "BSD license"
 __author__ = "Felix Fontein"

--- a/src/sphinx_antsibull_ext/assets.py
+++ b/src/sphinx_antsibull_ext/assets.py
@@ -6,9 +6,6 @@
 Handling assets.
 '''
 
-from __future__ import (absolute_import, division, print_function)
-
-
 import os
 import pkgutil
 


### PR DESCRIPTION
CC @webknjaz (https://github.com/ansible-community/antsibull/pull/281/files#r771452240).