### PR TITLE
Drop dependency on sh

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -28,7 +28,7 @@ jobs:
             options: '-e antsibull_ansible_version=7.99.0 -e antsibull_ansible_git_version=stable-2.14'
             python: '3.9'
             antsibull_changelog_ref: 0.14.0
-            antsibull_core_ref: stable-1
+            antsibull_core_ref: main
           - name: Ansible 8 with ansible-core devel
             options: '-e antsibull_ansible_version=8.99.0 -e antsibull_ansible_git_version=devel'
             python: '3.11'

--- a/changelogs/fragments/122-antsibull-core-sh.yml
+++ b/changelogs/fragments/122-antsibull-core-sh.yml
@@ -1,4 +1,4 @@
 minor_changes:
   - "Now depends antsibull-core 2.0.0 or newer; antsibull-core 1.x.y is no longer supported (https://github.com/ansible-community/antsibull/pull/514)."
   - "Antsibull now no longer depends directly on ``sh`` (https://github.com/ansible-community/antsibull/pull/514)."
-  - "Antsibull now uses ``sys.executable`` instead of ``'python'`` to start the build process of the ``ansible`` package (https://github.com/ansible-community/antsibull/pull/514)."
+  - "Antsibull now uses ``sys.executable`` instead of the first ``'python'`` in ``$PATH`` to call the pypa build tool (https://github.com/ansible-community/antsibull/pull/514)."

--- a/changelogs/fragments/122-antsibull-core-sh.yml
+++ b/changelogs/fragments/122-antsibull-core-sh.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Now depends antsibull-core 2.0.0 or newer; antsibull-core 1.x.y is no longer supported (https://github.com/ansible-community/antsibull/pull/514)."
+  - "Ansibull now no longer depends directly on ``sh`` (https://github.com/ansible-community/antsibull/pull/514)."

--- a/changelogs/fragments/122-antsibull-core-sh.yml
+++ b/changelogs/fragments/122-antsibull-core-sh.yml
@@ -1,4 +1,4 @@
 minor_changes:
   - "Now depends antsibull-core 2.0.0 or newer; antsibull-core 1.x.y is no longer supported (https://github.com/ansible-community/antsibull/pull/514)."
   - "Antsibull now no longer depends directly on ``sh`` (https://github.com/ansible-community/antsibull/pull/514)."
-  - "Antsibull now uses ``sys.executable`` instead of the first ``'python'`` in ``$PATH`` to call the pypa build tool (https://github.com/ansible-community/antsibull/pull/514)."
+  - "Antsibull now uses ``sys.executable`` instead of the first ``'python'`` in ``$PATH`` to call the PyPA build tool (https://github.com/ansible-community/antsibull/pull/514)."

--- a/changelogs/fragments/122-antsibull-core-sh.yml
+++ b/changelogs/fragments/122-antsibull-core-sh.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - "Now depends antsibull-core 2.0.0 or newer; antsibull-core 1.x.y is no longer supported (https://github.com/ansible-community/antsibull/pull/514)."
-  - "Ansibull now no longer depends directly on ``sh`` (https://github.com/ansible-community/antsibull/pull/514)."
+  - "Antsibull now no longer depends directly on ``sh`` (https://github.com/ansible-community/antsibull/pull/514)."
+  - "Antsibull now uses ``sys.executable`` instead of ``'python'`` to start the build process of the ``ansible`` package (https://github.com/ansible-community/antsibull/pull/514)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,11 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "antsibull-changelog >= 0.14.0",
-    "antsibull-core >= 1.5.0, < 3.0.0",
+    # TODO: bump to >= 2.0.0
+    "antsibull-core >= 2.0.0a2, < 3.0.0",
     "asyncio-pool",
     "build",
     "jinja2",
-    # sh v2 has breaking changes.,
-    # https://github.com/ansible-community/antsibull-core/issues/34,
-    "sh >= 1.0.0, < 2.0.0",
     "packaging >= 20.0",
     "semantic_version",
     "aiofiles",
@@ -112,10 +110,6 @@ source = [
 
 [tool.mypy]
 mypy_path = "stubs/"
-
-[[tool.mypy.overrides]]
-module = "sh"
-ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "semantic_version"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "antsibull-changelog >= 0.14.0",
-    # TODO: bump to >= 2.0.0
-    "antsibull-core >= 2.0.0a2, < 3.0.0",
+    "antsibull-core >= 2.0.0, < 3.0.0",
     "asyncio-pool",
     "build",
     "jinja2",

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -310,7 +310,7 @@ def write_galaxy_requirements(filename: str, included_versions: Mapping[str, str
 def make_dist(ansible_dir: str, dest_dir: str) -> None:
     # XXX: build has an API, but it's quite unstable, so we use the cli for now
     log_run(
-        ['python', '-m', 'build', '--sdist', '--outdir', dest_dir, ansible_dir],
+        [sys.executable, '-m', 'build', '--sdist', '--outdir', dest_dir, ansible_dir],
         logger=mlog.fields(func='make_dist'),
         stderr_loglevel='warning',
     )
@@ -318,7 +318,7 @@ def make_dist(ansible_dir: str, dest_dir: str) -> None:
 
 def make_dist_with_wheels(ansible_dir: str, dest_dir: str) -> None:
     log_run(
-        ['python', '-m', 'build', '--outdir', dest_dir, ansible_dir],
+        [sys.executable, '-m', 'build', '--outdir', dest_dir, ansible_dir],
         logger=mlog.fields(func='make_dist_with_wheels'),
         stderr_loglevel='warning',
     )

--- a/src/antsibull/build_collection.py
+++ b/src/antsibull/build_collection.py
@@ -12,11 +12,11 @@ import os.path
 import sys
 import tempfile
 
-import sh
 from jinja2 import Template
 
 from antsibull_core import app_context
 from antsibull_core.dependency_files import DepsFile
+from antsibull_core.subprocess_util import log_run
 
 from .utils.get_pkg_data import get_antsibull_data
 
@@ -34,8 +34,14 @@ def build_collection_command():
     with tempfile.TemporaryDirectory() as working_dir:
         collection_dir = os.path.join(working_dir, 'community', 'ansible')
 
-        # pylint:disable-next=no-member
-        sh.ansible_galaxy('collection', 'init', 'community.ansible', '--init-path', working_dir)
+        log_run([
+            'ansible-galaxy',
+            'collection',
+            'init',
+            'community.ansible',
+            '--init-path',
+            working_dir,
+        ])
         # Copy the README.md file
         readme = get_antsibull_data('README_md.txt')
         with open(os.path.join(collection_dir, 'README.md'), 'wb') as f:
@@ -57,9 +63,13 @@ def build_collection_command():
         with open(os.path.join(collection_dir, 'galaxy.yml'), 'w', encoding='utf-8') as f:
             f.write(galaxy_yml_contents)
 
-        # pylint:disable-next=no-member
-        sh.ansible_galaxy('collection', 'build',
-                          '--output-path', app_ctx.extra['collection_dir'],
-                          collection_dir)
+        log_run([
+            'ansible-galaxy',
+            'collection',
+            'build',
+            '--output-path',
+            app_ctx.extra['collection_dir'],
+            collection_dir,
+        ])
 
     return 0


### PR DESCRIPTION
Similar to https://github.com/ansible-community/antsibull-docs/pull/122. Let's remove the direct dependency on `sh`!

(I think we should do another release before merging this, so that the release role changes get out. This PR should only end up in a release once antsibull-core 2.0.0 is out and we can depend on it. I'm marking this PR as draft because of that.)