### PR TITLE
build_meta: remove ansible-core Github repo links

### DIFF
--- a/changelogs/fragments/558-classifiers2.yaml
+++ b/changelogs/fragments/558-classifiers2.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - "``ansible`` python metadata - remove links specific to ``ansible-core``
+    and add links to the Ansible forum and the ``ansible-build-data`` repository
+    (https://github.com/ansible-community/antsibull/pull/558)."

--- a/src/antsibull/constants.py
+++ b/src/antsibull/constants.py
@@ -16,9 +16,12 @@ MINIMUM_ANSIBLE_VERSIONS = {
     "PACKAGE_DATA_NEW_METHOD": PypiVer("8.0.0a1"),
     # Whether to store setuptools config in setup.cfg
     "BUILD_META_MAKER": PypiVer("9.0.0.dev0"),
+    "BUILD_META_NEW_URLS": PypiVer("9.0.0rc1"),
 }
 
 DOCSITE_BASE_URL = "https://docs.ansible.com/ansible"
 DOCSITE_COMMUNITY_URL = "https://docs.ansible.com/ansible/latest/community"
+BUILD_DATA_URL = "https://github.com/ansible-community/ansible-build-data"
+ANSIBLE_FORUM_URL = "https://forum.ansible.com"
 
 COLLECTION_EXCLUDE_DIRS = ("docs", "tests")

--- a/src/antsibull/python_metadata.py
+++ b/src/antsibull/python_metadata.py
@@ -25,6 +25,8 @@ from jinja2 import Template
 from packaging.version import Version as PypiVer
 
 from .constants import (
+    ANSIBLE_FORUM_URL,
+    BUILD_DATA_URL,
     COLLECTION_EXCLUDE_DIRS,
     DOCSITE_BASE_URL,
     DOCSITE_COMMUNITY_URL,
@@ -65,6 +67,28 @@ class IniList(IniType, list):
 
 INI_TYPES = Union[IniType, str, bool]
 
+OLD_URLS = IniDict(
+    {
+        "Bug Tracker": "https://github.com/ansible/ansible/issues",
+        "Code of Conduct": DOCSITE_COMMUNITY_URL + "/code_of_conduct.html",
+        "Documentation": DOCSITE_BASE_URL,
+        "Mailing lists": DOCSITE_COMMUNITY_URL
+        + "/communication.html#mailing-list-information",
+        "Source Code": "https://github.com/ansible/ansible",
+    }
+)
+
+NEW_URLS = IniDict(
+    {
+        "Build Data": BUILD_DATA_URL,
+        "Code of Conduct": DOCSITE_COMMUNITY_URL + "/code_of_conduct.html",
+        "Documentation": DOCSITE_BASE_URL,
+        "Forum": ANSIBLE_FORUM_URL,
+        "Mailing lists": DOCSITE_COMMUNITY_URL
+        + "/communication.html#mailing-list-information",
+    }
+)
+
 DEFAULT_METADATA: dict[str, INI_TYPES] = {
     "name": "ansible",
     "description": "Radically simple IT automation",
@@ -73,19 +97,6 @@ DEFAULT_METADATA: dict[str, INI_TYPES] = {
     "author": "Ansible, Inc.",
     "author_email": "info@ansible.com",
     "url": "https://ansible.com/",
-    "project_urls": IniDict(
-        {
-            # XXX: Should we replace Bug Tracker and Source Code with something
-            # else that's not copied from ansible-core?
-            # Should we use ansible_core_repo_url from LibContext instead?
-            "Bug Tracker": "https://github.com/ansible/ansible/issues",
-            "Code of Conduct": DOCSITE_COMMUNITY_URL + "/code_of_conduct.html",
-            "Documentation": DOCSITE_BASE_URL,
-            "Mailing lists": DOCSITE_COMMUNITY_URL
-            + "/communication.html#mailing-list-information",
-            "Source Code": "https://github.com/ansible/ansible",
-        }
-    ),
     "license": "GPL-3.0-or-later",
     "classifiers": IniList(
         [
@@ -271,6 +282,12 @@ class BuildMetaMaker:
         self["metadata"]["version"] = self.ansible_version
         self["metadata"].setdefault("classifiers", IniList()).extend(
             self.core_python_classifiers
+        )
+        self["metadata"].setdefault(
+            "project_urls",
+            NEW_URLS
+            if self.ansible_version >= MINIMUM_ANSIBLE_VERSIONS["BUILD_META_NEW_URLS"]
+            else OLD_URLS,
         )
         self["options"].setdefault("install_requires", IniList()).append(
             f"ansible-core ~= {self.ansible_core_version}"

--- a/tests/test_data/package-files/force_setup_cfg/8.1.0/setup.cfg
+++ b/tests/test_data/package-files/force_setup_cfg/8.1.0/setup.cfg
@@ -6,12 +6,6 @@ long_description_content_type = text/x-rst
 author = Ansible, Inc.
 author_email = info@ansible.com
 url = https://ansible.com/
-project_urls = 
-	Bug Tracker = https://github.com/ansible/ansible/issues
-	Code of Conduct = https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
-	Documentation = https://docs.ansible.com/ansible
-	Mailing lists = https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information
-	Source Code = https://github.com/ansible/ansible
 license = GPL-3.0-or-later
 classifiers = 
 	  Development Status :: 5 - Production/Stable
@@ -29,6 +23,12 @@ classifiers =
 	  Programming Language :: Python :: 3.11
 	  Programming Language :: Python :: 3 :: Only
 version = 8.1.0
+project_urls = 
+	Build Data = https://github.com/ansible-community/ansible-build-data
+	Code of Conduct = https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
+	Documentation = https://docs.ansible.com/ansible
+	Forum = https://forum.ansible.com
+	Mailing lists = https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information
 
 [options]
 zip_safe = False

--- a/tests/verify_package_files.py
+++ b/tests/verify_package_files.py
@@ -149,7 +149,12 @@ def generate_package_files(
         if force_generate_setup_cfg
         else contextlib.nullcontext()
     )
-    with cm:
+    cm2 = (
+        patch_dict(MINIMUM_ANSIBLE_VERSIONS, "BUILD_META_NEW_URLS", PypiVer(version))
+        if force_generate_setup_cfg
+        else contextlib.nullcontext()
+    )
+    with cm, cm2:
         if r := antsibull_build.run(
             [
                 "antsibull-build",


### PR DESCRIPTION
This removes the Bug Tracker and Source Code links from the ansible package's Python metadata that point to ansible-core repository.

These links are confusing. ansible-core's issue tracker is only for issues that apply to core, not all of the ansible package. None of the source code from ansible/ansible is included directly in this package, either.

The ansible-core links are replaced with a link to the forum and a link to the ansible-build-data repository.

This only applies to ansible >= 9.0.0rc1.