### PR TITLE
dep_closure: make error message clearer

### DIFF
--- a/changelogs/fragments/531-dep-closure-error.yaml
+++ b/changelogs/fragments/531-dep-closure-error.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Make ``dep_closure`` errors clearer by including the offending collection's version in the message
+    (https://github.com/ansible-community/antsibull/pull/531).

--- a/src/antsibull/dep_closure.py
+++ b/src/antsibull/dep_closure.py
@@ -51,8 +51,8 @@ def analyze_deps(collections: Mapping[str, CollectionRecord]) -> list[str]:
             dependency_version = SemVer(collections[dep_name].version)
             if dependency_version not in SemVerSpec(dep_version_spec):
                 errors.append(
-                    f"{collection_name} version_conflict:"
-                    f" {dep_name}-{str(dependency_version)} but needs"
+                    f"{collection_name} {collection_info.version} version_conflict:"
+                    f" {dep_name}-{dependency_version} but needs"
                     f" {dep_version_spec}"
                 )
                 continue


### PR DESCRIPTION
Include the offending collection's version in the error message to make debuging easier. This also removes an unnecessary call to str() in an f-string. This is called automatically.