### PR TITLE
Don't assume that pydantic.HttpUrl is a str subclass

### DIFF
--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -513,7 +513,7 @@ def prepare_command() -> int:
         get_collection_and_core_versions(
             deps,
             ansible_core_version_obj,
-            app_ctx.galaxy_url,
+            str(app_ctx.galaxy_url),
             ansible_core_allow_prerelease=_is_alpha(app_ctx.extra["ansible_version"]),
             constraints=constraints,
         )
@@ -613,7 +613,7 @@ def rebuild_single_command() -> int:
         asyncio.run(
             download_collections(
                 included_versions,
-                app_ctx.galaxy_url,
+                str(app_ctx.galaxy_url),
                 download_dir,
                 app_ctx.collection_cache,
             )

--- a/src/antsibull/cli/antsibull_build.py
+++ b/src/antsibull/cli/antsibull_build.py
@@ -599,6 +599,8 @@ def run(args: list[str]) -> int:
 
     context_data = app_context.create_contexts(args=parsed_args, cfg=cfg)
     with app_context.app_and_lib_context(context_data) as (app_ctx, dummy_):
+        # TODO: Call `model_dump()` instead of deprecated `dict()`
+        # once support for pydantic v1/antsibull-core v2 is dropped
         twiggy.dict_config(app_ctx.logging_cfg.dict())
         flog.debug("Set logging config")
 

--- a/src/antsibull/new_ansible.py
+++ b/src/antsibull/new_ansible.py
@@ -132,7 +132,7 @@ def new_ansible_command() -> int:
         os.path.join(app_ctx.extra["data_dir"], app_ctx.extra["pieces_file"])
     )
     ansible_core_release_infos, dependencies = asyncio.run(
-        get_version_info(collections, app_ctx.pypi_url)
+        get_version_info(collections, str(app_ctx.pypi_url))
     )
     ansible_core_versions = [
         (PypiVer(version), data[0]["requires_python"])


### PR DESCRIPTION
In Pydantic v2, `pydantic.HttpUrl` is no longer a subclass of `str`, so it's necessary to coerce it into a str for functions that expect that.

Relates: https://github.com/ansible-community/antsibull-core/pull/119

---

This can be merged anytime. The changes here are compatible with both pydantic v1 and pydantic v2.