### PR TITLE
Allow collection prereleases for alpha releases

### DIFF
--- a/changelogs/fragments/421-prereleases.yml
+++ b/changelogs/fragments/421-prereleases.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "The ``build-release`` role now no longer ignores collection prereleases of collections for the alpha releases (https://github.com/ansible-community/antsibull/pull/420)."

--- a/docs/build-ansible.rst
+++ b/docs/build-ansible.rst
@@ -64,8 +64,11 @@ All alpha releases and the first beta
     # Create a directory to output tarballs
     mkdir built
 
-    # Generate the list of compatible versions.
-    antsibull-build new-ansible 3.0.0a1 --data-dir ansible-build-data/3
+    # Generate the list of compatible versions. For the alpha versions, allow prereleases of collections:
+    antsibull-build new-ansible 3.0.0a1 --data-dir ansible-build-data/3 --allow-prereleases
+
+    # Generate the list of compatible versions. For the first beta, no collection prereleases are allowed:
+    antsibull-build new-ansible 3.0.0b1 --data-dir ansible-build-data/3
 
     # Prepare the ansible release
     # (This generates the dependency file and updates changelog.yaml)

--- a/roles/build-release/tasks/build.yaml
+++ b/roles/build-release/tasks/build.yaml
@@ -14,10 +14,16 @@
     path: '{{ _build_file }}'
   register: _antsibull_build_file_stat
 
+- name: Allow prereleases for alpha versions
+  set_fact:
+    _allow_prereleases: "--allow-prereleases"
+  when: antsibull_ansible_version is regex("^\d+.\d+.\d+(a\d+)$")
+
 - name: Update version ranges in the build file for alpha and beta releases
   command: >-
     {{ antsibull_build_command }} new-ansible {{ antsibull_ansible_version }}
       --data-dir {{ antsibull_data_dir }}
+      {{ _allow_prereleases | default('') }}
   when: antsibull_ansible_version is regex("^\d+.\d+.\d+(a\d+|b1)$") or not _antsibull_build_file_stat.stat.exists
 
 - name: Set up feature freeze for b2 through rc1


### PR DESCRIPTION
When merging #298 I forgot to update the docs and the release role to use the new switch for alpha releases. Our intention was always to allow pre-releases in alpha versions (https://github.com/ansible-community/antsibull/pull/298#issuecomment-891131577 and the next comment). For the betas we only include prereleases of specific collections if needed, so by default the ansible.build file is generated without them.