### PR TITLE
Use 'hatch version' instead of manually updating the version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -289,17 +289,6 @@ def check_package_files(
         )
 
 
-def _repl_version(session: nox.Session, new_version: str):
-    with open("pyproject.toml", "r+") as fp:
-        lines = tuple(fp)
-        fp.seek(0)
-        for line in lines:
-            if line.startswith("version = "):
-                line = f'version = "{new_version}"\n'
-            fp.write(line)
-        fp.truncate()
-
-
 def check_no_modifications(session: nox.Session) -> None:
     modified = session.run(
         "git",
@@ -356,7 +345,9 @@ def bump(session: nox.Session):
                 "or two positional arguments must be provided."
             )
     install(session, "antsibull-changelog[toml]", "hatch")
-    _repl_version(session, version)
+    current_version = session.run("hatch", "version", silent=True).strip()
+    if version != current_version:
+        session.run("hatch", "version", version)
     if len(session.posargs) > 1:
         fragment = session.run(
             "python",
@@ -403,8 +394,7 @@ def publish(session: nox.Session):
     check_no_modifications(session)
     install(session, "hatch")
     session.run("hatch", "publish", *session.posargs)
-    version = session.run("hatch", "version", silent=True).strip()
-    _repl_version(session, f"{version}.post0")
+    session.run("hatch", "version", "post")
     session.run("git", "add", "pyproject.toml", external=True)
     session.run("git", "commit", "-m", "Post-release version bump.", external=True)
 


### PR DESCRIPTION
We did this change to antsibull-docs some time ago. I had to fix that a bit today with https://github.com/ansible-community/antsibull-docs/commit/676780b99912f5e9d8b206b14a65ed03d8405919. This PR applies the noxfile changes to this project as well.