### PR TITLE
pyproject.toml: fix duplicate pyperclip dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ dependencies = [
     "pydantic < 3",
     # pydantic already pulls it in, but we use it for TypedDict
     "typing_extensions",
-    # Used for sending announcements
-    "pyperclip",
 ]
 
 [[project.authors]]


### PR DESCRIPTION
pyperclip is an optional dependency now, but I forgot to remove it from
the main dependencies array.
