### PR TITLE
Unify CI

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Run once per week (Monday at 04:00 UTC)
+  schedule:
+    - cron: '0 4 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -7,9 +7,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Run once per week (Monday at 06:00 UTC)
+  # Run once per week (Monday at 04:00 UTC)
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 4 * * 1'
 
 jobs:
   build-simple-docsite:

--- a/.github/workflows/antsibull-lint.yml
+++ b/.github/workflows/antsibull-lint.yml
@@ -5,9 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Run once per week (Monday at 06:00 UTC)
+  # Run once per week (Monday at 04:00 UTC)
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 4 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/build-css.yml
+++ b/.github/workflows/build-css.yml
@@ -7,9 +7,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Run once per week (Monday at 06:00 UTC)
+  # Run once per week (Monday at 04:00 UTC)
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 4 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/build-dumb-pypi.yml
+++ b/.github/workflows/build-dumb-pypi.yml
@@ -23,9 +23,9 @@ on:
         default: main
         description: The GitHub repo ref for pulling ansible build data from
         required: true
+  # Run once per week (Monday at 04:00 UTC)
   schedule:
-  # https://crontab.guru/#36_*/3_*_*_*
-  - cron: 36 */3 * * *  # At minute 36 past every 3rd hour.
+    - cron: '0 4 * * 1'
 
 jobs:
   build-dumb-pypi:

--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python 3.8 and other dependencies to lint the code.
+# This workflow will install Python 3.9 and other dependencies to lint the code.
 # For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
@@ -9,9 +9,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Run once per week (Monday at 06:00 UTC)
+  # Run once per week (Monday at 04:00 UTC)
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 4 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -9,9 +9,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Run once per week (Monday at 06:00 UTC)
+  # Run once per week (Monday at 04:00 UTC)
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 4 * * 1'
 
 jobs:
   build:


### PR DESCRIPTION
Right now, most jobs run once per week. One does not run on a schedule, and one does run every three hours (!). Let's unify this to once per week. (I've picked 04:00 instead of 06:00 UTC since quite a few collection CIs run on 06:00 UTC.)