### PR TITLE
Improve ansible PyPI README

### DIFF
--- a/src/antsibull/data/ansible-readme.rst
+++ b/src/antsibull/data/ansible-readme.rst
@@ -15,12 +15,12 @@ orchestration. Ansible makes complex changes like zero-downtime rolling updates 
 easy. More information on the Ansible `website <https://ansible.com/>`_.
 
 This is the ``ansible`` community package.
-``ansible`` contains a set of independent Ansible collections that are currated
-by the community, and it pulls in
-`ansible-core <pypi.org/project/ansible-core/>`_.
-The ``ansible-core`` package contains the core engine and CLI tools (such as
-``ansible``, ``ansible-playbook``) while ``ansible`` contains extra modules,
-plugins, and roles.
+The ``ansible`` python package contains a set of
+independent Ansible collections that are curated by the community,
+and it pulls in `ansible-core <pypi.org/project/ansible-core/>`_.
+The ``ansible-core`` python package contains the core runtime and CLI tools,
+such as ``ansible`` and ``ansible-playbook``,
+while the ``ansible`` package contains extra modules, plugins, and roles.
 
 ``ansible`` follows `semantic versioning <https://semver.org/>`_.
 Each major version of ``ansible`` depends on a specific major version of
@@ -52,10 +52,10 @@ on a variety of platforms.
 
 Reporting Issues
 ================
-Issues with plugins and modules within the Ansible package should be reported at
-collections' respective issue trackers.
-Issues with ``ansible-core`` should be reported in
-`its issue tracker <https://github.com/ansible/ansible/issues/>`_.
+Issues with plugins and modules in the Ansible package should be reported
+on the individual collection's issue tracker.
+Issues with ``ansible-core`` should be reported on
+the `ansible-core issue tracker <https://github.com/ansible/ansible/issues/>`_.
 
 Refer to the `Communication page
 <https://docs.ansible.com/ansible/latest/community/communication.html>`_ for a

--- a/src/antsibull/data/ansible-readme.rst
+++ b/src/antsibull/data/ansible-readme.rst
@@ -14,13 +14,13 @@ deployment, cloud provisioning, ad-hoc task execution, network automation, and m
 orchestration. Ansible makes complex changes like zero-downtime rolling updates with load balancers
 easy. More information on the Ansible `website <https://ansible.com/>`_.
 
-This is the ``ansible`` ccmmunity package.
+This is the ``ansible`` community package.
 ``ansible`` contains a set of independent Ansible collections that are currated
 by the community, and it pulls in
 `ansible-core <pypi.org/project/ansible-core/>`_.
-The ``ansible-core`` package contains the core engine and cli tools (e.g.
-``ansible``, ``ansible-playbook``) while ``ansible`` contains extra modules and
-plugins.
+The ``ansible-core`` package contains the core engine and CLI tools (such as
+``ansible``, ``ansible-playbook``) while ``ansible`` contains extra modules,
+plugins, and roles.
 
 ``ansible`` follows `semantic versioning <https://semver.org/>`_.
 Each major version of ``ansible`` depends on a specific major version of

--- a/src/antsibull/data/ansible-readme.rst
+++ b/src/antsibull/data/ansible-readme.rst
@@ -119,7 +119,8 @@ License
 
 GNU General Public License v3.0 or later
 
-See `COPYING <COPYING>`_ for the full license text.
+See `COPYING <https://github.com/ansible-community/antsibull/blob/main/src/antsibull/data/gplv3.txt>`_
+for the full license text.
 
 .. |PyPI version| image:: https://img.shields.io/pypi/v/ansible.svg
    :target: https://pypi.org/project/ansible

--- a/src/antsibull/data/ansible-readme.rst
+++ b/src/antsibull/data/ansible-readme.rst
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: GPL-3.0-or-later
   SPDX-FileCopyrightText: Ansible Project, 2020
 
-|PyPI version| |Docs badge| |Chat badge| |Build Status| |Code Of Conduct| |Mailing Lists| |License|
+|PyPI version| |Docs badge| |Chat badge| |Code Of Conduct| |Mailing Lists| |License|
 
 *******
 Ansible
