### PR TITLE
CI: remove in valid GHA parameters, make pyre work in CI

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -77,4 +77,4 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull
+          directory: antsibull

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull
+          directory: antsibull

--- a/noxfile.py
+++ b/noxfile.py
@@ -176,7 +176,8 @@ def codeqa(session: nox.Session):
 @nox.session
 def typing(session: nox.Session):
     others = other_antsibull()
-    install(session, ".[typing]", *others, editable=True)
+    # pyre does not work when we don't install ourself in editable mode 🙄.
+    install(session, "-e", ".[typing]", *others)
     session.run("mypy", "src/antsibull")
 
     additional_libraries = []


### PR DESCRIPTION
- The `codecov/codecov-action` GHA action does not support a `working-directory` option, it's called `directory` instead.
- Pyre does not work when the project isn't installed in editable mode (https://github.com/ansible-community/antsibull-docs/pull/137).