### PR TITLE
Fix codecov paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,3 +25,6 @@ coverage:
         only_pulls: false
 github_checks:
   annotations: false
+
+fixes:
+  - "antsibull/::"


### PR DESCRIPTION
The web UI cannot show code coverage based on lines since there is an additional antsibull/ prefix for the paths.