### PR TITLE
Store python_requires information instead of guessing it

### DIFF
--- a/changelogs/fragments/449-python_requires.yml
+++ b/changelogs/fragments/449-python_requires.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Now requires antsibull-core >= 1.3.0 (https://github.com/ansible-community/antsibull/pull/449)."
+  - "The ``python_requires`` information is now extracted from ansible-core and stored in the ``.build`` and ``.deps`` files instead of guessing it from the Ansible version (https://github.com/ansible-community/antsibull/pull/449)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ antsibull-lint = "antsibull.cli.antsibull_lint:main"
 [tool.poetry.dependencies]
 python = "^3.6.1"
 antsibull-changelog = ">= 0.14.0"
-antsibull-core = ">= 1.2.0, < 2.0.0"
+antsibull-core = ">= 1.3.0, < 2.0.0"
 antsibull-docs = ">= 1.0.0, < 2.0.0"
 asyncio-pool = "*"
 jinja2 = "*"

--- a/roles/build-release/filter_plugins/parse_deps.py
+++ b/roles/build-release/filter_plugins/parse_deps.py
@@ -1,0 +1,32 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.common.text.converters import to_native
+
+
+def parse_deps(content):
+    decoded_contents = to_native(content)
+    lines = [
+        line.strip() for line in decoded_contents.split('\n')
+        if line.strip() and not line.strip().startswith('#')
+    ]
+    deps = {}
+    for line in lines:
+        record = [entry.strip() for entry in line.split(':', 1)]
+        deps[record[0]] = record[1]
+    return deps
+
+
+class FilterModule(object):
+    ''' Deps file parsing filters '''
+
+    def filters(self):
+        filters = {
+            '_antsibull_parse_deps': parse_deps,
+        }
+
+        return filters

--- a/roles/build-release/tasks/tests.yaml
+++ b/roles/build-release/tasks/tests.yaml
@@ -26,10 +26,10 @@
 
 # Note: the version of ansible-core doesn't necessarily match the deps file since the version requirement is >=
 - block:
-    - name: Include deps_file
-      ansible.builtin.include_vars:
-        file: "{{ antsibull_data_dir }}/{{ _deps_file }}"
-        name: _deps
+    - name: Load deps_file
+      ansible.builtin.set_fact:
+        _deps: >-
+          {{ lookup('file', antsibull_data_dir ~ '/' ~ _deps_file) | _antsibull_parse_deps }}
 
     - name: Query installed pip packages
       community.general.pip_package_info:

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -173,12 +173,7 @@ setup(
         'Source Code': 'https://github.com/ansible/ansible',
     },
     license='GPLv3+',
-{%- if version.major < 5 %}
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-{%- else %}
-{# Ansible X depends on ansible-core 2.(X+7), which depends on Python 3.(floor((X+11)/2)) - at least for now :) #}
-    python_requires='>=3.{{ ((version.major + 11) / 2) | round(0, 'floor') }}',
-{%- endif %}
+    python_requires='{{ python_requires }}',
     packages=['ansible_collections'],
 {% if version.major >= 6 and collection_exclude_paths %}
     exclude_package_data={

--- a/src/antsibull/new_ansible.py
+++ b/src/antsibull/new_ansible.py
@@ -97,7 +97,7 @@ def new_ansible_command():
         (PypiVer(version), data[0]['requires_python'])
         for version, data in ansible_core_release_infos.items()
     ]
-    ansible_core_versions.sort(reverse=True, key=lambda tuple: tuple[0])
+    ansible_core_versions.sort(reverse=True, key=lambda ver_req: ver_req[0])
 
     ansible_core_version, python_requires = ansible_core_versions[0]
     dependencies = find_latest_compatible(


### PR DESCRIPTION
See https://github.com/ansible-community/antsibull/pull/448#issuecomment-1261473853.

Requires https://github.com/ansible-community/antsibull-core/pull/10 to be merged first, otherwise CI will fail.