### PR TITLE
Remove email addresses and (!UNKNOWN) from author names

### DIFF
--- a/changelogs/fragments/389-remove-email-addresses.yml
+++ b/changelogs/fragments/389-remove-email-addresses.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Remove email addresses and ``(!UNKNOWN)`` from plugin and role author names (https://github.com/ansible-community/antsibull/pull/389)."

--- a/src/antsibull/data/docsite/plugin.rst.j2
+++ b/src/antsibull/data/docsite/plugin.rst.j2
@@ -374,7 +374,7 @@ Authors
 ~~~~~~~
 
 {%   for author_name in doc['author'] %}
-- @{ author_name }@
+- @{ author_name | massage_author_name }@
 {%   endfor %}
 
 {% endif %}

--- a/src/antsibull/data/docsite/role.rst.j2
+++ b/src/antsibull/data/docsite/role.rst.j2
@@ -173,7 +173,7 @@ Authors
 ^^^^^^^
 
 {%     for author_name in ep_doc['author'] %}
-- @{ author_name }@
+- @{ author_name | massage_author_name }@
 {%     endfor %}
 
 {%   endif %}

--- a/src/antsibull/jinja2/environment.py
+++ b/src/antsibull/jinja2/environment.py
@@ -9,6 +9,7 @@ from jinja2 import Environment, FileSystemLoader, PackageLoader
 
 from .filters import (
     do_max, documented_type, html_ify, rst_ify, rst_escape, rst_fmt, rst_xline, move_first,
+    massage_author_name,
 )
 from .tests import still_relevant, test_list
 
@@ -68,6 +69,7 @@ def doc_environment(template_location):
     env.filters['xline'] = rst_xline
     env.filters['documented_type'] = documented_type
     env.filters['move_first'] = move_first
+    env.filters['massage_author_name'] = massage_author_name
     env.tests['list'] = test_list
     env.tests['still_relevant'] = still_relevant
 

--- a/src/antsibull/jinja2/filters.py
+++ b/src/antsibull/jinja2/filters.py
@@ -27,7 +27,8 @@ _LINK = re.compile(r"\bL\(([^)]+), *([^)]+)\)")
 _REF = re.compile(r"\bR\(([^)]+), *([^)]+)\)")
 _CONST = re.compile(r"\bC\(([^)]+)\)")
 _RULER = re.compile(r"\bHORIZONTALLINE\b")
-_EMAIL_ADDRESS = re.compile(r"[(<]?[\w.]+@[\w.]+\.\w+[)>]?")
+
+_EMAIL_ADDRESS = re.compile(r"(?:<{mail}>|\({mail}\)|{mail})".format(mail=r"[\w.+-]+@[\w.-]+\.\w+"))
 
 
 def html_ify(text):

--- a/src/antsibull/jinja2/filters.py
+++ b/src/antsibull/jinja2/filters.py
@@ -27,6 +27,7 @@ _LINK = re.compile(r"\bL\(([^)]+), *([^)]+)\)")
 _REF = re.compile(r"\bR\(([^)]+), *([^)]+)\)")
 _CONST = re.compile(r"\bC\(([^)]+)\)")
 _RULER = re.compile(r"\bHORIZONTALLINE\b")
+_EMAIL_ADDRESS = re.compile(r"[(<]?[\w.]+@[\w.]+\.\w+[)>]?")
 
 
 def html_ify(text):
@@ -185,3 +186,10 @@ def move_first(sequence, *move_to_beginning):
             pass
 
     return beginning + remaining
+
+
+def massage_author_name(value):
+    ''' remove email addresses from the given string, and remove `(!UNKNOWN)` '''
+    value = _EMAIL_ADDRESS.sub('', value)
+    value = value.replace('(!UNKNOWN)', '')
+    return value

--- a/tests/units/test_jinja2.py
+++ b/tests/units/test_jinja2.py
@@ -1,6 +1,6 @@
 import pytest
 
-from antsibull.jinja2.filters import rst_ify, rst_escape, move_first
+from antsibull.jinja2.filters import rst_ify, rst_escape, move_first, massage_author_name
 
 
 RST_IFY_DATA = {
@@ -68,3 +68,17 @@ MOVE_FIRST_DATA = [
 @pytest.mark.parametrize('input, move_to_beginning, expected', MOVE_FIRST_DATA)
 def test_move_first(input, move_to_beginning, expected):
     assert move_first(input, *move_to_beginning) == expected
+
+
+MASSAGE_AUTHOR_NAME = [
+    ('', ''),
+    ('John Doe (@johndoe) <john.doe@gmail.com>', 'John Doe (@johndoe) '),
+    ('John Doe (@johndoe) john+doe@gmail.com', 'John Doe (@johndoe) '),
+    ('John Doe (@johndoe) (john-doe@gmail.com)', 'John Doe (@johndoe) '),
+    ('John Doe (@johndoe, john.doe@gmail.com)', 'John Doe (@johndoe, )'),
+]
+
+
+@pytest.mark.parametrize('input, expected', MASSAGE_AUTHOR_NAME)
+def test_massage_author_name(input, expected):
+    assert massage_author_name(input) == expected


### PR DESCRIPTION
As an example, compare https://ansible.fontein.de/collections/ansible/builtin/sequence_lookup.html#authors to https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sequence_lookup.html#authors - the former docsite uses this PR, the latter does not (yet).