### PR TITLE
Supply paths to other projects explicitly for pyre

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -146,8 +146,14 @@ def codeqa(session: nox.Session):
 
 @nox.session
 def typing(session: nox.Session):
-    install(session, ".[typing]", *other_antsibull(), editable=True)
+    others = other_antsibull()
+    install(session, ".[typing]", *others, editable=True)
     session.run("mypy", "src/antsibull")
+
+    additional_libraries = []
+    for path in others:
+        if isinstance(path, Path):
+            additional_libraries.extend(('--search-path', str(path / 'src')))
 
     purelib = session.run(
         "python",
@@ -171,6 +177,7 @@ def typing(session: nox.Session):
         platlib,
         "--search-path",
         "stubs/",
+        *additional_libraries,
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -153,7 +153,7 @@ def typing(session: nox.Session):
     additional_libraries = []
     for path in others:
         if isinstance(path, Path):
-            additional_libraries.extend(('--search-path', str(path / 'src')))
+            additional_libraries.extend(('--search-path', str(path / "src")))
 
     purelib = session.run(
         "python",


### PR DESCRIPTION
I need this to run pyre successfully, otherwise I get a lot of errors:
```
ƛ Found 47 type errors!
src/antsibull/build_ansible_commands.py:26:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core`.
src/antsibull/build_ansible_commands.py:27:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.ansible_core`.
src/antsibull/build_ansible_commands.py:28:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.collections`.
src/antsibull/build_ansible_commands.py:29:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.dependency_files`.
src/antsibull/build_ansible_commands.py:30:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.galaxy`.
src/antsibull/build_ansible_commands.py:31:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.logging`.
src/antsibull/build_ansible_commands.py:32:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.utils.io`.
src/antsibull/build_ansible_commands.py:33:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.yaml`.
src/antsibull/build_ansible_commands.py:60:50 Undefined or invalid type [11]: Annotation `AnsibleCorePyPiClient` is not defined as a type.
src/antsibull/build_changelog.py:17:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_changelog.changelog_generator`.
src/antsibull/build_changelog.py:21:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_changelog.config`.
src/antsibull/build_changelog.py:22:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_changelog.rst`.
src/antsibull/build_changelog.py:24:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core`.
src/antsibull/build_changelog.py:52:34 Undefined or invalid type [11]: Annotation `ChangelogGeneratorEntry` is not defined as a type.
src/antsibull/build_changelog.py:72:32 Undefined or invalid type [11]: Annotation `RstBuilder` is not defined as a type.
src/antsibull/build_changelog.py:116:59 Undefined or invalid type [11]: Annotation `PluginDataT` is not defined as a type.
src/antsibull/build_collection.py:17:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core`.
src/antsibull/build_collection.py:18:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.dependency_files`.
src/antsibull/changelog.py:26:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_changelog.config`.
src/antsibull/changelog.py:27:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_changelog.changes`.
src/antsibull/changelog.py:28:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_changelog.changelog_generator`.
src/antsibull/changelog.py:29:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_changelog.utils`.
src/antsibull/changelog.py:31:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core`.
src/antsibull/changelog.py:32:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.ansible_core`.
src/antsibull/changelog.py:33:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.dependency_files`.
src/antsibull/changelog.py:34:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.galaxy`.
src/antsibull/changelog.py:35:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.yaml`.
src/antsibull/changelog.py:45:11 Undefined or invalid type [11]: Annotation `PathsConfig` is not defined as a type.
src/antsibull/changelog.py:46:12 Undefined or invalid type [11]: Annotation `ChangelogConfig` is not defined as a type.
src/antsibull/changelog.py:47:13 Undefined or invalid type [11]: Annotation `ChangesData` is not defined as a type.
src/antsibull/changelog.py:48:15 Undefined or invalid type [11]: Annotation `ChangelogGenerator` is not defined as a type.
src/antsibull/changelog.py:167:52 Undefined or invalid type [11]: Annotation `CollectionDownloader` is not defined as a type.
src/antsibull/changelog.py:423:19 Undefined or invalid type [11]: Annotation `DependencyFileData` is not defined as a type.
src/antsibull/cli/antsibull_build.py:17:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.logging`.
src/antsibull/cli/antsibull_build.py:23:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core`.
src/antsibull/cli/antsibull_build.py:24:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.args`.
src/antsibull/cli/antsibull_build.py:27:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.config`.
src/antsibull/collection_meta.py:18:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.yaml`.
src/antsibull/dep_closure.py:18:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core`.
src/antsibull/new_ansible.py:18:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core`.
src/antsibull/new_ansible.py:19:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.ansible_core`.
src/antsibull/new_ansible.py:20:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.dependency_files`.
src/antsibull/new_ansible.py:21:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.galaxy`.
src/antsibull/tagging.py:20:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.logging`.
src/antsibull/tagging.py:22:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core`.
src/antsibull/tagging.py:23:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.dependency_files`.
src/antsibull/tagging.py:24:0 Undefined import [21]: Could not find a module corresponding to import `antsibull_core.yaml`.
```
Maybe this is a Python 3.10 problem as well? In any case, I don't think it should hurt...