### PR TITLE
CI dumb-pypi: set major version to 10

### DIFF
--- a/.github/workflows/build-dumb-pypi.yml
+++ b/.github/workflows/build-dumb-pypi.yml
@@ -5,7 +5,7 @@
 
 name: 👷 dumb PyPI on GH pages
 env:
-  ANSIBLE_MAJOR_VERSION: '8'
+  ANSIBLE_MAJOR_VERSION: '10'
 on:
   push:
     branches:


### PR DESCRIPTION
ansible 10 is the next major version, so we should use that for the
nightly test builds. It has the necessary constraints and validate-tags
ignore tags to build with new dependencies.
