### PR TITLE
ci nox: remove -v verbosity flag

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -68,7 +68,7 @@ jobs:
           python-versions: "${{ matrix.python-versions }}"
       - name: "Run nox -e ${{ matrix.session }}"
         run: |
-          OTHER_ANTSIBULL_MODE=git nox -v -e "${{ matrix.session }}"
+          OTHER_ANTSIBULL_MODE=git nox -e "${{ matrix.session }}"
       - name: Report coverage
         if: ${{ matrix.codecov }}
         run: |


### PR DESCRIPTION
The -v flag makes the CI output very unwieldy and difficult to read.
