### PR TITLE
build-release: also delete the python wheel when rebuilding

### DIFF
--- a/changelogs/fragments/427-also-delete-the-python-wheel.yaml
+++ b/changelogs/fragments/427-also-delete-the-python-wheel.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "In the build-release role, when ``antsibull_force_rebuild`` is true, delete the existing python wheel in addition to the release tarball (https://github.com/ansible-community/antsibull/pull/427)."

--- a/roles/build-release/defaults/main.yaml
+++ b/roles/build-release/defaults/main.yaml
@@ -8,7 +8,7 @@ antsibull_sdist_dir: "{{ playbook_dir | dirname }}/build"
 # The build file
 antsibull_build_file: "ansible-5.build"
 
-# Force a rebuild by deleting an existing release tarball, if it exists
+# Force a rebuild by deleting an existing release tarball and python wheel, if they exist
 antsibull_force_rebuild: false
 
 # Where to get the ansible-build-data repository from

--- a/roles/build-release/tasks/build.yaml
+++ b/roles/build-release/tasks/build.yaml
@@ -5,6 +5,7 @@
     _galaxy_file: "ansible-{{ antsibull_ansible_version }}.yaml"
     _build_file: "{{ antsibull_data_dir }}/ansible-{{ antsibull_ansible_version.split('.', 1)[0] }}.build"
     _release_archive: "{{ antsibull_sdist_dir }}/ansible-{{ antsibull_ansible_version }}.tar.gz"
+    _release_wheel: "{{ antsibull_sdist_dir }}/ansible-{{ antsibull_ansible_version }}-py3-none-any.whl"
 
 # Documentation for the following commands:
 # https://github.com/ansible-community/antsibull/blob/main/docs/build-ansible.rst
@@ -47,11 +48,14 @@
     chdir: "{{ playbook_dir | dirname }}"
     creates: "{{ antsibull_data_dir }}/{{ _deps_file }}"
 
-- name: Remove existing release archive if it exists
+- name: Remove existing release tarball and wheel if they exist
   file:
-    path: "{{ _release_archive }}"
+    path: "{{ item }}"
     state: absent
   when: antsibull_force_rebuild | bool
+  loop:
+    - "{{ _release_archive }}"
+    - "{{ _release_wheel }}"
 
 # If the release archive is already there it won't be re-built if we run again
 - name: Build a release with existing deps


### PR DESCRIPTION
We recently started building wheels and it needs to be deleted too.