### PR TITLE
Refactor I/O code; only write/copy files if the destination's content would change (assuming it is not too large)

### DIFF
--- a/antsibull.cfg
+++ b/antsibull.cfg
@@ -9,6 +9,7 @@ process_max = none
 pypi_url = https://pypi.org/
 thread_max = 15
 max_retries = 10
+file_check_content = 262144
 logging_cfg = {
     version = 1.0
     outputs = {

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -27,6 +27,7 @@ from .changelog import ChangelogData, get_changelog
 from .collections import install_separately, install_together
 from .dependency_files import BuildFile, DependencyFileData, DepsFile
 from .galaxy import CollectionDownloader, GalaxyClient
+from .utils.io import write_file
 from .utils.get_pkg_data import get_antsibull_data
 
 
@@ -377,8 +378,7 @@ async def write_collection_readme(collection_name: str, package_dir: str) -> Non
     readme_contents = readme_tmpl.render(collection_name=collection_name)
 
     readme_filename = os.path.join(package_dir, 'README.rst')
-    async with aiofiles.open(readme_filename, 'w') as f:
-        await f.write(readme_contents)
+    await write_file(readme_filename, readme_contents)
 
 
 async def write_collection_setup(name: str, version: str, package_dir: str) -> None:
@@ -387,8 +387,7 @@ async def write_collection_setup(name: str, version: str, package_dir: str) -> N
     setup_tmpl = Template(get_antsibull_data('collection-setup_py.j2').decode('utf-8'))
     setup_contents = setup_tmpl.render(version=version, name=name)
 
-    async with aiofiles.open(setup_filename, 'w') as f:
-        await f.write(setup_contents)
+    await write_file(setup_filename, setup_contents)
 
 
 async def write_collection_manifest(package_dir: str) -> None:

--- a/src/antsibull/extra_docs.py
+++ b/src/antsibull/extra_docs.py
@@ -9,12 +9,12 @@ import os.path
 import re
 import typing as t
 
-import aiofiles
 import asyncio_pool
 
 from . import app_context
 from .logging import log
 from .yaml import load_yaml_file
+from .utils.io import read_file
 
 
 mlog = log.fields(mod=__name__)
@@ -193,8 +193,7 @@ async def load_collection_extra_docs(collection_name: str,
     for abs_path, rel_path in find_extra_docs(collection_path):
         try:
             # Load content
-            async with aiofiles.open(abs_path, 'r', encoding='utf-8') as f:
-                content = await f.read()
+            content = await read_file(abs_path, encoding='utf-8')
 
             # Lint content
             dummy, errors = lint_required_conditions(content, collection_name)

--- a/src/antsibull/galaxy.py
+++ b/src/antsibull/galaxy.py
@@ -12,7 +12,7 @@ from urllib.parse import urljoin
 import semantic_version as semver
 
 from . import app_context
-from .hashing import verify_hash
+from .utils.hashing import verify_hash
 from .utils.http import retry_get
 
 # The type checker can handle finding aiohttp.client but flake8 cannot :-(

--- a/src/antsibull/schemas/config.py
+++ b/src/antsibull/schemas/config.py
@@ -129,6 +129,7 @@ class ConfigModel(BaseModel):
     pypi_url: p.HttpUrl = 'https://pypi.org/'
     use_html_blobs: p.StrictBool = False
     thread_max: int = 15
+    file_check_content: int = 262144
 
     _convert_nones = p.validator('process_max', pre=True, allow_reuse=True)(convert_none)
     _convert_bools = p.validator('breadcrumbs', 'indexes', 'use_html_blobs',

--- a/src/antsibull/schemas/context.py
+++ b/src/antsibull/schemas/context.py
@@ -80,6 +80,9 @@ class LibContext(BaseModel):
     :ivar process_max: Maximum number of worker processes for parallel operations.  It may be None
         to mean, use all available CPU cores.
     :ivar thread_max: Maximum number of helper threads for parallel operations
+    :ivar file_check_content: Maximum number of bytes of a file to read before writing it to
+        compare contents. If contents are as expected, file is not overwritten. Set to 0 to
+        disable.
     :ivar max_retries: Maximum number of times to retry an http request (in case of timeouts and
         other transient problems.
     :ivar doc_parsing_backend: The backend to use for parsing the documentation strings from
@@ -92,5 +95,6 @@ class LibContext(BaseModel):
     max_retries: int = 10
     process_max: t.Optional[int] = None
     thread_max: int = 15
+    file_check_content: int = 262144
 
     _convert_nones = p.validator('process_max', pre=True, allow_reuse=True)(convert_none)

--- a/src/antsibull/utils/hashing.py
+++ b/src/antsibull/utils/hashing.py
@@ -8,7 +8,7 @@ import hashlib
 
 import aiofiles
 
-from . import app_context
+from .. import app_context
 
 
 async def verify_hash(filename: str, hash_digest: str, algorithm: str = 'sha256') -> bool:

--- a/src/antsibull/utils/io.py
+++ b/src/antsibull/utils/io.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2021
+"""I/O helper functions."""
+
+import os
+import os.path
+
+import aiofiles
+
+from .. import app_context
+from ..logging import log
+
+
+mlog = log.fields(mod=__name__)
+
+
+async def copy_file(source_path: str, dest_path: str) -> None:
+    """
+    Copy content from one file to another.
+
+    :arg source_path: Source path. Must be a file.
+    :arg dest_path: Destination path.
+    """
+    flog = mlog.fields(func='copy_file')
+    flog.debug('Enter')
+
+    lib_ctx = app_context.lib_ctx.get()
+    if lib_ctx.file_check_content > 0:
+        # Check whether the destination file exists and has the same content as the source file,
+        # in which case we won't overwrite the destination file
+        try:
+            stat_d = os.stat(dest_path)
+            if stat_d.st_size <= lib_ctx.file_check_content:
+                stat_s = os.stat(source_path)
+                if stat_d.st_size == stat_s.st_size:
+                    # Read both files and compare
+                    async with aiofiles.open(source_path, 'rb') as f_in:
+                        content_to_copy = await f_in.read()
+                    async with aiofiles.open(dest_path, 'rb') as f_in:
+                        existing_content = await f_in.read()
+                    if content_to_copy == existing_content:
+                        flog.debug('Skipping copy, since files are identical')
+                        return
+                    # Since we already read the contents of the file to copy, simply write it to
+                    # the destination instead of reading it again
+                    async with aiofiles.open(dest_path, 'wb') as f_out:
+                        f_out.write(content_to_copy)
+                    return
+        except FileNotFoundError:
+            # Destination (or source) file does not exist
+            pass
+
+    async with aiofiles.open(source_path, 'rb') as f_in:
+        async with aiofiles.open(dest_path, 'wb') as f_out:
+            # TODO: PY3.8: while chunk := await f.read(lib_ctx.chunksize)
+            chunk = await f_in.read(lib_ctx.chunksize)
+            while chunk:
+                await f_out.write(chunk)
+                chunk = await f_in.read(lib_ctx.chunksize)
+
+    flog.debug('Leave')
+
+
+async def write_file(filename: str, content: str) -> None:
+    flog = mlog.fields(func='write_file')
+    flog.debug('Enter')
+
+    content_bytes = content.encode('utf-8')
+
+    lib_ctx = app_context.lib_ctx.get()
+    if lib_ctx.file_check_content > 0 and len(content_bytes) <= lib_ctx.file_check_content:
+        # Check whether the destination file exists and has the same content as the one we want to
+        # write, in which case we won't overwrite the file
+        try:
+            stat = os.stat(filename)
+            if stat.st_size == len(content_bytes):
+                # Read file and compare
+                async with aiofiles.open(filename, 'rb') as f:
+                    existing_content = await f.read()
+                if existing_content == content_bytes:
+                    flog.debug('Skipping write, since file already contains the exact content')
+                    return
+        except FileNotFoundError:
+            # Destination file does not exist
+            pass
+
+    async with aiofiles.open(filename, 'wb') as f:
+        await f.write(content_bytes)
+
+    flog.debug('Leave')
+
+
+async def read_file(filename: str, encoding: str = 'utf-8') -> str:
+    flog = mlog.fields(func='read_file')
+    flog.debug('Enter')
+
+    async with aiofiles.open(filename, 'r', encoding=encoding) as f:
+        content = await f.read()
+
+    flog.debug('Leave')
+    return content

--- a/src/antsibull/write_docs.py
+++ b/src/antsibull/write_docs.py
@@ -5,6 +5,7 @@
 """Output documentation."""
 
 import asyncio
+import os
 import os.path
 import typing as t
 
@@ -46,6 +47,31 @@ async def copy_file(source_path: str, dest_path: str) -> None:
     flog.debug('Enter')
 
     lib_ctx = app_context.lib_ctx.get()
+    if lib_ctx.file_check_content > 0:
+        # Check whether the destination file exists and has the same content as the source file,
+        # in which case we won't overwrite the destination file
+        try:
+            stat_d = os.stat(dest_path)
+            if stat_d.st_size <= lib_ctx.file_check_content:
+                stat_s = os.stat(source_path)
+                if stat_d.st_size == stat_s.st_size:
+                    # Read both files and compare
+                    async with aiofiles.open(source_path, 'rb') as f_in:
+                        content_to_copy = await f_in.read()
+                    async with aiofiles.open(dest_path, 'rb') as f_in:
+                        existing_content = await f_in.read()
+                    if content_to_copy == existing_content:
+                        flog.debug('Skipping copy, since files are identical')
+                        return
+                    # Since we already read the contents of the file to copy, simply write it to
+                    # the destination instead of reading it again
+                    async with aiofiles.open(dest_path, 'wb') as f_out:
+                        f_out.write(content_to_copy)
+                    return
+        except FileNotFoundError:
+            # Destination (or source) file does not exist
+            pass
+
     async with aiofiles.open(source_path, 'rb') as f_in:
         async with aiofiles.open(dest_path, 'wb') as f_out:
             # TODO: PY3.8: while chunk := await f.read(lib_ctx.chunksize)
@@ -58,8 +84,32 @@ async def copy_file(source_path: str, dest_path: str) -> None:
 
 
 async def write_file(filename: str, content: str) -> None:
-    async with aiofiles.open(filename, 'w') as f:
+    flog = mlog.fields(func='write_file')
+    flog.debug('Enter')
+
+    content = content.encode('utf-8')
+
+    lib_ctx = app_context.lib_ctx.get()
+    if lib_ctx.file_check_content > 0 and len(content) <= lib_ctx.file_check_content:
+        # Check whether the destination file exists and has the same content as the one we want to
+        # write, in which case we won't overwrite the file
+        try:
+            stat = os.stat(filename)
+            if stat.st_size == len(content):
+                # Read file and compare
+                async with aiofiles.open(filename, 'rb') as f:
+                    existing_content = await f.read()
+                if existing_content == content:
+                    flog.debug('Skipping write, since file already contains the exact content')
+                    return
+        except FileNotFoundError:
+            # Destination file does not exist
+            pass
+
+    async with aiofiles.open(filename, 'wb') as f:
         await f.write(content)
+
+    flog.debug('Leave')
 
 
 def _render_template(_template: Template, _name: str, **kwargs) -> str:

--- a/src/antsibull/write_docs.py
+++ b/src/antsibull/write_docs.py
@@ -57,6 +57,11 @@ async def copy_file(source_path: str, dest_path: str) -> None:
     flog.debug('Leave')
 
 
+async def write_file(filename: str, content: str) -> None:
+    async with aiofiles.open(filename, 'w') as f:
+        await f.write(content)
+
+
 def _render_template(_template: Template, _name: str, **kwargs) -> str:
     try:
         return _template.render(**kwargs)
@@ -157,8 +162,7 @@ async def write_plugin_rst(collection_name: str, collection_meta: AnsibleCollect
 
         plugin_file = os.path.join(collection_dir, f'{plugin_short_name}_{plugin_type}.rst')
 
-    async with aiofiles.open(plugin_file, 'w') as f:
-        await f.write(plugin_contents)
+    await write_file(plugin_file, plugin_contents)
 
     flog.debug('Leave')
 
@@ -229,8 +233,7 @@ async def write_stub_rst(collection_name: str, collection_meta: AnsibleCollectio
 
         plugin_file = os.path.join(collection_dir, f'{plugin_short_name}_{plugin_type}.rst')
 
-    async with aiofiles.open(plugin_file, 'w') as f:
-        await f.write(plugin_contents)
+    await write_file(plugin_file, plugin_contents)
 
     flog.debug('Leave')
 
@@ -352,8 +355,7 @@ async def write_collection_list(collections: t.Iterable[str], namespaces: t.Iter
         breadcrumbs=breadcrumbs)
     index_file = os.path.join(dest_dir, 'index.rst')
 
-    async with aiofiles.open(index_file, 'w') as f:
-        await f.write(index_contents)
+    await write_file(index_file, index_contents)
 
 
 async def write_collection_namespace_index(namespace: str, collections: t.Iterable[str],
@@ -379,8 +381,7 @@ async def write_collection_namespace_index(namespace: str, collections: t.Iterab
         breadcrumbs=breadcrumbs)
     index_file = os.path.join(dest_dir, 'index.rst')
 
-    async with aiofiles.open(index_file, 'w') as f:
-        await f.write(index_contents)
+    await write_file(index_file, index_contents)
 
 
 async def write_plugin_type_index(plugin_type: str,
@@ -402,8 +403,7 @@ async def write_plugin_type_index(plugin_type: str,
         plugin_type=plugin_type,
         per_collection_plugins=per_collection_plugins)
 
-    async with aiofiles.open(dest_filename, 'w') as f:
-        await f.write(index_contents)
+    await write_file(dest_filename, index_contents)
 
 
 async def write_plugin_lists(collection_name: str,
@@ -440,8 +440,7 @@ async def write_plugin_lists(collection_name: str,
     os.makedirs(dest_dir, mode=0o755, exist_ok=True)
     index_file = os.path.join(dest_dir, 'index.rst')
 
-    async with aiofiles.open(index_file, 'w') as f:
-        await f.write(index_contents)
+    await write_file(index_file, index_contents)
 
 
 async def output_collection_index(collection_to_plugin_info: CollectionInfoT,

--- a/src/antsibull/write_docs.py
+++ b/src/antsibull/write_docs.py
@@ -9,7 +9,6 @@ import os
 import os.path
 import typing as t
 
-import aiofiles
 import asyncio_pool
 
 from jinja2 import Template
@@ -19,6 +18,7 @@ from .jinja2.environment import doc_environment
 from .logging import log
 from .extra_docs import CollectionExtraDocsInfoT
 from .docs_parsing import AnsibleCollectionMetadata
+from .utils.io import copy_file, write_file
 
 
 mlog = log.fields(mod=__name__)
@@ -34,82 +34,6 @@ CollectionInfoT = t.Mapping[str, t.Mapping[str, t.Mapping[str, str]]]
 #: Plugins grouped first by plugin type, then by collection
 #: The mapping is plugin_type: collection_name: plugin_name: plugin_short_description
 PluginCollectionInfoT = t.Mapping[str, t.Mapping[str, t.Mapping[str, str]]]
-
-
-async def copy_file(source_path: str, dest_path: str) -> None:
-    """
-    Copy content from one file to another.
-
-    :arg source_path: Source path. Must be a file.
-    :arg dest_path: Destination path.
-    """
-    flog = mlog.fields(func='copy_file')
-    flog.debug('Enter')
-
-    lib_ctx = app_context.lib_ctx.get()
-    if lib_ctx.file_check_content > 0:
-        # Check whether the destination file exists and has the same content as the source file,
-        # in which case we won't overwrite the destination file
-        try:
-            stat_d = os.stat(dest_path)
-            if stat_d.st_size <= lib_ctx.file_check_content:
-                stat_s = os.stat(source_path)
-                if stat_d.st_size == stat_s.st_size:
-                    # Read both files and compare
-                    async with aiofiles.open(source_path, 'rb') as f_in:
-                        content_to_copy = await f_in.read()
-                    async with aiofiles.open(dest_path, 'rb') as f_in:
-                        existing_content = await f_in.read()
-                    if content_to_copy == existing_content:
-                        flog.debug('Skipping copy, since files are identical')
-                        return
-                    # Since we already read the contents of the file to copy, simply write it to
-                    # the destination instead of reading it again
-                    async with aiofiles.open(dest_path, 'wb') as f_out:
-                        f_out.write(content_to_copy)
-                    return
-        except FileNotFoundError:
-            # Destination (or source) file does not exist
-            pass
-
-    async with aiofiles.open(source_path, 'rb') as f_in:
-        async with aiofiles.open(dest_path, 'wb') as f_out:
-            # TODO: PY3.8: while chunk := await f.read(lib_ctx.chunksize)
-            chunk = await f_in.read(lib_ctx.chunksize)
-            while chunk:
-                await f_out.write(chunk)
-                chunk = await f_in.read(lib_ctx.chunksize)
-
-    flog.debug('Leave')
-
-
-async def write_file(filename: str, content: str) -> None:
-    flog = mlog.fields(func='write_file')
-    flog.debug('Enter')
-
-    content = content.encode('utf-8')
-
-    lib_ctx = app_context.lib_ctx.get()
-    if lib_ctx.file_check_content > 0 and len(content) <= lib_ctx.file_check_content:
-        # Check whether the destination file exists and has the same content as the one we want to
-        # write, in which case we won't overwrite the file
-        try:
-            stat = os.stat(filename)
-            if stat.st_size == len(content):
-                # Read file and compare
-                async with aiofiles.open(filename, 'rb') as f:
-                    existing_content = await f.read()
-                if existing_content == content:
-                    flog.debug('Skipping write, since file already contains the exact content')
-                    return
-        except FileNotFoundError:
-            # Destination file does not exist
-            pass
-
-    async with aiofiles.open(filename, 'wb') as f:
-        await f.write(content)
-
-    flog.debug('Leave')
 
 
 def _render_template(_template: Template, _name: str, **kwargs) -> str:


### PR DESCRIPTION
The optimization ensures that if the Ansible docsite build is run twice in a row, Sphinx should be *a lot* faster on the second run since the input files do not change. (Or only some of them.)

I set the check limit to 256 KiB, which most RST files should be smaller than.