### PR TITLE
Fix antsibull-docs error if unexpected plugin type is documented

### DIFF
--- a/changelogs/fragments/404_not_found.yml
+++ b/changelogs/fragments/404_not_found.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - anstibull will not traceback anymore when it tries to process plugins not found in it's own constant but are available in ansible.

--- a/changelogs/fragments/404_not_found.yml
+++ b/changelogs/fragments/404_not_found.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - anstibull will not traceback anymore when it tries to process plugins not found in it's own constant but are available in ansible.
+  - anstibull-docs will no longer traceback when it tries to process plugins not found in its own constant but are available in ansible-core (https://github.com/ansible-community/antsibull/pull/404).

--- a/src/antsibull/docs_parsing/ansible_internal.py
+++ b/src/antsibull/docs_parsing/ansible_internal.py
@@ -8,6 +8,7 @@ import json
 import tempfile
 import typing as t
 
+from ..constants import DOCUMENTABLE_PLUGINS
 from ..logging import log
 from ..utils.get_pkg_data import get_antsibull_data
 from ..vendored.json_utils import _filter_non_json_lines
@@ -65,6 +66,10 @@ async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
 
     plugin_map = {}
     for plugin_type, plugins in result['plugins'].items():
+        if plugin_type not in DOCUMENTABLE_PLUGINS:
+            # avoid keyerrors down the line when we cannot match types
+            flog.debug('Skipping unknown plugin type: {0}'.format(plugin_type))
+            continue
         plugin_map[plugin_type] = {}
         for plugin_name, plugin_data in plugins.items():
             if '.' not in plugin_name:

--- a/src/antsibull/docs_parsing/ansible_internal.py
+++ b/src/antsibull/docs_parsing/ansible_internal.py
@@ -68,7 +68,7 @@ async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
     for plugin_type, plugins in result['plugins'].items():
         if plugin_type not in DOCUMENTABLE_PLUGINS:
             # avoid keyerrors down the line when we cannot match types
-            flog.debug('Skipping unknown plugin type: {0}'.format(plugin_type))
+            flog.debug(f'Skipping unknown plugin type: {plugin_type}')
             continue
         plugin_map[plugin_type] = {}
         for plugin_name, plugin_data in plugins.items():


### PR DESCRIPTION
fixes for
```
00:46   File "/root/ansible/docs/docsite/../../hacking/build-ansible.py", line 103, in <module>
00:46     main()
00:46   File "/root/ansible/docs/docsite/../../hacking/build-ansible.py", line 92, in main
00:46     retval = command.main(args)
00:46   File "/root/ansible/hacking/build_library/build_ansible/command_plugins/docs_build.py", line 235, in main
00:46     return generate_base_docs(args)
00:46   File "/root/ansible/hacking/build_library/build_ansible/command_plugins/docs_build.py", line 121, in generate_base_docs
00:46     return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
00:46   File "/root/.ansible/test/venv/sanity.docs-build/3.10/9e08beb0/lib/python3.10/site-packages/antsibull/cli/antsibull_docs.py", line 411, in run
00:46     return ARGS_MAP[args.command]()
00:46   File "/root/.ansible/test/venv/sanity.docs-build/3.10/9e08beb0/lib/python3.10/site-packages/antsibull/cli/doc_commands/stable.py", line 447, in generate_docs
00:46     return generate_docs_for_all_collections(
00:46   File "/root/.ansible/test/venv/sanity.docs-build/3.10/9e08beb0/lib/python3.10/site-packages/antsibull/cli/doc_commands/stable.py", line 319, in generate_docs_for_all_collections
00:46     remove_redirect_duplicates(plugin_info, collection_routing)
00:46   File "/root/.ansible/test/venv/sanity.docs-build/3.10/9e08beb0/lib/python3.10/site-packages/antsibull/docs_parsing/routing.py", line 275, in remove_redirect_duplicates
00:46     plugin_routing = collection_routing[plugin_type]
00:46 KeyError: 'filter'
00:46 make: *** [Makefile:205: base_plugins] Error 1
```