### PR TITLE
Always create build file if it does not exist

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: default settings
-            options: ''
+          - name: Ansible 5 with default settings
+            options: '-e antsibull_ansible_version=5.99.0'
           - name: Ansible 6 with ansible-core devel
-            options: '-e antsibull_ansible_version=6.0.0 -e antsibull_build_file=ansible-6.build -e antsibull_data_dir="{{ antsibull_data_git_dir }}/6" -e antsibull_ansible_git_version=devel'
+            options: '-e antsibull_ansible_version=6.99.0 -e antsibull_build_file=ansible-6.build -e antsibull_data_dir="{{ antsibull_data_git_dir }}/6" -e antsibull_ansible_git_version=devel'
 
     steps:
       - name: Check out antsibull

--- a/changelogs/fragments/408-build-file-role.yml
+++ b/changelogs/fragments/408-build-file-role.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "If the role is used to build a non-alpha or first beta version and the bulid file does not exist, it is created instead of later failing because it does not exist (https://github.com/ansible-community/antsibull/pull/408)."

--- a/roles/build-release/tasks/build.yaml
+++ b/roles/build-release/tasks/build.yaml
@@ -1,17 +1,23 @@
 ---
-- name: Set expected path to deps file and release archive
+- name: Set expected path to deps file, build file, and release archive
   ansible.builtin.set_fact:
     _deps_file: "ansible-{{ antsibull_ansible_version }}.deps"
+    _build_file: "{{ antsibull_data_dir }}/ansible-{{ antsibull_ansible_version.split('.', 1)[0] }}.build"
     _release_archive: "{{ antsibull_sdist_dir }}/ansible-{{ antsibull_ansible_version }}.tar.gz"
 
 # Documentation for the following commands:
 # https://github.com/ansible-community/antsibull/blob/main/docs/build-ansible.rst
 
+- name: Check whether the ansible build file exists
+  ansible.builtin.stat:
+    path: '{{ _build_file }}'
+  register: _antsibull_build_file_stat
+
 - name: Update version ranges in the build file for alpha and beta releases
   command: >-
     {{ antsibull_build_command }} new-ansible {{ antsibull_ansible_version }}
       --data-dir {{ antsibull_data_dir }}
-  when: antsibull_ansible_version is regex("^\d+.\d+.\d+(a\d+|b1)$")
+  when: antsibull_ansible_version is regex("^\d+.\d+.\d+(a\d+|b1)$") or not _antsibull_build_file_stat.stat.exists
 
 - name: Set up feature freeze for b2 through rc1
   set_fact:


### PR DESCRIPTION
Fixes CI.

@dmsimard looks like removing 6/ansible-6.build actually broke something ;-)
