### PR TITLE
setup.py: avoid using recursive globs for package_data

### DIFF
--- a/changelogs/fragments/520-setup.py.yml
+++ b/changelogs/fragments/520-setup.py.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "For ``setup.py`` generated for Ansible 8+, do not use recursive globs (``**``) as these are only supported since setuptools 62.3.0 (https://github.com/ansible-community/antsibull/pull/520)."

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -518,6 +518,21 @@ def compile_collection_exclude_paths(collection_names: Collection[str],
     return sorted(result), sorted(ignored_files)
 
 
+def _collect_collection_data_dirs(collection_path: str) -> list[str]:
+    directories = []
+    for root, dirs, _ in os.walk(collection_path, topdown=True):
+        if root == collection_path:
+            # Make sure that all directories starting with '.', and all
+            # directories called 'tests' or 'docs', are not traversed into.
+            for dirname in list(dirs):
+                if dirname in ('tests', 'docs') or dirname.startswith('.'):
+                    dirs.remove(dirname)
+            continue
+        relative_dir = os.path.relpath(root, collection_path)
+        directories.append(relative_dir)
+    return sorted(directories)
+
+
 def collect_collection_info(
     ansible_version: PypiVer,
     dependency_data: DependencyFileData,
@@ -532,12 +547,7 @@ def collect_collection_info(
             namespace, name = collection.split('.', 1)
             collection_namespaces[namespace].append(name)
             collection_path = os.path.join(ansible_collections_dir, namespace, name)
-            collection_directories[collection] = [
-                file for file in os.listdir(collection_path)
-                if file not in ('tests', 'docs')
-                and not file.startswith('.')
-                and os.path.isdir(os.path.join(collection_path, file))
-            ]
+            collection_directories[collection] = _collect_collection_data_dirs(collection_path)
     else:
         # pylint:disable-next=unused-variable
         collection_exclude_paths, collection_ignored_files = compile_collection_exclude_paths(

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -520,7 +520,7 @@ def compile_collection_exclude_paths(collection_names: Collection[str],
 
 def _collect_collection_data_dirs(collection_path: str) -> list[str]:
     directories = []
-    for root, dirs, _ in os.walk(collection_path, topdown=True):
+    for root, dirs, _ in os.walk(collection_path, topdown=True, followlinks=True):
         if root == collection_path:
             # Make sure that all directories starting with '.', and all
             # directories called 'tests' or 'docs', are not traversed into.

--- a/src/antsibull/data/ansible-setup_py.j2
+++ b/src/antsibull/data/ansible-setup_py.j2
@@ -200,7 +200,7 @@ setup(
         'ansible_collections.{{ collection }}': [
             '*',
 {%-     for dir in collection_directories[collection] %}
-            '{{ dir }}/**/*', '{{ dir }}/**/.*',
+            '{{ dir }}/*', '{{ dir }}/.*',
 {%-     endfor %}
         ],
 {%-   endfor %}


### PR DESCRIPTION
These are only supported since setuptools 62.3.0 (https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6230) (see https://github.com/pypa/setuptools/issues/1806 for details).