### PR TITLE
Work around setuptools 63 deprecations

### DIFF
--- a/changelogs/fragments/502-setup.py.yml
+++ b/changelogs/fragments/502-setup.py.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Make compatible with deprecations issued by newer setuptools releases (https://github.com/ansible-community/antsibull/issues/433, https://github.com/ansible-community/antsibull/pull/502)."

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -517,7 +517,7 @@ def compile_collection_exclude_paths(collection_names: Collection[str],
     return sorted(result), sorted(ignored_files)
 
 
-def rebuild_single_command() -> int:
+def rebuild_single_command() -> int:  # noqa: C901
     app_ctx = app_context.app_ctx.get()
 
     deps_filename = os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['deps_file'])
@@ -581,11 +581,13 @@ def rebuild_single_command() -> int:
         release_notes.write_changelog_to(app_ctx.extra['dest_data_dir'])
         release_notes.write_porting_guide_to(app_ctx.extra['dest_data_dir'])
 
-        # pylint:disable-next=unused-variable
-        collection_exclude_paths, collection_ignored_files = compile_collection_exclude_paths(
-            dependency_data.deps, ansible_collections_dir)
-
-        # TODO: do something with collection_ignored_files
+        if app_ctx.extra['ansible_version'].major >= 8:
+            collection_exclude_paths: list[str] = []
+        else:
+            # pylint:disable-next=unused-variable
+            collection_exclude_paths, collection_ignored_files = compile_collection_exclude_paths(
+                dependency_data.deps, ansible_collections_dir)
+            # TODO: do something with collection_ignored_files
 
         # Collect collection namespaces and collection root subdirectories
         collection_namespaces: dict[str, list[str]] = defaultdict(list)

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -593,9 +593,12 @@ def rebuild_single_command() -> int:
         for collection in dependency_data.deps:
             namespace, name = collection.split('.', 1)
             collection_namespaces[namespace].append(name)
+            collection_path = os.path.join(ansible_collections_dir, namespace, name)
             collection_directories[collection] = [
-                dir for dir in os.listdir(os.path.join(ansible_collections_dir, namespace, name))
-                if dir not in ('tests', 'docs') and not dir.startswith('.')
+                file for file in os.listdir(collection_path)
+                if file not in ('tests', 'docs')
+                and not file.startswith('.')
+                and os.path.isdir(os.path.join(collection_path, file))
             ]
 
         # Write build scripts and files

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -182,7 +182,8 @@ setup(
     packages=find_namespace_packages(
         '.',
         include=[
-            'ansible_collections*',
+            'ansible_collections',
+            'ansible_collections.*',
         ],
         exclude=[
 {%-   for collection in collection_names %}
@@ -194,25 +195,19 @@ setup(
         ],
     ),
     package_dir={'': '.'},
-    package_data={'': ['*', '*/*/*/**/.*']},
-    exclude_package_data={
-        'ansible_collections': [
+    package_data={
 {%-   for collection in collection_names %}
-            '{{ collection.replace('.', '/') }}/tests/.*',
-            '{{ collection.replace('.', '/') }}/tests/**/.*',
-            '{{ collection.replace('.', '/') }}/docs/.*',
-            '{{ collection.replace('.', '/') }}/docs/**/.*',
-{%-   endfor %}
-        ],
-{%-   for namespace, names in collection_namespaces | dictsort %}
-        'ansible_collections.{{ namespace }}': [
-{%-     for name in names %}
-            '{{ name }}/tests/.*', '{{ name }}/tests/**/.*', '{{ name }}/docs/.*', '{{ name }}/docs/**/.*',
+        'ansible_collections.{{ collection }}': [
+            '*',
+{%-     for dir in collection_directories[collection] %}
+            '{{ dir }}/**/*', '{{ dir }}/**/.*',
 {%-     endfor %}
         ],
 {%-   endfor %}
+    },
+    exclude_package_data={
 {%-   for collection in collection_names %}
-        'ansible_collections.{{ collection }}': ['tests/.*', 'tests/**/.*', 'docs/.*', 'docs/**/.*'],
+        'ansible_collections.{{ collection }}': ['tests/**/*', 'docs/**/*'],
 {%-   endfor %}
     },
 {%- else %}

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -205,11 +205,6 @@ setup(
         ],
 {%-   endfor %}
     },
-    exclude_package_data={
-{%-   for collection in collection_names %}
-        'ansible_collections.{{ collection }}': ['tests/**/*', 'docs/**/*'],
-{%-   endfor %}
-    },
 {%- else %}
     packages=['ansible_collections'],
 {%-   if version.major >= 6 and collection_exclude_paths %}

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -185,7 +185,9 @@ setup(
             'ansible_collections*',
         ],
         exclude=[
+            'ansible_collections.*.*.tests.*',
             'ansible_collections.*.*.tests',
+            'ansible_collections.*.*.docs.*',
             'ansible_collections.*.*.docs',
         ],
     ),

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -196,9 +196,20 @@ setup(
     package_dir={'': '.'},
     package_data={'': ['*', '*/*/*/**/.*']},
     exclude_package_data={
-        'ansible_collections': ['*/*/tests/.*', '*/*/tests/**/.*', '*/*/docs/.*', '*/*/docs/**/.*'],
-{%-   for namespace in collection_namespaces %}
-        'ansible_collections.{{ namespace }}': ['*/tests/.*', '*/tests/**/.*', '*/docs/.*', '*/docs/**/.*'],
+        'ansible_collections': [
+{%-   for collection in collection_names %}
+            '{{ collection.replace('.', '/') }}/tests/.*',
+            '{{ collection.replace('.', '/') }}/tests/**/.*',
+            '{{ collection.replace('.', '/') }}/docs/.*',
+            '{{ collection.replace('.', '/') }}/docs/**/.*',
+{%-   endfor %}
+        ],
+{%-   for namespace, names in collection_namespaces | dictsort %}
+        'ansible_collections.{{ namespace }}': [
+{%-     for name in names %}
+            '{{ name }}/tests/.*', '{{ name }}/tests/**/.*', '{{ name }}/docs/.*', '{{ name }}/docs/**/.*',
+{%-     endfor %}
+        ],
 {%-   endfor %}
 {%-   for collection in collection_names %}
         'ansible_collections.{{ collection }}': ['tests/.*', 'tests/**/.*', 'docs/.*', 'docs/**/.*'],

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -5,7 +5,11 @@
 
 import os
 import sys
+{%- if version.major >= 8 %}
+from setuptools import setup, find_namespace_packages
+{%- else %}
 from setuptools import setup
+{%- endif %}
 
 {%- if version.major < 6 %}
 
@@ -174,17 +178,32 @@ setup(
     },
     license='GPLv3+',
     python_requires='{{ python_requires }}',
+{%- if version.major >= 8 %}
+    packages=find_namespace_packages(
+        '.',
+        include=[
+            'ansible_collections*',
+        ],
+        exclude=[
+            'ansible_collections.*.*.tests',
+            'ansible_collections.*.*.docs',
+        ],
+    ),
+    package_dir={'': '.'},
+    package_data={'': ['*', '*/*/*/**/.*']},
+{%- else %}
     packages=['ansible_collections'],
-{% if version.major >= 6 and collection_exclude_paths %}
+{%-   if version.major >= 6 and collection_exclude_paths %}
     exclude_package_data={
         'ansible_collections': [
-{%-  for path in collection_exclude_paths %}
+{%-     for path in collection_exclude_paths %}
             '{{ path }}',
-{%-  endfor %}
+{%-     endfor %}
         ],
     },
-{%- endif %}
+{%-   endif %}
     include_package_data=True,
+{%- endif %}
     install_requires=[
         '{{ ansible_core_package_name }} ~= {{ ansible_core_version }}',{{ collection_deps }}
     ],

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -185,14 +185,25 @@ setup(
             'ansible_collections*',
         ],
         exclude=[
-            'ansible_collections.*.*.tests.*',
-            'ansible_collections.*.*.tests',
-            'ansible_collections.*.*.docs.*',
-            'ansible_collections.*.*.docs',
+{%-   for collection in collection_names %}
+            'ansible_collections.{{ collection }}.tests.*',
+            'ansible_collections.{{ collection }}.tests',
+            'ansible_collections.{{ collection }}.docs.*',
+            'ansible_collections.{{ collection }}.docs',
+{%-   endfor %}
         ],
     ),
     package_dir={'': '.'},
     package_data={'': ['*', '*/*/*/**/.*']},
+    exclude_package_data={
+        'ansible_collections': ['*/*/tests/.*', '*/*/tests/**/.*', '*/*/docs/.*', '*/*/docs/**/.*'],
+{%-   for namespace in collection_namespaces %}
+        'ansible_collections.{{ namespace }}': ['*/tests/.*', '*/tests/**/.*', '*/docs/.*', '*/docs/**/.*'],
+{%-   endfor %}
+{%-   for collection in collection_names %}
+        'ansible_collections.{{ collection }}': ['tests/.*', 'tests/**/.*', 'docs/.*', 'docs/**/.*'],
+{%-   endfor %}
+    },
 {%- else %}
     packages=['ansible_collections'],
 {%-   if version.major >= 6 and collection_exclude_paths %}


### PR DESCRIPTION
Fixes #433.
Closes #434.

This uses a modified (https://github.com/ansible-community/antsibull/issues/433#issuecomment-1490751775, https://github.com/ansible-community/antsibull/issues/433#issuecomment-1490756844) version of @gotmax23's proposal in https://github.com/ansible-community/antsibull/issues/433#issuecomment-1421446696.

This only uses the new approach from Ansible 8 on, to avoid suddenly breaking Ansible 7.5.0+.