### PR TITLE
antsibull-docs: fully implement collection subcommand

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -20,9 +20,7 @@ jobs:
         options:
           - '--use-current --sphinx-theme sphinx_rtd_theme'
           - '--use-current --use-html-blobs --no-breadcrumbs community.crypto community.docker'
-          # The following should be run without `--use-current` and with `--collection-version 2.0.0`,
-          # but that isn't implemented yet:
-          - '--use-current --no-indexes --squash-hierarchy community.crypto'
+          - '--no-indexes --squash-hierarchy community.crypto --collection-version 2.0.0'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install collections
         run:
-          ansible-galaxy collection install community.docker community.crypto
+          ansible-galaxy collection install community.docker community.crypto felixfontein.acme
         if: contains(matrix.options, '--use-current')
 
       - name: Build docsite

--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install collections
         run:
-          ansible-galaxy collection install community.docker community.crypto felixfontein.acme
+          ansible-galaxy collection install community.docker community.crypto sensu.sensu_go
         if: contains(matrix.options, '--use-current')
 
       - name: Build docsite

--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -63,6 +63,11 @@ jobs:
         run:
           python .github/workflows/validate-html.py build/html/
 
+      - name: Test plugin rendering
+        run:
+          coverage run -p --source antsibull -m antsibull.cli.antsibull_docs plugin --plugin-type module --dest-dir . community.crypto.acme_info
+        if: contains(matrix.options, '--use-current')
+
       - name: Combine and upload coverage stats
         run: |
           coverage combine .coverage.*

--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Test plugin rendering
         run:
-          coverage run -p --source antsibull -m antsibull.cli.antsibull_docs plugin --plugin-type module --dest-dir . community.crypto.acme_info
+          coverage run -p --source antsibull -m antsibull.cli.antsibull_docs plugin --plugin-type module --dest-dir . community.crypto.acme_account_info
         if: contains(matrix.options, '--use-current')
 
       - name: Combine and upload coverage stats

--- a/changelogs/fragments/383-antsibull-docs-collections.yml
+++ b/changelogs/fragments/383-antsibull-docs-collections.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - "Fully implement ``antsibull-docs collection``. So far ``--current`` was required (https://github.com/ansible-community/antsibull/pull/383)."
+bugfixes:
+  - "Improve error message when plugin specified for ``antsibull-docs plugin`` cannot be found (https://github.com/ansible-community/antsibull/pull/383)."

