### PR TITLE
Fix version comparsion

### DIFF
--- a/changelogs/fragments/426-role-version-test.yml
+++ b/changelogs/fragments/426-role-version-test.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Use ``packaging.version`` instead of (indirectly) ``distutils.version`` to check whether the correct ansible-core version is installed (https://github.com/ansible-community/antsibull/pull/426)."

--- a/roles/build-release/tasks/tests.yaml
+++ b/roles/build-release/tasks/tests.yaml
@@ -39,7 +39,7 @@
     - name: Validate the version of ansible-core
       ansible.builtin.assert:
         that:
-          - _installed_ansible_core.stdout is version(_expected_ansible_core.stdout, '>=')
+          - _installed_ansible_core.stdout is _antsibull_packaging_version(_expected_ansible_core.stdout, '>=')
         success_msg: "ansible-core {{ _installed_ansible_core.stdout }} matches (or exceeds) {{ _deps_file }}"
         fail_msg: "ansible-core {{ _installed_ansible_core.stdout }} does not match {{ _deps_file }}"
 

--- a/roles/build-release/test_plugins/version.py
+++ b/roles/build-release/test_plugins/version.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import operator as py_operator
+
+from packaging.version import parse
+
+
+def packaging_version(version_a, version_b, op):
+    a = parse(version_a)
+    b = parse(version_b)
+    method = getattr(py_operator, {
+        '<': 'lt',
+        '<=': 'le',
+        '==': 'eq',
+        '>=': 'ge',
+        '>': 'gt',
+    }[op])
+    return method(a, b)
+
+
+class TestModule:
+    ''' Version jinja2 tests '''
+
+    def tests(self):
+        return {
+            '_antsibull_packaging_version': packaging_version,
+        }


### PR DESCRIPTION
Currently the sanity check for the installed ansible-core version in the build role fails as `2.13.0rc1 > 2.13.0` according to `distutils.version.LooseVersion`, which is used by ansible-core's `version` test. (`StrictVersion` and `SemanticVersion` do not accept `2.13.0rc1`, so they don't help here.)

I've added an internal filter `_antsibull_packaging_version` to the role that is used for this comparison. It uses `packaging.version`, which handles the version numbers correctly.
