### PR TITLE
Do not use ansible-core prereleases for non-alpha releases

### DIFF
--- a/changelogs/fragments/436-ansible-core-prereleases.yml
+++ b/changelogs/fragments/436-ansible-core-prereleases.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - When preparing a new Ansible release, only use pre-releases for ansible-core when the
+    Ansible release itself is an alpha pre-release. This encodes that the first beta release of
+    a new major Ansible release coincides with the ansible-core GA
+    (https://github.com/ansible-community/antsibull/pull/436).

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -342,7 +342,8 @@ def build_single_command() -> int:
 
 def _is_alpha(version: PypiVer) -> bool:
     """Test whether the provided version is an alpha version."""
-    return version.is_prerelease and version.pre[0] == 'a'
+    pre = version.pre
+    return version.is_prerelease and pre is not None and pre[0] == 'a'
 
 
 def prepare_command() -> int:


### PR DESCRIPTION
This should avoid https://github.com/ansible-community/ansible-build-data/pull/145#discussion_r919081038

CC @Ompragash