### PR TITLE
Pass CODECOV token to upload action

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -83,3 +83,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           directory: antsibull
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -79,3 +79,5 @@ jobs:
         with:
           directory: antsibull
           name: "${{ matrix.session }}"
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This was a breaking change in the codecov/codecov-action@v4 action.