### PR TITLE
Downgrade codecov uploader to v3 until it is no longer in a broken state

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -80,7 +80,7 @@ jobs:
         working-directory: antsibull
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           directory: antsibull
         env:

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -75,7 +75,7 @@ jobs:
           nox -v -e coverage
       - name: Upload coverage
         if: ${{ matrix.codecov }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           directory: antsibull
           name: "${{ matrix.session }}"


### PR DESCRIPTION
It breaks with
```

Traceback (most recent call last):
  File "codecov_cli/main.py", line 81, in <module>
  File "codecov_cli/main.py", line 77, in run
  File "click/core.py", line 1157, in __call__
  File "click/core.py", line 1078, in main
  File "click/core.py", line 1688, in invoke
  File "click/core.py", line 1434, in invoke
  File "click/core.py", line 783, in invoke
  File "click/decorators.py", line 33, in new_func
  File "codecov_cli/commands/upload.py", line 243, in do_upload
  File "codecov_cli/services/upload/__init__.py", line 71, in do_upload_logic
  File "codecov_cli/services/upload/upload_collector.py", line 152, in generate_upload_data
  File "codecov_cli/services/upload/network_finder.py", line 17, in find_files
  File "codecov_cli/helpers/versioning_systems.py", line 111, in list_relevant_files
ValueError: Can't determine root folder
```
While the corresponding issue (https://github.com/codecov/codecov-action/issues/1258) has been closed, it's not fixed, and there's only a workaround (https://github.com/codecov/feedback/issues/263#issuecomment-1928605435) which, seriously, looks pretty dubious to me.