### PR TITLE
lint-pyre.sh: Replace usage of distutils

### DIFF
--- a/lint-pyre.sh
+++ b/lint-pyre.sh
@@ -5,6 +5,6 @@
 
 set -e
 
-PURELIB=$(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib(0))')
-PLATLIB=$(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib(1))')
+PURELIB=$(poetry run python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
+PLATLIB=$(poetry run python -c 'import sysconfig; print(sysconfig.get_path("platlib"))')
 poetry run pyre --source-directory src --search-path ../antsibull-changelog/src/ --search-path ../antsibull-core/src/ --search-path ../antsibull-docs/src/ --search-path "$PURELIB" --search-path "$PLATLIB" --search-path stubs/ "$@"


### PR DESCRIPTION
Replace distutils.sysconfig with sysconfig. distutils is deprecated and will be removed in Python 3.12.