### PR TITLE
add test and filter plugins

### DIFF
--- a/src/antsibull/constants.py
+++ b/src/antsibull/constants.py
@@ -7,16 +7,18 @@
 from typing import Dict, FrozenSet
 
 
+# TODO: pull these from the ansbile version as not all versions supprot same list
 #: All the types of ansible plugins
 PLUGIN_TYPES: FrozenSet[str] = frozenset(('become', 'cache', 'callback', 'cliconf', 'connection',
                                           'httpapi', 'inventory', 'lookup', 'shell', 'strategy',
-                                          'vars', 'module', 'module_utils', 'role',))
+                                          'vars', 'module', 'module_utils', 'role', 'test', 'filter'))
 
+# TODO: pull these from the ansbile version as not all versions supprot same list
 #: The subset of PLUGINS which we build documentation for
 DOCUMENTABLE_PLUGINS: FrozenSet[str] = frozenset(('become', 'cache', 'callback', 'cliconf',
                                                   'connection', 'httpapi', 'inventory', 'lookup',
                                                   'netconf', 'shell', 'vars', 'module',
-                                                  'strategy', 'role',))
+                                                  'strategy', 'role', 'test', 'filter'))
 
 
 DOCUMENTABLE_PLUGINS_MIN_VERSION: Dict[str, str] = {

--- a/src/antsibull/docs_parsing/ansible_internal.py
+++ b/src/antsibull/docs_parsing/ansible_internal.py
@@ -11,6 +11,7 @@ import typing as t
 from ..logging import log
 from ..utils.get_pkg_data import get_antsibull_data
 from ..vendored.json_utils import _filter_non_json_lines
+from ..constants import DOCUMENTABLE_PLUGINS
 from . import _get_environment, AnsibleCollectionMetadata
 
 if t.TYPE_CHECKING:
@@ -65,6 +66,10 @@ async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
 
     plugin_map = {}
     for plugin_type, plugins in result['plugins'].items():
+        if plugin_type not in DOCUMENTABLE_PLUGINS:
+            # avoid keyerrors down the line when we cannot match types
+            flog.debug('Skipping unknown plugin type: {0}'.format(plugin_type))
+            continue
         plugin_map[plugin_type] = {}
         for plugin_name, plugin_data in plugins.items():
             if '.' not in plugin_name:


### PR DESCRIPTION
fixes for
```
00:46   File "/root/ansible/docs/docsite/../../hacking/build-ansible.py", line 103, in <module>
00:46     main()
00:46   File "/root/ansible/docs/docsite/../../hacking/build-ansible.py", line 92, in main
00:46     retval = command.main(args)
00:46   File "/root/ansible/hacking/build_library/build_ansible/command_plugins/docs_build.py", line 235, in main
00:46     return generate_base_docs(args)
00:46   File "/root/ansible/hacking/build_library/build_ansible/command_plugins/docs_build.py", line 121, in generate_base_docs
00:46     return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
00:46   File "/root/.ansible/test/venv/sanity.docs-build/3.10/9e08beb0/lib/python3.10/site-packages/antsibull/cli/antsibull_docs.py", line 411, in run
00:46     return ARGS_MAP[args.command]()
00:46   File "/root/.ansible/test/venv/sanity.docs-build/3.10/9e08beb0/lib/python3.10/site-packages/antsibull/cli/doc_commands/stable.py", line 447, in generate_docs
00:46     return generate_docs_for_all_collections(
00:46   File "/root/.ansible/test/venv/sanity.docs-build/3.10/9e08beb0/lib/python3.10/site-packages/antsibull/cli/doc_commands/stable.py", line 319, in generate_docs_for_all_collections
00:46     remove_redirect_duplicates(plugin_info, collection_routing)
00:46   File "/root/.ansible/test/venv/sanity.docs-build/3.10/9e08beb0/lib/python3.10/site-packages/antsibull/docs_parsing/routing.py", line 275, in remove_redirect_duplicates
00:46     plugin_routing = collection_routing[plugin_type]
00:46 KeyError: 'filter'
00:46 make: *** [Makefile:205: base_plugins] Error 1
```