### PR TITLE
Add `antsibull_build_reset` role option

### DIFF
--- a/changelogs/fragments/601-antsibull_build_reset.yml
+++ b/changelogs/fragments/601-antsibull_build_reset.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "The release role now has a ``antsibull_build_reset`` option, which defaults to the value of ``antsibull_data_reset``, that allows
+     to control whether ``.build`` files are reset during alpha and beta-1 releases (https://github.com/ansible-community/antsibull/pull/601)."

--- a/roles/build-release/defaults/main.yaml
+++ b/roles/build-release/defaults/main.yaml
@@ -41,11 +41,15 @@ antsibull_ansible_major_version: "{{ (antsibull_ansible_version | default('')).s
 # Where the Ansible release tarball will be installed for test purposes
 antsibull_ansible_venv: "{{ antsibull_sdist_dir }}/venv"
 
-# Whether or not to start from scratch with a new venv if one exists
-antsibull_venv_cleanup: true
+# Whether to forcefully reset the ansible-X.build file for alpha and beta-1 releases
+# ex: set to false if there are manual changes that should not be overwritten
+antsibull_build_reset: "{{ antsibull_data_reset }}"
 
 # Whether to preserve existing .deps files during the prepare step
 antsibull_preserve_deps: false
+
+# Whether or not to start from scratch with a new venv if one exists
+antsibull_venv_cleanup: true
 
 
 #####

--- a/roles/build-release/meta/argument_specs.yml
+++ b/roles/build-release/meta/argument_specs.yml
@@ -58,7 +58,7 @@ argument_specs:
       antsibull_data_reset:
         description:
           - Whether to forcefully reset the ansible-build-data repository.
-          - Set to C(false) if there are manual changes that should not be overwritten.
+          - Set to V(false) if there are manual changes that should not be overwritten.
         type: bool
         default: true
 
@@ -86,6 +86,16 @@ argument_specs:
           - Where the Ansible release tarball will be installed for test purposes.
         type: path
         default: "{{ antsibull_sdist_dir }}/venv"
+
+      antsibull_build_reset:
+        description:
+          - If set to V(true), will reset existing C(.build) files during the preparation of
+            alpha and beta-1 releases.
+          - If set to V(false), will only create C(.build) files if they do not yet exist.
+          - The default value is the one of O(antsibull_data_reset) for backwards compatibility.
+        type: bool
+        default: antsibull_data_reset
+        version_added: 0.63.0
 
       antsibull_venv_cleanup:
         description:

--- a/roles/build-release/tasks/build.yaml
+++ b/roles/build-release/tasks/build.yaml
@@ -36,7 +36,7 @@
       --data-dir {{ antsibull_data_dir }}
       {{ _allow_prereleases | default('') }}
   when: >-
-    (antsibull_ansible_version is regex("^\d+.\d+.\d+(a\d+|b1)$") and antsibull_data_reset)
+    (antsibull_ansible_version is regex("^\d+.\d+.\d+(a\d+|b1)$") and antsibull_build_reset)
     or not _antsibull_build_file_stat.stat.exists
 
 - name: Set up feature freeze for b2 and later betas, and release candidates


### PR DESCRIPTION
This is needed to successfully build alpha-x (x > 1) and beta-1 releases with the automated release process from ansible-build-data. That process always sets `antsibull_data_reset=false`, which prevents reset of the `.build` file when it already exists.

This will cause problems for pre-releases following feature freeze, since antsibull assumes that the build file has been regenerated for the feature freeze release.

Having a new option which specifically controls regeneration of the `.build` file allows to fix the automated release process.
