### PR TITLE
build-release: directly install the wheel for testing

### DIFF
--- a/changelogs/fragments/553-release-wheel-test.yaml
+++ b/changelogs/fragments/553-release-wheel-test.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - build-release role - directly install the wheel when running tests
+    (https://github.com/ansible-community/antsibull/pull/553).

--- a/roles/build-release/tasks/tests.yaml
+++ b/roles/build-release/tasks/tests.yaml
@@ -17,9 +17,9 @@
   ansible.builtin.set_fact:
     _python_version: "python{{ ansible_python.version.major }}.{{ ansible_python.version.minor }}"
 
-- name: Install the release tarball in a virtualenv so we can test it
+- name: Install the release wheel in a virtualenv so we can test it
   ansible.builtin.pip:
-    name: "file://{{ _release_archive }}"
+    name: "file://{{ _release_wheel }}"
     state: present
     virtualenv: "{{ antsibull_ansible_venv }}"
     virtualenv_command: "{{ ansible_python.executable }} -m venv"


### PR DESCRIPTION
We should test the wheel we build and ship to users instead of having
pip build a new one from the sdist. Also, this makes this task more
efficient. Unpacking the sdist, building the wheel, and then unpacking
and installing that wheel takes a while for a large package such as
ansible.
