### PR TITLE
CI: fix nox-test codecov upload

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -49,6 +49,8 @@ jobs:
           python-versions: "3.9, 3.10, 3.11"
       - name: nox -e test
         run: |
-          OTHER_ANTSIBULL_MODE=git nox -v -e test -- --cov-report=xml
+          OTHER_ANTSIBULL_MODE=git nox -v -e test -- --cov-report=xml --cov-append
       - name: Upload coverage
         uses: codecov/codecov-action@v3
+        with:
+          working-directory: antsibull


### PR DESCRIPTION
Combine test results across Python versions and set the correct
working-directory.
