### PR TITLE
Make sure that PosixPaths are converted to strings

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,7 @@ def install(session: nox.Session, *args, editable=False, **kwargs):
     # This ensures that the wheel contains all of the correct files.
     if editable and ALLOW_EDITABLE:
         args = ("-e", *args)
-    session.install(*args, "-U", **kwargs)
+    session.install(*(str(arg) for arg in args), "-U", **kwargs)
 
 
 def other_antsibull(


### PR DESCRIPTION
When running nox for some of the tests locally, I get:
```
nox > Session typing raised exception TypeError('expected string or bytes-like object')
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/nox/sessions.py", line 728, in execute
    self.func(session)
  File "/usr/lib/python3.10/site-packages/nox/_decorators.py", line 75, in __call__
    return self.func(*args, **kwargs)
  File ".../antsibull/noxfile.py", line 150, in typing
    install(session, ".[typing]", *other_antsibull(), editable=True)
  File ".../antsibull/noxfile.py", line 35, in install
    session.install(*args, "-U", **kwargs)
  File "/usr/lib/python3.10/site-packages/nox/sessions.py", line 567, in install
    self._run("python", "-m", "pip", "install", *args, external="error", **kwargs)
  File "/usr/lib/python3.10/site-packages/nox/sessions.py", line 422, in _run
    return nox.command.run(args, env=env, paths=self.bin_paths, **kwargs)
  File "/usr/lib/python3.10/site-packages/nox/command.py", line 95, in run
    full_cmd = f"{cmd} {_shlex_join(args)}"
  File "/usr/lib/python3.10/site-packages/nox/command.py", line 75, in _shlex_join
    return " ".join(shlex.quote(arg) for arg in args)
  File "/usr/lib/python3.10/site-packages/nox/command.py", line 75, in <genexpr>
    return " ".join(shlex.quote(arg) for arg in args)
  File "/usr/lib/python3.10/shlex.py", line 329, in quote
    if _find_unsafe(s) is None:
TypeError: expected string or bytes-like object
```
This is because `args` contains `PosixPath` objects, which `shlex` does not like. (This might be something changed in Python 3.11.)