@@ -13,6 +13,19 @@ Ansible is a radically simple IT automation system. It handles configuration man
 deployment, cloud provisioning, ad-hoc task execution, network automation, and multi-node
 orchestration. Ansible makes complex changes like zero-downtime rolling updates with load balancers
 easy. More information on the Ansible `website <https://ansible.com/>`_.
+
+This is the ``ansible`` ccmmunity package.
+``ansible`` contains a set of independent Ansible collections that are currated
+by the community, and it pulls in
+`ansible-core <pypi.org/project/ansible-core/>`_.
+The ``ansible-core`` package contains the core engine and cli tools (e.g.
+``ansible``, ``ansible-playbook``) while ``ansible`` contains extra modules and
+plugins.
+
+``ansible`` follows `semantic versioning <https://semver.org/>`_.
+Each major version of ``ansible`` depends on a specific major version of
+``ansible-core`` and contains specific major versions of the collections it
+includes.
 
 Design Principles
 =================
@@ -36,6 +49,18 @@ Use Ansible
 You can install a released version of Ansible with ``pip`` or a package manager. See our
 `Installation guide <https://docs.ansible.com/ansible/latest/installation_guide/index.html>`_ for details on installing Ansible
 on a variety of platforms.
+
+Reporting Issues
+================
+Issues with plugins and modules within the Ansible package should be reported at
+collections' respective issue trackers.
+Issues with ``ansible-core`` should be reported in
+`its issue tracker <https://github.com/ansible/ansible/issues/>`_.
+
+Refer to the `Communication page
+<https://docs.ansible.com/ansible/latest/community/communication.html>`_ for a
+list of support channels if you need assistance from the community or are
+unsure where to report your issue.
 
 
 Get Involved
@@ -67,6 +92,10 @@ Branch Info
 *  The Ansible package is a 'batteries included' package that brings in ``ansible-core`` and a curated set of collections. Ansible uses `semantic versioning <https://semver.org/>`_ (for example, Ansible 5.6.0). 
 *  The Ansible package has only one stable branch, called 'latest' in the documentation.
 *  See `Ansible release and maintenance <https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html>`_  for information about active branches and their corresponding ``ansible-core`` versions.
+*  Refer to the
+   `ansible-build-data <https://https://github.com/ansible-community/ansible-build-data/>`_
+   repository for the exact versions of ``ansible-core`` and collections that
+   are included in each ``ansible`` release.
 
 Roadmap
 =======
@@ -90,14 +119,12 @@ License
 
 GNU General Public License v3.0 or later
 
-See `COPYING <COPYING>`_ to see the full text.
+See `COPYING <COPYING>`_ for the full license text.
 
 .. |PyPI version| image:: https://img.shields.io/pypi/v/ansible.svg
    :target: https://pypi.org/project/ansible
 .. |Docs badge| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
    :target: https://docs.ansible.com/ansible/latest/
-.. |Build Status| image:: https://dev.azure.com/ansible/ansible/_apis/build/status/CI?branchName=devel
-   :target: https://dev.azure.com/ansible/ansible/_build/latest?definitionId=20&branchName=devel
 .. |Chat badge| image:: https://img.shields.io/badge/chat-IRC-brightgreen.svg
    :target: https://docs.ansible.com/ansible/latest/community/communication.html
 .. |Code Of Conduct| image:: https://img.shields.io/badge/code%20of%20conduct-Ansible-silver.svg


### PR DESCRIPTION
The current README for ansible package on PyPI is not very informative IMO. Some of it has information that is only relevant to ansible-core. Additionally, it's missing important details about what the `ansible` package actually is and how it differs from ansible-core. The Branch Info section kind of touches on it but it's not detailed and is buried at the bottom.

- Prominently explain the difference between ansible-core and ansible.
- Remove ansible-core CI badge.
- Add section about reporting issues.
- Mention ansible-build-data