### PR TITLE
ci: Account for antsibull-changelog dropping py3.8

### DIFF
--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           repository: ansible-community/antsibull-changelog
           path: antsibull-changelog
+          # TODO: Remove once we drop support for Python 3.8
+          ref: 0.17.0
 
       - name: Check out dependent project antsibull-core
         uses: actions/checkout@v3

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           repository: ansible-community/antsibull-changelog
           path: antsibull-changelog
+          ref: >-
+            ${{ contains(fromJson('["3.8"]'), matrix.python-version)
+                && '0.17.0' || 'main' }}
 
       - name: Check out dependent project antsibull-core
         uses: actions/checkout@v3


### PR DESCRIPTION
Relates: https://github.com/ansible-community/antsibull-changelog/commit/15b5bb071b353a45cfcf0ea92595d373d8125679
