### PR TITLE
fix sphinx-init --fail-on-error trailing backslash

### DIFF
--- a/changelogs/fragments/409-sphinx-init-fail-on-error.yml
+++ b/changelogs/fragments/409-sphinx-init-fail-on-error.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - antsibull-docs sphinx-init - the ``--fail-on-error`` option results in an invalid ``build.sh`` (https://github.com/ansible-community/antsibull/pull/409).
+  - antsibull-docs sphinx-init - the ``--fail-on-error`` option resulted in an invalid ``build.sh`` (https://github.com/ansible-community/antsibull/pull/409).

--- a/changelogs/fragments/409-sphinx-init-fail-on-error.yml
+++ b/changelogs/fragments/409-sphinx-init-fail-on-error.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - antsibull-docs sphinx-init - the ``--fail-on-error`` option results in an invalid ``build.sh`` (https://github.com/ansible-community/antsibull/pull/409).

--- a/src/antsibull/data/sphinx_init/build_sh.j2
+++ b/src/antsibull/data/sphinx_init/build_sh.j2
@@ -9,7 +9,7 @@ mkdir -p temp-rst
 {%   if collections | length > 0 %}
 antsibull-docs collection \
 {%     if fail_on_error %}
-    --fail-on-error
+    --fail-on-error \
 {%     endif %}
     --use-current \
 {%     if squash_hierarchy %}
@@ -23,7 +23,7 @@ antsibull-docs collection \
 {%   else %}
 antsibull-docs current \
 {%     if fail_on_error %}
-    --fail-on-error
+    --fail-on-error \
 {%     endif %}
     --{% if not use_html_blobs %}no-{% endif %}use-html-blobs \
     --{% if not breadcrumbs %}no-{% endif %}breadcrumbs \
@@ -33,7 +33,7 @@ antsibull-docs current \
 {% else %}
 antsibull-docs collection \
 {%     if fail_on_error %}
-    --fail-on-error
+    --fail-on-error \
 {%     endif %}
 {%     if collection_version != '@latest' %}
     --collection-version @{ collection_version }@ \


### PR DESCRIPTION
I found that using `--fail-on-error` with `sphinx-init` resulted in a broken `build.sh` due to a missing trailing backslash.

Example:

```bash
#!/usr/bin/env bash
set -e
cd /home/runner/work/_temp/docsbuild

# Create collection documentation into temporary directory
rm -rf temp-rst
mkdir -p temp-rst
antsibull-docs collection \
    --fail-on-error
    --use-current \
    --no-use-html-blobs \
    --breadcrumbs \
    --indexes \
    --dest-dir temp-rst \
    lowlydba.sqlserver

# Copy collection documentation into source directory
rsync -cprv --delete-after temp-rst/collections/ rst/collections/

# Build Sphinx site
sphinx-build -M html rst build -c . -W --keep-going
```