### PR TITLE
Use certain fields from library context instead of app context that are deprecated in the app context and are removed from antsibull-core 3.0.0

### DIFF
--- a/changelogs/fragments/569-context.yml
+++ b/changelogs/fragments/569-context.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Use certain fields from library context instead of app context that are deprecated in the app context and are removed from antsibull-core 3.0.0 (https://github.com/ansible-community/antsibull/pull/569)."

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -354,6 +354,7 @@ def _extract_python_requires(
 
 def prepare_command() -> int:
     app_ctx = app_context.app_ctx.get()
+    lib_ctx = app_context.lib_ctx.get()
 
     build_filename = os.path.join(
         app_ctx.extra["data_dir"], app_ctx.extra["build_file"]
@@ -378,8 +379,8 @@ def prepare_command() -> int:
     ansible_core_release_infos, collections_to_versions = asyncio.run(
         get_version_info(
             list(deps),
-            pypi_server_url=str(app_ctx.pypi_url),
-            galaxy_url=str(app_ctx.galaxy_url),
+            pypi_server_url=str(lib_ctx.pypi_url),
+            galaxy_url=str(lib_ctx.galaxy_url),
         )
     )
 
@@ -465,6 +466,7 @@ def prepare_command() -> int:
 
 def rebuild_single_command() -> int:
     app_ctx = app_context.app_ctx.get()
+    lib_ctx = app_context.lib_ctx.get()
 
     deps_filename = os.path.join(app_ctx.extra["data_dir"], app_ctx.extra["deps_file"])
     deps_file = DepsFile(deps_filename)
@@ -492,9 +494,9 @@ def rebuild_single_command() -> int:
         asyncio.run(
             download_collections(
                 included_versions,
-                str(app_ctx.galaxy_url),
+                str(lib_ctx.galaxy_url),
                 download_dir,
-                app_ctx.collection_cache,
+                lib_ctx.collection_cache,
             )
         )
 
@@ -508,7 +510,7 @@ def rebuild_single_command() -> int:
             app_ctx.extra["ansible_version"],
             deps_dir=app_ctx.extra["data_dir"],
             deps_data=[dependency_data],
-            collection_cache=app_ctx.collection_cache,
+            collection_cache=lib_ctx.collection_cache,
             ansible_changelog=ansible_changelog,
         )
 

--- a/src/antsibull/build_changelog.py
+++ b/src/antsibull/build_changelog.py
@@ -697,11 +697,12 @@ class ReleaseNotes:
 def build_changelog() -> int:
     """Create changelog and porting guide CLI command."""
     app_ctx = app_context.app_ctx.get()
+    lib_ctx = app_context.lib_ctx.get()
 
     ansible_version: PypiVer = app_ctx.extra["ansible_version"]
     data_dir: str = app_ctx.extra["data_dir"]
     dest_data_dir: str = app_ctx.extra["dest_data_dir"]
-    collection_cache: str | None = app_ctx.collection_cache
+    collection_cache: str | None = lib_ctx.collection_cache
 
     changelog = get_changelog(
         ansible_version, deps_dir=data_dir, collection_cache=collection_cache

--- a/src/antsibull/new_ansible.py
+++ b/src/antsibull/new_ansible.py
@@ -24,11 +24,12 @@ from .versions import (
 
 def new_ansible_command() -> int:
     app_ctx = app_context.app_ctx.get()
+    lib_ctx = app_context.lib_ctx.get()
     collections = parse_pieces_file(
         os.path.join(app_ctx.extra["data_dir"], app_ctx.extra["pieces_file"])
     )
     ansible_core_release_infos, collections_to_versions = asyncio.run(
-        get_version_info(collections, str(app_ctx.pypi_url))
+        get_version_info(collections, str(lib_ctx.pypi_url))
     )
     ansible_core_versions = [
         (PypiVer(version), data[0]["requires_python"])


### PR DESCRIPTION
These fields have been moved from app to library context for antsibull-core 2.0.0 (or even before?). I apparently forgot to fix this earlier...

Ref: https://github.com/ansible-community/antsibull-core/pull/128