### PR TITLE
build-release: ensure Python files in the package compile

### DIFF
--- a/changelogs/fragments/552-compileall.yaml
+++ b/changelogs/fragments/552-compileall.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - build-release role - add a test to ensure that Python files in the
+    ansible package successfully compile
+    (https://github.com/ansible-community/antsibull/pull/552).

--- a/roles/build-release/defaults/main.yaml
+++ b/roles/build-release/defaults/main.yaml
@@ -59,6 +59,17 @@ antsibull_tags_enforce_policy: false
 # File containing a newline separated list of collections to ignore
 antsibull_tags_ignores_file: "{{ antsibull_data_dir }}/validate-tags-ignores"
 
+
+#####
+# These variables relate to testing byte-compilation of the Python code in the
+# package.
+# None of them apply if antsibull_test_bytecompile is false.
+antsibull_test_bytecompile: true
+antsibull_test_bytecompile_pythons:
+  - "{{ ansible_python_executable | default(ansible_playbook_python) }}"
+# Default to using all CPUs
+antsibull_test_bytecompile_jobs: 0
+
 # TODO:
 # --dest-data-dir (Directory to write .build and .deps files to, as well as changelog and porting guide if applicable. Defaults to --data-dir)
 # --collection-cache (Directory of cached collection tarballs. Will be used if a collection tarball to be downloaded exists in here, and will be populated when downloading new tarballs.)

--- a/roles/build-release/meta/argument_specs.yml
+++ b/roles/build-release/meta/argument_specs.yml
@@ -108,3 +108,21 @@ argument_specs:
             This file will be ignored if it doesn't exist.
         type: path
         default: "{{ antsibull_data_dir }}/validate-tags-ignores"
+      antsibull_test_bytecompile:
+        description:
+          - Whether to run a test byte-compiliation of the Python code in the ansible package
+        type: bool
+        default: true
+      antsibull_test_bytecompile_pythons:
+        description:
+          - Which Python interpreters to use for the test byte-compilation
+        type: list
+        elements: str
+        default:
+          - "{{ ansible_python_executable | default(ansible_playbook_python) }}"
+      antsibull_test_bytecompile_jobs:
+        description:
+          - How many threads to use to byte-compile the Python code in the ansible package
+          - Defaults to 0 (all available CPUs)
+        type: int
+        default: 0

--- a/roles/build-release/tasks/test_bytecompile.yaml
+++ b/roles/build-release/tasks/test_bytecompile.yaml
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Maxwell G <maxwell@gtmx.me>
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Run tests in a tempdir
+  block:
+    - name: Create tempdir
+      register: _tempdir
+      ansible.builtin.tempfile:
+        state: directory
+    - name: Unpack wheel
+      ansible.builtin.command:
+        argv:
+          - "unzip"
+          - "-d{{ _tempdir.path }}"
+          - "-q"
+          - "{{ _release_wheel }}"
+    - name: Run bytecompile
+      ansible.builtin.command:
+        argv:
+          - "{{ _current_python }}"
+          - "-m"
+          - "compileall"
+          - "-q"
+          - "-j{{ antsibull_test_bytecompile_jobs | string }}"
+          - "{{ _tempdir.path }}/ansible_collections"
+  always:
+    - name: Clean tempdir
+      ansible.builtin.file:
+        dest: "{{ _tempdir.path }}"
+        state: absent

--- a/roles/build-release/tasks/tests.yaml
+++ b/roles/build-release/tasks/tests.yaml
@@ -126,3 +126,10 @@
           -e antsibull_ansible_venv="{{ antsibull_ansible_venv }}"
           -e _python_version="{{ _python_version }}"
           {{ playbook_dir }}/nested-ansible-tests.yaml
+
+- name: Byte-compile python modules
+  when: antsibull_test_bytecompile
+  loop: "{{ antsibull_test_bytecompile_pythons }}"
+  loop_control:
+    loop_var: _current_python
+  ansible.builtin.include_tasks: "test_bytecompile.yaml"


### PR DESCRIPTION
We've had multiple problems with certain collections pushing releases
with broken Python files that don't compile. These issues break
downstream packages even for users that don't need the broken plugins.
This basic smoke test should help us prevent that type of issue.
