### PR TITLE
Check dependencies

### DIFF
--- a/changelogs/fragments/416-deps.yml
+++ b/changelogs/fragments/416-deps.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - "Add ``antsibull-build`` subcommand ``validate-deps`` which validates dependencies for an ``ansible_collections`` tree (https://github.com/ansible-community/antsibull/pull/416)."
+  - "Check collection dependencies during ``antsibull-build rebuild-single`` and warn about errors (https://github.com/ansible-community/antsibull/pull/416)."

--- a/changelogs/fragments/416-deps.yml
+++ b/changelogs/fragments/416-deps.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add ``antsibull-build`` subcommand ``validate-deps`` which validates dependencies for an ``ansible_collections`` tree (https://github.com/ansible-community/antsibull/pull/416)."

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -454,7 +454,7 @@ def rebuild_single_command() -> int:
         if dep_errors:
             print('WARNING: found collection dependency errors!')
             for error in dep_errors:
-                print(error)
+                print(f'WARNING: {error}')
 
     return 0
 

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -30,6 +30,7 @@ from antsibull_core.utils.io import write_file
 
 from .build_changelog import ReleaseNotes
 from .changelog import ChangelogData, get_changelog
+from .dep_closure import check_collection_dependencies
 from .utils.get_pkg_data import get_antsibull_data
 
 
@@ -446,6 +447,14 @@ def rebuild_single_command() -> int:
             make_dist(package_dir, app_ctx.extra['sdist_dir'])
         else:
             make_dist_with_wheels(package_dir, app_ctx.extra['sdist_dir'])
+
+        # Check dependencies
+        dep_errors = check_collection_dependencies(os.path.join(package_dir, 'ansible_collections'))
+
+        if dep_errors:
+            print('WARNING: found collection dependency errors!')
+            for error in dep_errors:
+                print(error)
 
     return 0
 

--- a/src/antsibull/cli/antsibull_build.py
+++ b/src/antsibull/cli/antsibull_build.py
@@ -29,6 +29,7 @@ from ..build_ansible_commands import (  # noqa: E402
     prepare_command, build_single_command, build_multiple_command, rebuild_single_command,
 )
 from ..build_changelog import build_changelog  # noqa: E402
+from ..dep_closure import validate_dependencies_command  # noqa: E402
 from ..new_ansible import new_ansible_command  # noqa: E402
 # pylint: enable=wrong-import-position
 
@@ -45,6 +46,7 @@ ARGS_MAP = {'new-ansible': new_ansible_command,
             'collection': build_collection_command,
             'changelog': build_changelog,
             'rebuild-single': rebuild_single_command,
+            'validate-deps': validate_dependencies_command,
             # Old names, deprecated
             'new-acd': new_ansible_command,
             'build-single': build_single_command,
@@ -84,6 +86,9 @@ def _normalize_commands(args: argparse.Namespace) -> None:
 
 
 def _normalize_build_options(args: argparse.Namespace) -> None:
+    if args.command in ('validate-deps', ):
+        return
+
     if not os.path.isdir(args.data_dir):
         raise InvalidArgumentError(f'{args.data_dir} must be an existing directory')
 
@@ -299,6 +304,13 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     subparsers.add_parser('changelog',
                           parents=[build_write_data_parser, cache_parser],
                           description='Build the Ansible changelog')
+
+    validate_deps = subparsers.add_parser('validate-deps',
+                                          description='Validate collection dependencies')
+
+    validate_deps.add_argument('collection_root',
+                               help='Path to a ansible_collections directory containing a'
+                               ' collection tree to check.')
 
     # Backwards compat
     subparsers.add_parser('new-acd', add_help=False, parents=[new_parser])

--- a/src/antsibull/cli/dep-closure.py
+++ b/src/antsibull/cli/dep-closure.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3 -tt
+
+import json
+import pathlib
+import sys
+
+from collections import namedtuple
+
+from semantic_version import Version as SemVer, SimpleSpec as SemVerSpec
+
+
+ansible_collection_dir = pathlib.Path(sys.argv[1])
+
+CollectionRecord = namedtuple('CollectionRecord', ('version', 'dependencies'))
+
+
+def parse_manifest(collection_dir):
+    manifest = collection_dir.joinpath('MANIFEST.json')
+    with manifest.open() as f:
+        manifest_data = json.load(f)['collection_info']
+
+    collection_record = {f'{manifest_data["namespace"]}.{manifest_data["name"]}':
+                         CollectionRecord(manifest_data['version'],
+                                          manifest_data['dependencies'])
+                         }
+
+    return collection_record
+
+
+def analyze_deps(collections):
+    errors = []
+
+    # Look at dependencies
+    # make sure their dependencies are found
+    for collection_name, collection_info in collections.items():
+        for dep_name, dep_version_spec in collection_info.dependencies.items():
+            if dep_name not in collections:
+                errors.append(f'{collection_name} missing: {dep_name} ({dep_version_spec})')
+                continue
+
+            dependency_version = SemVer(collections[dep_name].version)
+            if dependency_version not in SemVerSpec(dep_version_spec):
+                errors.append(f'{collection_name} version_conflict:'
+                              f' {dep_name}-{str(dependency_version)} but needs'
+                              f' {dep_version_spec}')
+                continue
+
+    return errors
+
+
+def main():
+    collections = {}
+    for namespace_dir in (n for n in ansible_collection_dir.iterdir() if n.is_dir()):
+        for collection_dir in (c for c in namespace_dir.iterdir() if c.is_dir()):
+            try:
+                collections.update(parse_manifest(collection_dir))
+            except FileNotFoundError:
+                print(f'{collection_dir} is not a valid collection')
+
+    errors = analyze_deps(collections)
+    if errors:
+        print('== Dependency errors detected ==')
+        print('\n* ', end='')
+        print('\n* '.join(errors))
+        sys.exit(1)
+    else:
+        print('== All dependencies were satisfied ==')
+
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()

--- a/src/antsibull/dep_closure.py
+++ b/src/antsibull/dep_closure.py
@@ -12,6 +12,8 @@ from typing import Dict, List, Mapping
 
 from semantic_version import Version as SemVer, SimpleSpec as SemVerSpec
 
+from antsibull_core import app_context
+
 
 CollectionRecord = namedtuple('CollectionRecord', ('version', 'dependencies'))
 
@@ -67,3 +69,17 @@ def check_collection_dependencies(collection_root: str) -> List[str]:
 
     errors.extend(analyze_deps(collections))
     return errors
+
+
+def validate_dependencies_command() -> int:
+    '''CLI functionality for analyzing dependencies.'''
+    app_ctx = app_context.app_ctx.get()
+
+    collection_root: str = app_ctx.extra['collection_root']
+
+    errors = check_collection_dependencies(collection_root)
+
+    for error in errors:
+        print(error)
+
+    return 3 if errors else 0


### PR DESCRIPTION
This continues #270 by adding a new antsibull-build subcommand `validate-deps` that runs the dependency check, and by also running the dependency check when the Ansible package is build.

With this PR, rebuilding Ansible 5.6.0 outputs:
```
WARNING: found collection dependency errors!
community.okd version_conflict: kubernetes.core-2.3.0 but needs >=2.1.0,<2.3.0
```