### PR TITLE
Support antsibull-core v3.0.0a1

### DIFF
--- a/changelogs/fragments/586-core-3.0.0a1.yaml
+++ b/changelogs/fragments/586-core-3.0.0a1.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "Add support for the latest antsibull-core v3 pre-release, ``3.0.0a1``
+    (https://github.com/ansible-community/antsibull/pull/586)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "antsibull-changelog >= 0.24.0",
-    "antsibull-core >= 2.0.0, <= 3.0.0.dev0",
+    "antsibull-core >= 2.0.0, <= 3.0.0a1",
     "asyncio-pool",
     "build",
     "jinja2",


### PR DESCRIPTION
I'd like to release antsibull-core 3.0.0a1 and then get this merged before we release 0.60.0.