### PR TITLE
Add requirements.txt files for dev dependencies

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,0 +1,12 @@
+# Copyright (C) 2023 Maxwell G <gotmax@e.email>
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+codecov
+flake8 >= 3.8.0
+mypy
+pyre-check ~= 0.9.15
+pylint ~= 2.12.0
+types-docutils
+types-PyYAML
+types-aiofiles

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-aiofiles
-aiohttp>=3.0.0
-jinja2
-packaging
-semantic_version
-sh
-
-# Testing
-pytest-asyncio
-asynctest
+-e ../antsibull-changelog
+-e ../antsibull-core
+-e .
+-r test-requirements.txt
+-r lint-requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,9 @@
+# Copyright (C) 2023 Maxwell G <gotmax@e.email>
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+asynctest
+cryptography
+pytest
+pytest-asyncio >= 0.12
+pytest-cov


### PR DESCRIPTION
Previously, the requirements.tzt was incongruent with pyproject.toml. This updates it.

The new requirements.txt makes it easier for developers who wish to manage venvs manually. This can also be used in CI. Running `pip install -r requirements.txt` will install antsibull, antsibull-core, and antsibull-changelog in editable mode, and install all of the test/lint dependencies. The test and lint dependencies can also be installed individually.

We can remove the duplicates in pyproject.toml when/if we decide to ditch Poetry.