### PR TITLE
Add space after release notes and emojis

### DIFF
--- a/src/antsibull/data/ansible-matrix-announcement.j2
+++ b/src/antsibull/data/ansible-matrix-announcement.j2
@@ -13,4 +13,4 @@
 python3 -m pip install ansible=={{ version }} --user
 ```
 
-➡️ Check [Release Notes📦️🗒️]({{ build_data_path }}/CHANGELOG-v{{ major_version }}.md) and [Ansible {{ major_version }} Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_{{ major_version }}.html) for more details!
+➡️ Check [Release Notes 📦️🗒️]({{ build_data_path }}/CHANGELOG-v{{ major_version }}.md) and [Ansible {{ major_version }} Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_{{ major_version }}.html) for more details!

--- a/tests/test_data/announce-7.0.0/ansible-matrix-announcement.md
+++ b/tests/test_data/announce-7.0.0/ansible-matrix-announcement.md
@@ -6,4 +6,4 @@
 python3 -m pip install ansible==7.0.0 --user
 ```
 
-➡️ Check [Release Notes📦️🗒️](https://github.com/ansible-community/ansible-build-data/blob/7.0.0/7/CHANGELOG-v7.md) and [Ansible 7 Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_7.html) for more details!
+➡️ Check [Release Notes 📦️🗒️](https://github.com/ansible-community/ansible-build-data/blob/7.0.0/7/CHANGELOG-v7.md) and [Ansible 7 Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_7.html) for more details!

--- a/tests/test_data/announce-7.0.0b1/ansible-matrix-announcement.md
+++ b/tests/test_data/announce-7.0.0b1/ansible-matrix-announcement.md
@@ -6,4 +6,4 @@
 python3 -m pip install ansible==7.0.0b1 --user
 ```
 
-➡️ Check [Release Notes📦️🗒️](https://github.com/ansible-community/ansible-build-data/blob/7.0.0b1/7/CHANGELOG-v7.md) and [Ansible 7 Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_7.html) for more details!
+➡️ Check [Release Notes 📦️🗒️](https://github.com/ansible-community/ansible-build-data/blob/7.0.0b1/7/CHANGELOG-v7.md) and [Ansible 7 Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_7.html) for more details!

--- a/tests/test_data/announce-7.4.0/ansible-matrix-announcement.md
+++ b/tests/test_data/announce-7.4.0/ansible-matrix-announcement.md
@@ -6,4 +6,4 @@
 python3 -m pip install ansible==7.4.0 --user
 ```
 
-➡️ Check [Release Notes📦️🗒️](https://github.com/ansible-community/ansible-build-data/blob/7.4.0/7/CHANGELOG-v7.md) and [Ansible 7 Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_7.html) for more details!
+➡️ Check [Release Notes 📦️🗒️](https://github.com/ansible-community/ansible-build-data/blob/7.4.0/7/CHANGELOG-v7.md) and [Ansible 7 Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_7.html) for more details!


### PR DESCRIPTION
Somehow adding tests changes to https://github.com/ansible-community/antsibull/pull/605 didn't push it up to that.. pr, so opening a new PR

Addes a space after Release Notes in the announcements so the Bullhorn renders properly.