### PR TITLE
Add pyproject.toml to ansible sdist

### DIFF
--- a/changelogs/fragments/471.yaml
+++ b/changelogs/fragments/471.yaml
@@ -1,6 +1,7 @@
 ---
 minor_changes:
-  - Add pyproject.toml to ansible sdist to use the setuptools.build_meta PEP
-    517 backend. Tools that still call setup.py directly will work the same as
-    they did before.
-    (https://github.com/ansible-community/antsibull/pull/471)
+  - Add ``pyproject.toml`` to ansible sdist to use the
+    ``setuptools.build_meta`` `PEP 517 <https://peps.python.org/pep-0517/>`__
+    backend. Tools that still call ``setup.py`` directly will work the same as
+    they did before
+    (https://github.com/ansible-community/antsibull/pull/471).

--- a/changelogs/fragments/471.yaml
+++ b/changelogs/fragments/471.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - Add pyproject.toml to ansible sdist to use the setuptools.build_meta PEP
+    517 backend. Tools that still call setup.py directly will work the same as
+    they did before.
+    (https://github.com/ansible-community/antsibull/pull/471)

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -151,6 +151,10 @@ def copy_boilerplate_files(package_dir: str) -> None:
     with open(os.path.join(package_dir, 'README.rst'), 'wb') as f:
         f.write(readme)
 
+    pyproject_toml = get_antsibull_data('pyproject.toml')
+    with open(os.path.join(package_dir, 'pyproject.toml'), 'wb') as f:
+        f.write(pyproject_toml)
+
 
 def write_manifest(package_dir: str,
                    release_notes: t.Optional[ReleaseNotes] = None,

--- a/src/antsibull/data/pyproject.toml
+++ b/src/antsibull/data/pyproject.toml
@@ -1,0 +1,7 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Maxwell G <gotmax@e.email>
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This tells pip to use the setuptools.build_meta PEP 517 backend to build/install ansible instead of the deprecated interface that calls setup.py directly.

Tools that still call setup.py directly will work exactly the same as before.