### PR TITLE
Add tab completion to antsibull-build

### DIFF
--- a/changelogs/fragments/611-argcomplete.yml
+++ b/changelogs/fragments/611-argcomplete.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - "If you are using `argcomplete <https://pypi.org/project/argcomplete/>`__, you can now tab-complete ``antsibull-build`` command lines.
+     See `Activating global completion <https://pypi.org/project/argcomplete/#activating-global-completion>`__ in the argcomplete README for
+     how to enable tab completion globally. This will also tab-complete Ansible commands such as ``ansible-playbook`` and ``ansible-test``
+     (https://github.com/ansible-community/antsibull/pull/611)."

--- a/src/antsibull/cli/antsibull_build.py
+++ b/src/antsibull/cli/antsibull_build.py
@@ -3,6 +3,9 @@
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: Ansible Project, 2020
+
+# PYTHON_ARGCOMPLETE_OK
+
 """Entrypoint to the antsibull-build tool."""
 
 from __future__ import annotations
@@ -11,6 +14,13 @@ import argparse
 import os.path
 import sys
 from pathlib import Path
+
+try:
+    import argcomplete
+
+    HAS_ARGCOMPLETE = True
+except ImportError:
+    HAS_ARGCOMPLETE = False
 
 import twiggy  # type: ignore[import]
 from antsibull_core.logging import initialize_app_logging, log
@@ -758,6 +768,10 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         " Defaults to performing all actions.",
         dest="send_actions",
     )
+
+    # This must come after all parser setup
+    if HAS_ARGCOMPLETE:
+        argcomplete.autocomplete(parser)
 
     parsed_args: argparse.Namespace = parser.parse_args(args)
 


### PR DESCRIPTION
Ref: https://github.com/ansible-community/antsibull-changelog/pull/173

I did work a bit on improving startup times, but that turned out to be more complex since also constants are imported from some packages that are used in the help output, and moving them to `antsibull.constants` turned out not to be trivial (since they are dict keys where the values are functions from that module). Since startup time isn't *that* bad ("only" ~0.3 seconds) and antsibull-build isn't used by that many folks I've decided to keep the startup as-is.
