### PR TITLE
Use ansible-documentation repo for core porting guide

### DIFF
--- a/changelogs/fragments/540.yaml
+++ b/changelogs/fragments/540.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Retrieve the ansible-core Porting Guide from the ansible-documentation
+    repo. These files are being removed from the ansible-core repo
+    (https://github.com/ansible-community/antsibull/pull/540).

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -320,7 +320,9 @@ class AnsibleCoreChangelogCollector:
         self.changelog = ChangelogData.concatenate(changelogs)
 
     async def download_porting_guide(self, aio_session: aiohttp.client.ClientSession):
-        branch_url = "https://raw.githubusercontent.com/ansible/ansible/devel"
+        branch_url = (
+            "https://raw.githubusercontent.com/ansible/ansible-documentation/devel"
+        )
 
         query_url = f"{branch_url}/{get_porting_guide_filename(self.latest)}"
         async with aio_session.get(query_url) as response:


### PR DESCRIPTION
As of https://github.com/ansible-community/community-topics/issues/240, the ansible documentation (including porting guides) are stored in a new repository.