### PR TITLE
Explicitly set up Galaxy context instead of relying on deprecated functionality

### DIFF
--- a/changelogs/fragments/570-galaxy-context.yml
+++ b/changelogs/fragments/570-galaxy-context.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Explicitly set up Galaxy context instead of relying on deprecated functionality from antsibull-core (https://github.com/ansible-community/antsibull/pull/570)."

--- a/src/antsibull/build_changelog.py
+++ b/src/antsibull/build_changelog.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import os.path
 import typing as t
@@ -23,6 +24,7 @@ from packaging.version import Version as PypiVer
 
 from .changelog import Changelog, ChangelogData, ChangelogEntry, get_changelog
 from .collection_meta import CollectionsMetadata
+from .utils.galaxy import create_galaxy_context
 
 #
 # Changelog
@@ -704,8 +706,12 @@ def build_changelog() -> int:
     dest_data_dir: str = app_ctx.extra["dest_data_dir"]
     collection_cache: str | None = lib_ctx.collection_cache
 
+    galaxy_context = asyncio.run(create_galaxy_context())
     changelog = get_changelog(
-        ansible_version, deps_dir=data_dir, collection_cache=collection_cache
+        ansible_version,
+        galaxy_context=galaxy_context,
+        deps_dir=data_dir,
+        collection_cache=collection_cache,
     )
 
     release_notes = ReleaseNotes.build(changelog)

--- a/src/antsibull/new_ansible.py
+++ b/src/antsibull/new_ansible.py
@@ -15,6 +15,7 @@ from antsibull_core.dependency_files import BuildFile, parse_pieces_file
 from packaging.version import Version as PypiVer
 
 from .changelog import ChangelogData
+from .utils.galaxy import create_galaxy_context
 from .versions import (
     find_latest_compatible,
     get_version_info,
@@ -28,8 +29,11 @@ def new_ansible_command() -> int:
     collections = parse_pieces_file(
         os.path.join(app_ctx.extra["data_dir"], app_ctx.extra["pieces_file"])
     )
+    galaxy_context = asyncio.run(create_galaxy_context())
     ansible_core_release_infos, collections_to_versions = asyncio.run(
-        get_version_info(collections, str(lib_ctx.pypi_url))
+        get_version_info(
+            collections, str(lib_ctx.pypi_url), galaxy_context=galaxy_context
+        )
     )
     ansible_core_versions = [
         (PypiVer(version), data[0]["requires_python"])

--- a/src/antsibull/utils/galaxy.py
+++ b/src/antsibull/utils/galaxy.py
@@ -1,0 +1,19 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Ansible Project, 2023
+"""Helper to create a Galaxy context."""
+
+from __future__ import annotations
+
+import aiohttp
+from antsibull_core.galaxy import GalaxyContext
+
+
+async def create_galaxy_context() -> GalaxyContext:
+    """
+    Create a Galaxy context.
+    """
+    async with aiohttp.ClientSession() as aio_session:
+        return await GalaxyContext.create(aio_session)

--- a/src/antsibull/versions.py
+++ b/src/antsibull/versions.py
@@ -18,7 +18,7 @@ import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
 from antsibull_core.ansible_core import AnsibleCorePyPiClient
 from antsibull_core.dependency_files import parse_pieces_file
-from antsibull_core.galaxy import GalaxyClient
+from antsibull_core.galaxy import GalaxyClient, GalaxyContext
 from packaging.version import Version as PypiVer
 from semantic_version import SimpleSpec as SemVerSpec
 from semantic_version import Version as SemVer
@@ -161,7 +161,8 @@ def _display_exception(loop, context):  # pylint:disable=unused-argument
 async def get_version_info(
     collections: Sequence[str],
     pypi_server_url: str | None = None,
-    galaxy_url: str | None = None,
+    *,
+    galaxy_context: GalaxyContext,
 ) -> tuple[dict[str, t.Any], dict[str, list[str]]]:
     """
     Return the versions of all the collections and ansible-core
@@ -180,7 +181,7 @@ async def get_version_info(
         )
         requestors["_ansible_core"] = await pool.spawn(pypi_client.get_release_info())
 
-        galaxy_client = GalaxyClient(aio_session, galaxy_server=galaxy_url)
+        galaxy_client = GalaxyClient(aio_session, context=galaxy_context)
         for collection in collections:
             requestors[collection] = await pool.spawn(
                 galaxy_client.get_versions(collection)


### PR DESCRIPTION
Found this while working on https://github.com/ansible-community/antsibull-core/issues/121.