### PR TITLE
[Ansible 6] Disable collision checks with Ansible 2.9 / ansible-base 2.10 in setup.py

### DIFF
--- a/changelogs/fragments/394-setup.py-collision.yml
+++ b/changelogs/fragments/394-setup.py-collision.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - Remove Ansible 2.9 / ansible-base 2.10 checks from ``setup.py`` for Ansible 6 so that we can finally ship wheels. This change is only active for Ansible 6 (https://github.com/ansible-community/antsibull/pull/394).

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -4,6 +4,7 @@ import os
 import sys
 from setuptools import setup
 
+{% if version.major < 6 %}
 
 def detect_bad_upgrade():
     # prevent direct upgrade from 2.9.x or earlier to 2.10 due to pip limitations
@@ -144,6 +145,7 @@ if not os.environ.get('ANSIBLE_SKIP_CONFLICT_CHECK'):
     if detect_bad_upgrade():
         sys.exit(1)
 
+{% endif %}
 
 __version__ = '{{ version }}'
 __author__ = 'Ansible, Inc.'


### PR DESCRIPTION
Subset of https://github.com/ansible-community/antsibull/pull/342 which only disables the Ansible 2.9 / ansible-base 2.10 collision check for Ansible 6+. This allows to finally ship wheels! :tada:

Part of the Ansible 6 roadmap.