### PR TITLE
setup.py template: Correct Python version classifiers

### DIFF
--- a/changelogs/fragments/correct-classifiers.yaml
+++ b/changelogs/fragments/correct-classifiers.yaml
@@ -1,0 +1,6 @@
+---
+bufixes:
+  - Correct Python version classifiers in the ansible ``setup.py`` template.
+    Limit the Python 3.8 classifer to ansible 5 and 6
+    and add the Python 3.11 classifier to ansible >= 7
+    (https://github.com/ansible-community/antsibull/pull/479).

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -206,9 +206,14 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
 {%- endif %}
+{%- if version.major >= 5 and version.major < 7 %}
         'Programming Language :: Python :: 3.8',
+{%- endif %}
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+{%- if version.major >= 7 %}
+        'Programming Language :: Python :: 3.11',
+{%- endif %}
         'Topic :: System :: Installation/Setup',
         'Topic :: System :: Systems Administration',
         'Topic :: Utilities',


### PR DESCRIPTION
This conflicts with https://github.com/ansible-community/antsibull/pull/477. I'll rebase that patch to apply the breaking change on top of this PR after this PR is approved.