--- a/changelogs/fragments/383-antsibull-docs-collections.yml
+++ b/changelogs/fragments/383-antsibull-docs-collections.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Fully implement ``antsibull-docs collection``. So far ``--current`` was required (https://github.com/ansible-community/antsibull/pull/383)."

--- a/src/antsibull/cli/doc_commands/collection.py
+++ b/src/antsibull/cli/doc_commands/collection.py
@@ -4,51 +4,138 @@
 # Copyright: Ansible Project, 2020
 """Build documentation for one or more collections."""
 
+import asyncio
+import os
+import os.path
+import tempfile
+import typing as t
+
+import aiohttp
+import asyncio_pool
+
 from ... import app_context
+from ...collections import install_together
+from ...compat import asyncio_run
+from ...galaxy import CollectionDownloader
 from ...logging import log
 from ...venv import FakeVenvRunner
 from .stable import generate_docs_for_all_collections
+
+if t.TYPE_CHECKING:
+    import semantic_version as semver  # pylint:disable=unused-import
 
 
 mlog = log.fields(mod=__name__)
 
 
-def generate_current_docs(indexes: bool, squash_hierarchy: bool) -> int:
+def generate_collection_docs(collection_dir: t.Optional[str], squash_hierarchy: bool) -> int:
     flog = mlog.fields(func='generate_current_docs')
-    flog.debug('Begin processing docs')
+    flog.debug('Begin generating docs')
 
     app_ctx = app_context.app_ctx.get()
 
     venv = FakeVenvRunner()
 
     return generate_docs_for_all_collections(
-        venv, None, app_ctx.extra['dest_dir'], app_ctx.extra['collections'],
-        create_indexes=indexes and not squash_hierarchy,
+        venv, collection_dir, app_ctx.extra['dest_dir'], app_ctx.extra['collections'],
+        create_indexes=app_ctx.indexes and not squash_hierarchy,
         squash_hierarchy=squash_hierarchy,
         breadcrumbs=app_ctx.breadcrumbs,
         use_html_blobs=app_ctx.use_html_blobs,
         fail_on_error=app_ctx.extra['fail_on_error'])
 
 
+async def retrieve(collections: t.List[str],
+                   collection_version: t.Optional[str],
+                   tmp_dir: str,
+                   galaxy_server: str,
+                   collection_cache: t.Optional[str] = None) -> t.Dict[str, 'semver.Version']:
+    """
+    Download collections, with specified version if applicable.
+
+    :arg collections: List of collection names.
+    :arg collection_version: Collection version to download.
+    :arg tmp_dir: The directory to download into.
+    :arg galaxy_server: URL to the galaxy server.
+    :kwarg collection_cache: If given, a path to a directory containing collection tarballs.
+        These tarballs will be used instead of downloading new tarballs provided that the
+        versions match the criteria (latest compatible version known to galaxy).
+    :returns: Map of collection name to directory it is in.
+    """
+    collection_dir = os.path.join(tmp_dir, 'collections')
+    os.mkdir(collection_dir, mode=0o700)
+
+    requestors = {}
+
+    lib_ctx = app_context.lib_ctx.get()
+    async with aiohttp.ClientSession() as aio_session:
+        async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
+            downloader = CollectionDownloader(aio_session, collection_dir,
+                                              galaxy_server=galaxy_server,
+                                              collection_cache=collection_cache)
+            for collection in collections:
+                if collection_version is None:
+                    requestors[collection] = await pool.spawn(
+                        downloader.download_latest_matching(collection, '*'))
+                else:
+                    requestors[collection] = await pool.spawn(
+                        downloader.download(collection, collection_version))
+
+            responses = await asyncio.gather(*requestors.values())
+            if collection_version is None:
+                responses = [resp.download_path for resp in responses]
+
+    # Note: Python dicts have always had a stable order as long as you don't modify the dict.
+    # So requestors (implicitly, the keys) and responses have a matching order here.
+    return dict(zip(requestors, responses))
+
+
 def generate_docs() -> int:
     """
-    Create documentation for the current-collection subcommand.
+    Create documentation for the collection subcommand.
 
-    Current collection documentation creates documentation for one or multiple currently
-    installed collections.
+    Creates documentation for one or multiple (currently installed) collections.
 
     :arg args: The parsed comand line args.
     :returns: A return code for the program.  See :func:`antsibull.cli.antsibull_docs.main` for
         details on what each code means.
     """
+    flog = mlog.fields(func='generate_docs')
+    flog.debug('Begin processing docs')
+
     app_ctx = app_context.app_ctx.get()
 
-    indexes: bool = app_ctx.indexes
     squash_hierarchy: bool = app_ctx.extra['squash_hierarchy']
 
     if app_ctx.extra['use_current']:
-        return generate_current_docs(indexes, squash_hierarchy)
+        return generate_collection_docs(None, squash_hierarchy)
 
-    raise NotImplementedError('Priority to implement subcommands is stable, devel, plugin, and'
-                              ' then collection commands. Only --use-current is implemented'
-                              ' for the collection subcommand right now.')
+    collection_version = app_ctx.extra['collection_version']
+    if collection_version == '@latest':
+        collection_version = None
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Retrieve the collections
+        flog.fields(tmp_dir=tmp_dir).info('created tmpdir')
+        collection_tarballs = asyncio_run(
+            retrieve(app_ctx.extra['collections'], collection_version,
+                     tmp_dir, galaxy_server=app_ctx.galaxy_url,
+                     collection_cache=app_ctx.collection_cache))
+        # flog.fields(tarballs=collection_tarballs).debug('Download complete')
+        flog.notice('Finished retrieving tarballs')
+
+        # Install the collections to a directory
+
+        # Directory that ansible needs to see
+        collection_dir = os.path.join(tmp_dir, 'installed')
+        # Directory that the collections will be untarred inside of
+        collection_install_dir = os.path.join(collection_dir, 'ansible_collections')
+        # Safe to recursively mkdir because we created the tmp_dir
+        os.makedirs(collection_install_dir, mode=0o700)
+        flog.fields(collection_install_dir=collection_install_dir).debug('collection install dir')
+
+        # Install the collections
+        asyncio_run(install_together(collection_tarballs.values(), collection_install_dir))
+        flog.notice('Finished installing collections')
+
+        return generate_collection_docs(collection_dir, squash_hierarchy)

--- a/src/antsibull/cli/doc_commands/plugin.py
+++ b/src/antsibull/cli/doc_commands/plugin.py
@@ -81,7 +81,12 @@ def generate_docs() -> int:
 
     stdout = ansible_doc_results.stdout.decode("utf-8", errors="surrogateescape")
 
-    plugin_info = json.loads(_filter_non_json_lines(stdout)[0])[plugin_name]
+    plugin_data = json.loads(_filter_non_json_lines(stdout)[0])
+    try:
+        plugin_info = plugin_data[plugin_name]
+    except KeyError:
+        print(f'Cannot find documentation for plugin {plugin_name}!')
+        return 1
     flog.debug('Finished parsing info from plugin')
 
     try:

--- a/src/antsibull/cli/doc_commands/plugin.py
+++ b/src/antsibull/cli/doc_commands/plugin.py
@@ -28,35 +28,16 @@ from ...write_docs import write_plugin_rst
 mlog = log.fields(mod=__name__)
 
 
-def generate_docs() -> int:
+def generate_plugin_docs(plugin_type: str, plugin_name: str,
+                         collection_name: str, plugin: str,
+                         output_path: str) -> int:
     """
-    Create documentation for the current-plugin subcommand.
-
-    Current plugin documentation creates documentation for one currently installed plugin.
-
-    :returns: A return code for the program.  See :func:`antsibull.cli.antsibull_docs.main` for
-        details on what each code means.
+    Render documentation for a locally installed plugin.
     """
-    flog = mlog.fields(func='generate_docs')
-    flog.debug('Begin processing docs')
+    flog = mlog.fields(func='generate_plugin_docs')
+    flog.debug('Begin generating plugin docs')
 
     app_ctx = app_context.app_ctx.get()
-    plugin_type: str = app_ctx.extra['plugin_type']
-    plugin_name: str = app_ctx.extra['plugin'][0]
-
-    if not is_fqcn(plugin_name):
-        raise NotImplementedError('Priority to implement subcommands is stable, devel, plugin, and'
-                                  ' then collection commands. Only the FQCN form is implemented'
-                                  ' for the plugin subcommand right now.')
-
-    output_path = os.path.join(app_ctx.extra['dest_dir'], f'{plugin_name}_{plugin_type}.rst')
-
-    try:
-        namespace, collection, plugin = get_fqcn_parts(plugin_name)
-    except ValueError:
-        namespace, collection = 'ansible', 'builtin'
-        plugin = plugin_name
-    plugin_name = '.'.join([namespace, collection, plugin])
 
     venv = FakeVenvRunner()
     venv_ansible_doc = venv.get_command('ansible-doc')
@@ -121,10 +102,45 @@ def generate_docs() -> int:
     error_tmpl = env.get_template('plugin-error.rst.j2')
 
     asyncio_run(write_plugin_rst(
-        '.'.join([namespace, collection]), AnsibleCollectionMetadata.empty(), plugin, plugin_type,
+        collection_name, AnsibleCollectionMetadata.empty(), plugin, plugin_type,
         plugin_info, errors, plugin_tmpl, error_tmpl, '',
         path_override=output_path,
         use_html_blobs=app_ctx.use_html_blobs))
     flog.debug('Finished writing plugin docs')
 
     return 0
+
+
+def generate_docs() -> int:
+    """
+    Create documentation for the current-plugin subcommand.
+
+    Current plugin documentation creates documentation for one currently installed plugin.
+
+    :returns: A return code for the program.  See :func:`antsibull.cli.antsibull_docs.main` for
+        details on what each code means.
+    """
+    flog = mlog.fields(func='generate_docs')
+    flog.debug('Begin processing docs')
+
+    app_ctx = app_context.app_ctx.get()
+    plugin_type: str = app_ctx.extra['plugin_type']
+    plugin_name: str = app_ctx.extra['plugin'][0]
+
+    if not is_fqcn(plugin_name):
+        raise NotImplementedError('Priority to implement subcommands is stable, devel, plugin, and'
+                                  ' then collection commands. Only the FQCN form is implemented'
+                                  ' for the plugin subcommand right now.')
+
+    output_path = os.path.join(app_ctx.extra['dest_dir'], f'{plugin_name}_{plugin_type}.rst')
+
+    try:
+        namespace, collection, plugin = get_fqcn_parts(plugin_name)
+    except ValueError:
+        namespace, collection = 'ansible', 'builtin'
+        plugin = plugin_name
+    collection_name = '.'.join([namespace, collection])
+    plugin_name = '.'.join([namespace, collection, plugin])
+
+    return generate_plugin_docs(
+        plugin_type, plugin_name, collection_name, plugin, output_path)

--- a/src/antsibull/cli/doc_commands/stable.py
+++ b/src/antsibull/cli/doc_commands/stable.py
@@ -118,6 +118,9 @@ def normalize_plugin_info(plugin_type: str,
         in :mod:`antsibull.schemas.docs`.  The nonfatal errors are strings representing the problems
         encountered.
     """
+    # If you wonder why this code isn't showing up in code coverage: that's because it's executed
+    # in a subprocess. See normalize_all_plugin_info below.
+
     errors = []
     if plugin_type == 'role':
         try:


### PR DESCRIPTION
There wasn't much left than sticking things together.

Fixes #55.

(The only antsibull-docs functionality still not implemented is the `plugin` subcommand with a path name. I don't plan to implement it, if nobody else wants it, it might be better to remove any mention of it :) )