### PR TITLE
Avoid including the complete condensed changelog of collections added to Ansible to that Ansible release's changelog and porting guide entries.

### DIFF
--- a/changelogs/fragments/428-changelog.yml
+++ b/changelogs/fragments/428-changelog.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Avoid including the complete condensed changelog of collections added to Ansible to that Ansible release's changelog and porting guide entries (https://github.com/ansible-community/antsibull/pull/428)."

--- a/src/antsibull/build_changelog.py
+++ b/src/antsibull/build_changelog.py
@@ -125,13 +125,15 @@ def append_changelog_changes_collections(builder: RstBuilder,
         ]
         cells = []
         for (
-                collector, collection_version, prev_collection_version
+                collector, collection_version, prev_collection_version, newly_added
         ) in changelog_entry.changed_collections:
             row = [collector.collection, '', str(collection_version), '']
             if prev_collection_version is not None:
                 row[1] = str(prev_collection_version)
             changelog = collector.changelog
-            if changelog:
+            if newly_added:
+                row[-1] = "The collection was added to Ansible"
+            elif changelog:
                 release_entries = changelog.generator.collect(
                     squash=True,
                     after_version=prev_collection_version,
@@ -434,8 +436,10 @@ def append_porting_guide_section(builder: RstBuilder, changelog_entry: Changelog
         changelog_entry.ansible_core_version,
         changelog_entry.prev_ansible_core_version)
     for (
-            collector, collection_version, prev_collection_version
+            collector, collection_version, prev_collection_version, newly_added
     ) in changelog_entry.changed_collections:
+        if newly_added:
+            continue
         check_changelog(
             collector.collection,
             collector.changelog,

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -327,7 +327,7 @@ class ChangelogEntry:
 
     removed_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
     added_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
-    unchanged_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
+    unchanged_collections: t.List[t.Tuple[CollectionChangelogCollector, str, bool]]
     changed_collections: t.List[t.Tuple[CollectionChangelogCollector, str, t.Optional[str]]]
 
     def __init__(self, version: PypiVer, version_str: str,
@@ -369,15 +369,17 @@ class ChangelogEntry:
                 versions_per_collection[collector.collection].get(prev_version)
                 if prev_version else None
             )
+            added = False
             if prev_version:
                 if not prev_collection_version:
                     self.added_collections.append((collector, collection_version))
+                    added = True
                 elif prev_collection_version == collection_version:
                     self.unchanged_collections.append((collector, collection_version))
                     continue
 
             self.changed_collections.append((
-                collector, collection_version, prev_collection_version))
+                collector, collection_version, prev_collection_version, added))
 
 
 class CollectionMetadata:

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -327,8 +327,8 @@ class ChangelogEntry:
 
     removed_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
     added_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
-    unchanged_collections: t.List[t.Tuple[CollectionChangelogCollector, str, bool]]
-    changed_collections: t.List[t.Tuple[CollectionChangelogCollector, str, t.Optional[str]]]
+    unchanged_collections: t.List[t.Tuple[CollectionChangelogCollector, str]]
+    changed_collections: t.List[t.Tuple[CollectionChangelogCollector, str, t.Optional[str], bool]]
 
     def __init__(self, version: PypiVer, version_str: str,
                  prev_version: t.Optional[PypiVer],


### PR DESCRIPTION
For example, when cisco.dnac is added to Ansible, in the changelog and porting guide release for the version that adds that collection (6.0.0b1) the full condensed changelog of cisco.dnac is contained. This is not helpful for users since there are quite some entries and they do not cover anything that was included in Ansible before (since the collection is new). It's also not helpful for users who manually installed the collection before since they usually didn't install its initial release, but a later version. So it's better to not include all that information.

The result can be seen in https://github.com/ansible-community/ansible-build-data/pull/129.