### PR TITLE
Deprecate 'multiple' and 'collection' subcommands

### DIFF
--- a/changelogs/fragments/505-deprecate.yml
+++ b/changelogs/fragments/505-deprecate.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - "The ``multiple`` and ``collection`` subcommands are deprecated and will be removed soon. They were never used to our knowledge except in the exploratory phase before the first Ansible 2.10 releases, have no test coverage, and might not even work at all. If you are actively using them and are interested in keeping them, please create an issue in the antsibull repository as soon as possible (https://github.com/ansible-community/antsibull/pull/505)."

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -678,6 +678,12 @@ async def make_collection_dists(dest_dir: str, collection_dirs: list[str]) -> No
 def build_multiple_command() -> int:
     app_ctx = app_context.app_ctx.get()
 
+    print(
+        'DEPRECATION WARNING: The `multiple` subcommand is deprecated and will be removed soon.'
+        ' If you are actively using this subcommand and are interested in keeping it, please'
+        ' create an issue in the antsibull repository as soon as possible.'
+    )
+
     build_filename = os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['build_file'])
     build_file = BuildFile(build_filename)
     build_ansible_version, ansible_core_version, deps = build_file.parse()

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -10,6 +10,7 @@ import datetime
 import os
 import os.path
 import shutil
+import sys
 import tempfile
 from collections.abc import Collection, Mapping
 from typing import TYPE_CHECKING
@@ -681,7 +682,8 @@ def build_multiple_command() -> int:
     print(
         'DEPRECATION WARNING: The `multiple` subcommand is deprecated and will be removed soon.'
         ' If you are actively using this subcommand and are interested in keeping it, please'
-        ' create an issue in the antsibull repository as soon as possible.'
+        ' create an issue in the antsibull repository as soon as possible.',
+        file=sys.stderr,
     )
 
     build_filename = os.path.join(app_ctx.extra['data_dir'], app_ctx.extra['build_file'])

--- a/src/antsibull/build_collection.py
+++ b/src/antsibull/build_collection.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os.path
+import sys
 import tempfile
 
 import sh
@@ -26,7 +27,8 @@ def build_collection_command():
     print(
         'DEPRECATION WARNING: The `collection` subcommand is deprecated and will be removed soon.'
         ' If you are actively using this subcommand and are interested in keeping it, please'
-        ' create an issue in the antsibull repository as soon as possible.'
+        ' create an issue in the antsibull repository as soon as possible.',
+        file=sys.stderr,
     )
 
     with tempfile.TemporaryDirectory() as working_dir:

--- a/src/antsibull/build_collection.py
+++ b/src/antsibull/build_collection.py
@@ -22,6 +22,13 @@ from .utils.get_pkg_data import get_antsibull_data
 
 def build_collection_command():
     app_ctx = app_context.app_ctx.get()
+
+    print(
+        'DEPRECATION WARNING: The `collection` subcommand is deprecated and will be removed soon.'
+        ' If you are actively using this subcommand and are interested in keeping it, please'
+        ' create an issue in the antsibull repository as soon as possible.'
+    )
+
     with tempfile.TemporaryDirectory() as working_dir:
         collection_dir = os.path.join(working_dir, 'community', 'ansible')
 


### PR DESCRIPTION
@gotmax23 this is a simple change I would also like to get in the next release. It deprecates two subcommands that have never really been used (to my knowledge), except maybe in the exploratory phase before Ansible 2.10.0, and that aren't tested and might not even work anymore. I'd really like to remove them soon.