### PR TITLE
announcements: add missing newline before before heading

### DIFF
--- a/changelogs/fragments/589-announcement-fix2.yaml
+++ b/changelogs/fragments/589-announcement-fix2.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "announcements - add missing newline before heading in email template
+    (https://github.com/ansible-community/antsibull/pull/589)."

--- a/src/antsibull/data/ansible-email-announcement.j2
+++ b/src/antsibull/data/ansible-email-announcement.j2
@@ -11,6 +11,7 @@ We're happy to announce the release of the Ansible {{ version }} package{% if is
 
 Ansible {{ version }} depends on ansible-core {{ core_version }} and includes a curated set of Ansible collections that provide a vast number of modules, plugins, and roles.{% if is_major_release and is_prerelease %} This is a pre-release of Ansible {{ major_version }}.{% elif is_major_release %} This is the first stable release of Ansible {{ major_version }}.{% elif is_prerelease %} This is a pre-release of Ansible.{% endif %}
 
+
 {{ "How to get it" | email_heading }}
 
 This {% if is_prerelease %}pre-{% endif %}release is available on PyPI and can be installed with pip:

--- a/tests/test_data/announce-7.0.0/ansible-email-announcement.txt
+++ b/tests/test_data/announce-7.0.0/ansible-email-announcement.txt
@@ -3,6 +3,7 @@ Hello everyone,
 We're happy to announce the release of the Ansible 7.0.0 package!
 
 Ansible 7.0.0 depends on ansible-core 2.14.0 and includes a curated set of Ansible collections that provide a vast number of modules, plugins, and roles. This is the first stable release of Ansible 7.
+
 How to get it
 -------------
 

--- a/tests/test_data/announce-7.0.0b1/ansible-email-announcement.txt
+++ b/tests/test_data/announce-7.0.0b1/ansible-email-announcement.txt
@@ -3,6 +3,7 @@ Hello everyone,
 We're happy to announce the release of the Ansible 7.0.0b1 package pre-release!
 
 Ansible 7.0.0b1 depends on ansible-core 2.14.0 and includes a curated set of Ansible collections that provide a vast number of modules, plugins, and roles. This is a pre-release of Ansible 7.
+
 How to get it
 -------------
 

--- a/tests/test_data/announce-7.4.0/ansible-email-announcement.txt
+++ b/tests/test_data/announce-7.4.0/ansible-email-announcement.txt
@@ -3,6 +3,7 @@ Hello everyone,
 We're happy to announce the release of the Ansible 7.4.0 package!
 
 Ansible 7.4.0 depends on ansible-core 2.14.4 and includes a curated set of Ansible collections that provide a vast number of modules, plugins, and roles.
+
 How to get it
 -------------
 


### PR DESCRIPTION
We have trim_blocks enabled in the Jinja environment, so we need an
extra newline here.
