### PR TITLE
Make sure warnings from sdist/wheel build are passed on, fix wrong MANIFEST.in entry, add build debug feature

### DIFF
--- a/changelogs/fragments/434-setuptools.yml
+++ b/changelogs/fragments/434-setuptools.yml
@@ -1,5 +1,0 @@
-bugfixes:
-  - "Fix typo in generated MANIFEST.in to list the existing file ``README.rst`` instead of the non-existing file ``README`` (https://github.com/ansible-community/antsibull/pull/434)."
-minor_changes:
-  - "Show warnings emitted by building the source distribution and/or wheels (https://github.com/ansible-community/antsibull/pull/434)."
-  - "Allow to copy the files used to create the source distribution and wheels to a new directory during ``antsibull-build rebuild-single`` (https://github.com/ansible-community/antsibull/pull/434)."

--- a/changelogs/fragments/434-setuptools.yml
+++ b/changelogs/fragments/434-setuptools.yml
@@ -1,2 +1,4 @@
+bugfixes:
+  - "Fix typo in generated MANIFEST.in to list the existing file ``README.rst`` instead of the non-existing file ``README`` (https://github.com/ansible-community/antsibull/pull/434)."
 minor_changes:
   - "Show warnings emitted by building the source distribution and/or wheels (https://github.com/ansible-community/antsibull/pull/434)."

--- a/changelogs/fragments/434-setuptools.yml
+++ b/changelogs/fragments/434-setuptools.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Show warnings emitted by building the source distribution and/or wheels (https://github.com/ansible-community/antsibull/pull/434)."

--- a/changelogs/fragments/434-setuptools.yml
+++ b/changelogs/fragments/434-setuptools.yml
@@ -2,3 +2,4 @@ bugfixes:
   - "Fix typo in generated MANIFEST.in to list the existing file ``README.rst`` instead of the non-existing file ``README`` (https://github.com/ansible-community/antsibull/pull/434)."
 minor_changes:
   - "Show warnings emitted by building the source distribution and/or wheels (https://github.com/ansible-community/antsibull/pull/434)."
+  - "Allow to copy the files used to create the source distribution and wheels to a new directory during ``antsibull-build rebuild-single`` (https://github.com/ansible-community/antsibull/pull/434)."

--- a/changelogs/fragments/435-setup.py.yml
+++ b/changelogs/fragments/435-setup.py.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - "Fix typo in generated MANIFEST.in to list the existing file ``README.rst`` instead of the non-existing file ``README`` (https://github.com/ansible-community/antsibull/pull/435)."
+minor_changes:
+  - "Show warnings emitted by building the source distribution and/or wheels (https://github.com/ansible-community/antsibull/pull/435)."
+  - "Allow to copy the files used to create the source distribution and wheels to a new directory during ``antsibull-build rebuild-single`` (https://github.com/ansible-community/antsibull/pull/435)."

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -154,7 +154,7 @@ def write_manifest(package_dir: str,
     manifest_file = os.path.join(package_dir, 'MANIFEST.in')
     with open(manifest_file, 'w', encoding='utf-8') as f:
         f.write('include COPYING\n')
-        f.write('include README\n')
+        f.write('include README.rst\n')
         f.write('include build-ansible.sh\n')
         if release_notes:
             f.write(f'include {release_notes.changelog_filename}\n')

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -538,6 +538,13 @@ def rebuild_single_command() -> int:
             write_debian_directory(app_ctx.extra['ansible_version'], ansible_core_version,
                                    package_dir)
 
+        if app_ctx.extra.get('sdist_src_dir'):
+            shutil.copytree(
+                package_dir,
+                app_ctx.extra['sdist_src_dir'],
+                symlinks=True,
+                ignore_dangling_symlinks=True)
+
         # Create source distribution
         if app_ctx.extra["ansible_version"].major < 6:
             make_dist(package_dir, app_ctx.extra['sdist_dir'])

--- a/src/antsibull/cli/antsibull_build.py
+++ b/src/antsibull/cli/antsibull_build.py
@@ -169,6 +169,10 @@ def _normalize_release_build_options(args: argparse.Namespace) -> None:
         if not os.path.isdir(args.sdist_dir):
             raise InvalidArgumentError(f'{args.sdist_dir} must be an existing directory')
 
+    if args.command in ('rebuild-single', ) and args.sdist_src_dir is not None:
+        if os.path.exists(args.sdist_src_dir):
+            raise InvalidArgumentError(f'{args.sdist_src_dir} must not exist')
+
 
 def _normalize_release_rebuild_options(args: argparse.Namespace) -> None:
     if args.command not in ('rebuild-single', ):
@@ -300,6 +304,10 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     rebuild_single_parser.add_argument('--debian', action='store_true',
                                        help='Include Debian/Ubuntu packaging files in'
                                        ' the resulting output directory')
+    rebuild_single_parser.add_argument('--sdist-src-dir',
+                                       help='Copy the files from which the source distribution is'
+                                       ' created to the specified directory. This is mainly useful'
+                                       ' for debugging antsibull-build')
 
     build_multiple_parser = subparsers.add_parser('multiple',
                                                   parents=[build_write_data_parser, cache_parser,

--- a/src/antsibull/cli/antsibull_build.py
+++ b/src/antsibull/cli/antsibull_build.py
@@ -131,6 +131,16 @@ def _normalize_new_release_options(args: argparse.Namespace) -> None:
             )
 
 
+def _check_release_build_directories(args: argparse.Namespace) -> None:
+    if args.command in ('single', 'multiple', 'rebuild-single'):
+        if not os.path.isdir(args.sdist_dir):
+            raise InvalidArgumentError(f'{args.sdist_dir} must be an existing directory')
+
+    if args.command in ('rebuild-single', ):
+        if args.sdist_src_dir is not None and os.path.exists(args.sdist_src_dir):
+            raise InvalidArgumentError(f'{args.sdist_src_dir} must not exist')
+
+
 def _normalize_release_build_options(args: argparse.Namespace) -> None:
     if args.command not in ('prepare', 'single', 'multiple', 'rebuild-single'):
         return
@@ -165,13 +175,7 @@ def _normalize_release_build_options(args: argparse.Namespace) -> None:
 
         args.galaxy_file = f'{basename}-{args.ansible_version}.yaml'
 
-    if args.command in ('single', 'multiple', 'rebuild-single'):
-        if not os.path.isdir(args.sdist_dir):
-            raise InvalidArgumentError(f'{args.sdist_dir} must be an existing directory')
-
-    if args.command in ('rebuild-single', ) and args.sdist_src_dir is not None:
-        if os.path.exists(args.sdist_src_dir):
-            raise InvalidArgumentError(f'{args.sdist_src_dir} must not exist')
+    _check_release_build_directories(args)
 
 
 def _normalize_release_rebuild_options(args: argparse.Namespace) -> None:


### PR DESCRIPTION
This is a subset of #434. Since it seems that making the Ansible package fully compatible with setuptools 63 is somewhat more complicated, I think it's better to get these parts merged independently, and to rebase #434 to only contain the setuptools part (and improve on that one).