### PR TITLE
Fix bug in --preserve-deps handling

### DIFF
--- a/changelogs/fragments/602-preserve_deps.yml
+++ b/changelogs/fragments/602-preserve_deps.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix bug in ``--preserve-deps`` option handling (https://github.com/ansible-community/antsibull/pull/602)."

--- a/src/antsibull/build_ansible_commands.py
+++ b/src/antsibull/build_ansible_commands.py
@@ -407,7 +407,7 @@ def validate_deps_data(
     constraints: dict[str, SemVerSpec],
 ) -> None:
     """
-    Validate dependencies against constraints and build deps.
+    Validate collection dependencies against constraints and build deps.
 
     Raise ``ValueError`` in case of inconsistencies.
     """
@@ -467,6 +467,7 @@ def prepare_command() -> int:
 
     if app_ctx.extra["preserve_deps"] and os.path.exists(deps_filename):
         dependency_data = deps_file.parse()
+        python_requires = dependency_data.deps.pop("_python")
     else:
         dependency_data = prepare_deps(
             app_ctx.extra["ansible_version"],


### PR DESCRIPTION
The `_python` key had to be removed.

See https://github.com/ansible-community/ansible-build-data/actions/runs/9078234072/job/24944827409 for why this is needed.