### PR TITLE
CI: stop building Ansible 6, instead build Ansible 8

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Ansible 6 with default settings
-            options: '-e antsibull_ansible_version=6.99.0 -e antsibull_ansible_git_version=stable-2.13'
-          - name: Ansible 7 with ansible-core devel
-            options: '-e antsibull_ansible_version=7.99.0 -e antsibull_ansible_git_version=devel'
+          - name: Ansible 7 with default settings
+            options: '-e antsibull_ansible_version=7.99.0 -e antsibull_ansible_git_version=stable-2.14'
+          - name: Ansible 8 with ansible-core devel
+            options: '-e antsibull_ansible_version=8.99.0 -e antsibull_ansible_git_version=devel'
 
     steps:
       - name: Check out antsibull


### PR DESCRIPTION
Needs https://github.com/ansible-community/ansible-build-data/pull/181.