### PR TITLE
mypy: Use types-aiofiles

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,8 +7,5 @@
 [mypy-sh.*]
 ignore_missing_imports = True
 
-[mypy-aiofiles.*]
-ignore_missing_imports = True
-
 [mypy-semantic_version.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ pytest-asyncio = ">= 0.12"
 pytest-cov = "*"
 types-docutils = "*"
 types-PyYAML = "*"
+types-aiofiles = "*"
 # For development, we install dependent projects under our control in dev mode:
 antsibull-changelog = { path = "../antsibull-changelog/", develop = true }
 antsibull-core = { path = "../antsibull-core/", develop = true }


### PR DESCRIPTION
Instead of disabling mypy's checks for missing aiofiles stubs, this adds the typeshed ones to the dev dependencies.