### PR TITLE
Add collection-meta.yaml linter

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -29,14 +29,14 @@ jobs:
             options: '-e antsibull_ansible_version=8.99.0'
             python: '3.9'
             antsibull_changelog_ref: 0.24.0
-            antsibull_core_ref: stable-2
+            antsibull_core_ref: main
             antsibull_docutils_ref: 1.0.0  # isn't used by antsibull-changelog 0.24.0
             antsibull_fileutils_ref: main
           - name: Ansible 9
             options: '-e antsibull_ansible_version=9.99.0'
             python: '3.11'
             antsibull_changelog_ref: main
-            antsibull_core_ref: stable-2
+            antsibull_core_ref: main
             antsibull_docutils_ref: main
             antsibull_fileutils_ref: main
           - name: Ansible 10

--- a/changelogs/fragments/617-collection-meta-linter.yml
+++ b/changelogs/fragments/617-collection-meta-linter.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "Add subcommand ``lint-collection-meta`` for linting ``collection-meta.yaml`` files in ``ansible-build-data`` (https://github.com/ansible-community/antsibull/pull/617)."
+breaking_changes:
+  - "Antsibull now depends on antsibull-core >= 3.0.0 and pydantic >= 2.0.0 (https://github.com/ansible-community/antsibull/pull/617)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "antsibull-changelog >= 0.24.0",
-    "antsibull-core >= 2.0.0, < 4.0.0",
+    "antsibull-core >= 3.0.0, < 4.0.0",
     "antsibull-fileutils >= 1.0.0, < 2.0.0",
     "asyncio-pool",
     "build",
@@ -38,8 +38,7 @@ dependencies = [
     "aiohttp >= 3.0.0",
     "twiggy",
     "pyyaml",
-    # We rely on deprecated features to maintain compat btw. pydantic v1 and v2
-    "pydantic < 3",
+    "pydantic >= 2, < 3",
     # pydantic already pulls it in, but we use it for TypedDict
     "typing_extensions",
 ]

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -506,7 +506,7 @@ def get_changelog(
         PypiVer(ansible_ancestor_version_str) if ansible_ancestor_version_str else None
     )
 
-    collection_metadata = CollectionsMetadata(deps_dir)
+    collection_metadata = CollectionsMetadata.load_from(deps_dir)
 
     if deps_dir is not None:
         for path in glob.glob(os.path.join(deps_dir, "*.deps"), recursive=False):

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -52,7 +52,13 @@ class RemovalInformation(p.BaseModel):
     model_config = p.ConfigDict(extra="ignore", arbitrary_types_allowed=True)
 
     major_version: t.Union[int, t.Literal["TBD"]]
-    reason: t.Literal["deprecated", "considered-unmaintained", "renamed", "other"]
+    reason: t.Literal[
+        "deprecated",
+        "considered-unmaintained",
+        "renamed",
+        "guidelines-violation",
+        "other",
+    ]
     reason_text: t.Optional[str] = None
     announce_version: t.Optional[PydanticPypiVersion] = None
     new_name: t.Optional[str] = None
@@ -61,13 +67,16 @@ class RemovalInformation(p.BaseModel):
 
     @p.model_validator(mode="after")
     def _check_reason_text(self) -> Self:
-        if self.reason == "other":
+        reasons_with_text = ("other", "guidelines-violation")
+        if self.reason in reasons_with_text:
             if self.reason_text is None:
-                raise ValueError("reason_text must be provided if reason is 'other'")
+                reasons = ", ".join(f"'{reason}'" for reason in reasons_with_text)
+                raise ValueError(f"reason_text must be provided if reason is {reasons}")
         else:
             if self.reason_text is not None:
+                reasons = ", ".join(f"'{reason}'" for reason in reasons_with_text)
                 raise ValueError(
-                    "reason_text must not be provided if reason is not 'other'"
+                    f"reason_text must not be provided if reason is not {reasons}"
                 )
         return self
 

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -63,11 +63,11 @@ class RemovalInformation(p.BaseModel):
     def _check_reason_text(self) -> Self:
         if self.reason == "other":
             if self.reason_text is None:
-                raise ValueError("reason_text must be provided if reason is other")
+                raise ValueError("reason_text must be provided if reason is 'other'")
         else:
             if self.reason_text is not None:
                 raise ValueError(
-                    "reason_text must not be provided if reason is not other"
+                    "reason_text must not be provided if reason is not 'other'"
                 )
         return self
 
@@ -76,7 +76,7 @@ class RemovalInformation(p.BaseModel):
         if self.reason != "renamed":
             return self
         if self.new_name is None:
-            raise ValueError("new_name must be provided if reason is renamed")
+            raise ValueError("new_name must be provided if reason is 'renamed'")
         if (
             self.redirect_replacement_major_version is not None
             and self.major_version != "TBD"
@@ -92,13 +92,13 @@ class RemovalInformation(p.BaseModel):
         if self.reason == "renamed":
             return self
         if self.new_name is not None:
-            raise ValueError("new_name must not be provided if reason is not renamed")
+            raise ValueError("new_name must not be provided if reason is not 'renamed'")
         if self.redirect_replacement_major_version is not None:
             raise ValueError(
-                "redirect_replacement_major_version must not be provided if reason is not renamed"
+                "redirect_replacement_major_version must not be provided if reason is not 'renamed'"
             )
         if self.major_version == "TBD":
-            raise ValueError("major_version must not be TBD if reason is not renamed")
+            raise ValueError("major_version must not be TBD if reason is not 'renamed'")
         return self
 
 

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -25,11 +25,15 @@ if t.TYPE_CHECKING:
 
 
 def _convert_pypi_version(v: t.Any) -> t.Any:
-    if not isinstance(v, str):
-        raise ValueError(f"must be a string, got {v!r}")
-    if not v:
-        raise ValueError(f"must be a non-trivial string, got {v!r}")
-    version = PypiVer(v)
+    if isinstance(v, str):
+        if not v:
+            raise ValueError(f"must be a non-trivial string, got {v!r}")
+        version = PypiVer(v)
+    elif isinstance(v, PypiVer):
+        version = v
+    else:
+        raise ValueError(f"must be a string or PypiVer object, got {v!r}")
+
     if len(version.release) != 3:
         raise ValueError(
             f"must be a version with three release numbers (e.g. 1.2.3, 2.3.4a1), got {v!r}"

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -75,7 +75,9 @@ class RemovalInformation(p.BaseModel):
             raise ValueError("new_name must be provided if reason is renamed")
         if self.redirect_replacement_version is not None and self.version != "TBD":
             if self.redirect_replacement_version >= self.version:
-                raise ValueError("redirect_replacement_version must be smaller than version")
+                raise ValueError(
+                    "redirect_replacement_version must be smaller than version"
+                )
         return self
 
     @p.model_validator(mode="after")

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -25,11 +25,15 @@ if t.TYPE_CHECKING:
 
 
 def _convert_pypi_version(v: t.Any) -> t.Any:
-    if not isinstance(v, str):
-        raise ValueError(f"must be a string, got {v!r}")
-    if not v:
-        raise ValueError(f"must be a non-trivial string, got {v!r}")
-    version = PypiVer(v)
+    if isinstance(v, str):
+        if not v:
+            raise ValueError(f"must be a non-trivial string, got {v!r}")
+        version = PypiVer(v)
+    elif isinstance(v, PyPiVer):
+        version = v
+    else:
+        raise ValueError(f"must be a string or PypiVer object, got {v!r}")
+
     if len(version.release) != 3:
         raise ValueError(
             f"must be a version with three release numbers (e.g. 1.2.3, 2.3.4a1), got {v!r}"

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -20,6 +20,9 @@ from packaging.version import Version as PypiVer
 from pydantic.functional_validators import BeforeValidator
 from typing_extensions import Annotated
 
+if t.TYPE_CHECKING:
+    from _typeshed import StrPath
+
 
 def _convert_pypi_version(v: t.Any) -> t.Any:
     if not isinstance(v, str):
@@ -80,7 +83,7 @@ class CollectionsMetadata(p.BaseModel):
     collections: dict[str, CollectionMetadata]
 
     @staticmethod
-    def load_from(deps_dir: str | None):
+    def load_from(deps_dir: StrPath | None):
         if deps_dir is None:
             return CollectionsMetadata(collections={})
         collection_meta_path = os.path.join(deps_dir, "collection-meta.yaml")

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -45,7 +45,8 @@ class RemovalInformation(p.BaseModel):
     model_config = p.ConfigDict(extra="ignore", arbitrary_types_allowed=True)
 
     version: t.Union[int, t.Literal["TBD"]]
-    reason: t.Literal["deprecated", "considered-unmaintained", "renamed"]
+    reason: t.Literal["deprecated", "considered-unmaintained", "renamed", "other"]
+    reason_text: str
     announce_version: t.Optional[PydanticPypiVersion] = None
     new_name: t.Optional[str] = None
     discussion: t.Optional[p.HttpUrl] = None

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -63,11 +63,11 @@ class RemovalInformation(p.BaseModel):
     def _check_reason_text(self) -> Self:
         if self.reason == "other":
             if self.reason_text is None:
-                raise ValueError("reason_text must be provided if reason is other")
+                raise ValueError("reason_text must be provided if reason is 'other'")
         else:
             if self.reason_text is not None:
                 raise ValueError(
-                    "reason_text must not be provided if reason is not other"
+                    "reason_text must not be provided if reason is not 'other'"
                 )
         return self
 
@@ -76,7 +76,7 @@ class RemovalInformation(p.BaseModel):
         if self.reason != "renamed":
             return self
         if self.new_name is None:
-            raise ValueError("new_name must be provided if reason is renamed")
+            raise ValueError("new_name must be provided if reason is 'renamed'")
         if (
             self.redirect_replacement_version is not None
             and self.version != "TBD"
@@ -92,13 +92,13 @@ class RemovalInformation(p.BaseModel):
         if self.reason == "renamed":
             return self
         if self.new_name is not None:
-            raise ValueError("new_name must not be provided if reason is not renamed")
+            raise ValueError("new_name must not be provided if reason is not 'renamed'")
         if self.redirect_replacement_version is not None:
             raise ValueError(
-                "redirect_replacement_version must not be provided if reason is not renamed"
+                "redirect_replacement_version must not be provided if reason is not 'renamed'"
             )
         if self.version == "TBD":
-            raise ValueError("version must not be TBD if reason is not renamed")
+            raise ValueError("version must not be TBD if reason is not 'renamed'")
         return self
 
 

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -73,11 +73,14 @@ class RemovalInformation(p.BaseModel):
             return self
         if self.new_name is None:
             raise ValueError("new_name must be provided if reason is renamed")
-        if self.redirect_replacement_version is not None and self.version != "TBD":
-            if self.redirect_replacement_version >= self.version:
-                raise ValueError(
-                    "redirect_replacement_version must be smaller than version"
-                )
+        if (
+            self.redirect_replacement_version is not None
+            and self.version != "TBD"
+            and self.redirect_replacement_version >= self.version
+        ):
+            raise ValueError(
+                "redirect_replacement_version must be smaller than version"
+            )
         return self
 
     @p.model_validator(mode="after")

--- a/src/antsibull/collection_meta.py
+++ b/src/antsibull/collection_meta.py
@@ -18,7 +18,7 @@ import pydantic as p
 from antsibull_fileutils.yaml import load_yaml_file
 from packaging.version import Version as PypiVer
 from pydantic.functional_validators import BeforeValidator
-from typing_extensions import Annotated
+from typing_extensions import Annotated, Self
 
 if t.TYPE_CHECKING:
     from _typeshed import StrPath
@@ -56,7 +56,7 @@ class RemovalInformation(p.BaseModel):
     redirect_replacement_version: t.Optional[int] = None
 
     @p.model_validator(mode="after")
-    def check_reason_text(self) -> t.Self:
+    def _check_reason_text(self) -> Self:
         if self.reason == "other":
             if self.reason_text is None:
                 raise ValueError("reason_text must be provided if reason is other")
@@ -68,7 +68,7 @@ class RemovalInformation(p.BaseModel):
         return self
 
     @p.model_validator(mode="after")
-    def check_reason_is_renamed(self) -> t.Self:
+    def _check_reason_is_renamed(self) -> Self:
         if self.reason != "renamed":
             return self
         if self.new_name is None:
@@ -81,7 +81,7 @@ class RemovalInformation(p.BaseModel):
         return self
 
     @p.model_validator(mode="after")
-    def check_reason_is_not_renamed(self) -> t.Self:
+    def _check_reason_is_not_renamed(self) -> Self:
         if self.reason == "renamed":
             return self
         if self.new_name is not None:
@@ -122,7 +122,7 @@ class CollectionsMetadata(p.BaseModel):
     collections: dict[str, CollectionMetadata]
 
     @staticmethod
-    def load_from(deps_dir: StrPath | None):
+    def load_from(deps_dir: StrPath | None) -> CollectionsMetadata:
         if deps_dir is None:
             return CollectionsMetadata(collections={})
         collection_meta_path = os.path.join(deps_dir, "collection-meta.yaml")

--- a/src/antsibull/collection_meta_lint.py
+++ b/src/antsibull/collection_meta_lint.py
@@ -37,11 +37,11 @@ class _Validator:
 
         if (
             removal.announce_version is not None
-            and removal.announce_version.major != self.major_release
+            and removal.announce_version.major > self.major_release
         ):
             self.errors.append(
                 f"{prefix} announce_version: Major version of {removal.announce_version}"
-                f" must be the current major version {self.major_release}"
+                f" must not be larger than the current major version {self.major_release}"
             )
 
         if removal.redirect_replacement_version is not None:
@@ -62,9 +62,7 @@ class _Validator:
                 )
 
         if removal.reason == "renamed" and removal.new_name == collection:
-            self.errors.append(
-                f"{prefix} new_name: Must not be the collection's name"
-            )
+            self.errors.append(f"{prefix} new_name: Must not be the collection's name")
 
     def _validate_collection(
         self, collection: str, meta: CollectionMetadata, prefix: str

--- a/src/antsibull/collection_meta_lint.py
+++ b/src/antsibull/collection_meta_lint.py
@@ -1,0 +1,180 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Ansible Project, 2024
+
+"""
+Classes to lint collection-meta.yaml
+"""
+
+from __future__ import annotations
+
+import os
+
+import pydantic as p
+from antsibull_core import app_context
+from antsibull_core.dependency_files import parse_pieces_file
+from antsibull_core.yaml import load_yaml_file
+
+from .collection_meta import CollectionMetadata, CollectionsMetadata, RemovalInformation
+
+
+class _Validator:
+    def __init__(self, *, all_collections: list[str], major_release: int):
+        self.errors: list[str] = []
+        self.all_collections = all_collections
+        self.major_release = major_release
+
+    def _validate_reason_renamed(
+        self, collection: str, removal: RemovalInformation, prefix: str
+    ) -> None:
+        if removal.new_name is None:
+            self.errors.append(
+                f"{prefix} -> new_name: Must be provided if reason is renamed"
+            )
+        elif removal.new_name == collection:
+            self.errors.append(
+                f"{prefix} -> new_name: Must not be the collection's name"
+            )
+
+    def _validate_reason_not_renamed(
+        self,
+        collection: str,  # pylint: disable=unused-argument
+        removal: RemovalInformation,
+        prefix: str,
+    ) -> None:
+        if removal.new_name is not None:
+            self.errors.append(
+                f"{prefix} -> new_name: Must not be provided if reason is not renamed"
+            )
+        if removal.redirect_replacement_version is not None:
+            self.errors.append(
+                f"{prefix} -> redirect_replacement_version: Must not be"
+                " provided if reason is not renamed"
+            )
+        if removal.version == "TBD":
+            self.errors.append(
+                f"{prefix} -> version: Must not be TBD if reason is not renamed"
+            )
+
+    def _validate_removal(
+        self, collection: str, removal: RemovalInformation, prefix: str
+    ) -> None:
+        if removal.version != "TBD" and removal.version <= self.major_release:
+            self.errors.append(
+                f"{prefix} version: Removal version {removal.version} must"
+                f" be larger than current major version {self.major_release}"
+            )
+
+        if (
+            removal.announce_version is not None
+            and removal.announce_version.major != self.major_release
+        ):
+            self.errors.append(
+                f"{prefix} announce_version: Major version of {removal.announce_version}"
+                f" must be the current major version {self.major_release}"
+            )
+
+        if removal.redirect_replacement_version is not None:
+            if removal.redirect_replacement_version <= self.major_release:
+                self.errors.append(
+                    f"{prefix} redirect_replacement_version: Redirect removal version"
+                    f" {removal.redirect_replacement_version} must be larger than"
+                    f" current major version {self.major_release}"
+                )
+            if (
+                removal.version != "TBD"
+                and removal.redirect_replacement_version >= removal.version
+            ):
+                self.errors.append(
+                    f"{prefix} redirect_replacement_version: Redirect removal version"
+                    f" {removal.redirect_replacement_version} must be smaller than"
+                    f" the removal major version {removal.version}"
+                )
+
+        if removal.reason == "renamed":
+            self._validate_reason_renamed(collection, removal, prefix)
+        else:
+            self._validate_reason_not_renamed(collection, removal, prefix)
+
+    def _validate_collection(
+        self, collection: str, meta: CollectionMetadata, prefix: str
+    ) -> None:
+        if meta.repository is None:
+            self.errors.append(f"{prefix} repository: Required field not provided")
+
+        if meta.removal:
+            self._validate_removal(collection, meta.removal, f"{prefix} removal ->")
+
+    def validate(self, data: CollectionsMetadata) -> None:
+        # Check order
+        sorted_list = sorted(data.collections)
+        raw_list = list(data.collections)
+        if raw_list != sorted_list:
+            for raw_entry, sorted_entry in zip(raw_list, sorted_list):
+                if raw_entry != sorted_entry:
+                    self.errors.append(
+                        "The collection list must be sorted; "
+                        f"{sorted_entry!r} must come before {raw_entry}"
+                    )
+                    break
+
+        # Validate collection data
+        remaining_collections = set(self.all_collections)
+        for collection, meta in data.collections.items():
+            if collection not in remaining_collections:
+                self.errors.append(
+                    f"collections -> {collection}: Collection not in ansible.in"
+                )
+            else:
+                remaining_collections.remove(collection)
+            self._validate_collection(
+                collection, meta, f"collections -> {collection} ->"
+            )
+
+        # Complain about remaining collections
+        for collection in sorted(remaining_collections):
+            print(f"collections: No metadata present for {collection}")
+
+
+def lint_collection_meta() -> int:
+    """Lint collection-meta.yaml."""
+    app_ctx = app_context.app_ctx.get()
+
+    major_release: int = app_ctx.extra["ansible_major_version"]
+    data_dir: str = app_ctx.extra["data_dir"]
+    pieces_file: str = app_ctx.extra["pieces_file"]
+
+    validator = _Validator(
+        all_collections=parse_pieces_file(os.path.join(data_dir, pieces_file)),
+        major_release=major_release,
+    )
+
+    for cls in (
+        # NOTE: The order is important here! The most deeply nested classes must come first,
+        #       otherwise extra=forbid might not be used for something deeper in the hierarchy.
+        RemovalInformation,
+        CollectionMetadata,
+        CollectionsMetadata,
+    ):
+        cls.model_config["extra"] = "forbid"
+        cls.model_rebuild(force=True)
+
+    collection_meta_path = os.path.join(data_dir, "collection-meta.yaml")
+    if not os.path.exists(collection_meta_path):
+        validator.errors.append(f"Cannot find {collection_meta_path}")
+    else:
+        data = load_yaml_file(collection_meta_path)
+        try:
+            parsed_data = CollectionsMetadata.parse_obj(data)
+            validator.validate(parsed_data)
+        except p.ValidationError as exc:
+            for error in exc.errors():
+                location = " -> ".join(str(loc) for loc in error["loc"])
+                validator.errors.append(f'{location}: {error["msg"]}')
+
+    for message in validator.errors:
+        print(message)
+
+    return 3 if validator.errors else 0

--- a/src/antsibull/collection_meta_lint.py
+++ b/src/antsibull/collection_meta_lint.py
@@ -26,60 +26,6 @@ class _Validator:
         self.all_collections = all_collections
         self.major_release = major_release
 
-    def _validate_reason_renamed(
-        self, collection: str, removal: RemovalInformation, prefix: str
-    ) -> None:
-        if removal.new_name is None:
-            self.errors.append(
-                f"{prefix} -> new_name: Must be provided if reason is renamed"
-            )
-        elif removal.new_name == collection:
-            self.errors.append(
-                f"{prefix} -> new_name: Must not be the collection's name"
-            )
-
-    def _validate_reason_not_renamed(
-        self,
-        collection: str,  # pylint: disable=unused-argument
-        removal: RemovalInformation,
-        prefix: str,
-    ) -> None:
-        if removal.new_name is not None:
-            self.errors.append(
-                f"{prefix} -> new_name: Must not be provided if reason is not renamed"
-            )
-        if removal.redirect_replacement_version is not None:
-            self.errors.append(
-                f"{prefix} -> redirect_replacement_version: Must not be"
-                " provided if reason is not renamed"
-            )
-        if removal.version == "TBD":
-            self.errors.append(
-                f"{prefix} -> version: Must not be TBD if reason is not renamed"
-            )
-
-    def _validate_reason_other(
-        self,
-        collection: str,  # pylint: disable=unused-argument
-        removal: RemovalInformation,
-        prefix: str,
-    ) -> None:
-        if removal.reason_text is None:
-            self.errors.append(
-                f"{prefix} -> reason_text: Must be provided if reason is other"
-            )
-
-    def _validate_reason_not_other(
-        self,
-        collection: str,  # pylint: disable=unused-argument
-        removal: RemovalInformation,
-        prefix: str,
-    ) -> None:
-        if removal.reason_text is not None:
-            self.errors.append(
-                f"{prefix} -> reason_text: Must not be provided if reason is not other"
-            )
-
     def _validate_removal(
         self, collection: str, removal: RemovalInformation, prefix: str
     ) -> None:
@@ -115,15 +61,10 @@ class _Validator:
                     f" the removal major version {removal.version}"
                 )
 
-        if removal.reason == "renamed":
-            self._validate_reason_renamed(collection, removal, prefix)
-        else:
-            self._validate_reason_not_renamed(collection, removal, prefix)
-
-        if removal.reason == "other":
-            self._validate_reason_other(collection, removal, prefix)
-        else:
-            self._validate_reason_not_other(collection, removal, prefix)
+        if removal.reason == "renamed" and removal.new_name == collection:
+            self.errors.append(
+                f"{prefix} -> new_name: Must not be the collection's name"
+            )
 
     def _validate_collection(
         self, collection: str, meta: CollectionMetadata, prefix: str

--- a/src/antsibull/collection_meta_lint.py
+++ b/src/antsibull/collection_meta_lint.py
@@ -63,7 +63,7 @@ class _Validator:
 
         if removal.reason == "renamed" and removal.new_name == collection:
             self.errors.append(
-                f"{prefix} -> new_name: Must not be the collection's name"
+                f"{prefix} new_name: Must not be the collection's name"
             )
 
     def _validate_collection(

--- a/src/antsibull/collection_meta_lint.py
+++ b/src/antsibull/collection_meta_lint.py
@@ -29,9 +29,12 @@ class _Validator:
     def _validate_removal(
         self, collection: str, removal: RemovalInformation, prefix: str
     ) -> None:
-        if removal.version != "TBD" and removal.version <= self.major_release:
+        if (
+            removal.major_version != "TBD"
+            and removal.major_version <= self.major_release
+        ):
             self.errors.append(
-                f"{prefix} version: Removal version {removal.version} must"
+                f"{prefix} major_version: Removal major version {removal.major_version} must"
                 f" be larger than current major version {self.major_release}"
             )
 
@@ -44,21 +47,21 @@ class _Validator:
                 f" must not be larger than the current major version {self.major_release}"
             )
 
-        if removal.redirect_replacement_version is not None:
-            if removal.redirect_replacement_version <= self.major_release:
+        if removal.redirect_replacement_major_version is not None:
+            if removal.redirect_replacement_major_version <= self.major_release:
                 self.errors.append(
-                    f"{prefix} redirect_replacement_version: Redirect removal version"
-                    f" {removal.redirect_replacement_version} must be larger than"
+                    f"{prefix} redirect_replacement_major_version: Redirect removal version"
+                    f" {removal.redirect_replacement_major_version} must be larger than"
                     f" current major version {self.major_release}"
                 )
             if (
-                removal.version != "TBD"
-                and removal.redirect_replacement_version >= removal.version
+                removal.major_version != "TBD"
+                and removal.redirect_replacement_major_version >= removal.major_version
             ):
                 self.errors.append(
-                    f"{prefix} redirect_replacement_version: Redirect removal version"
-                    f" {removal.redirect_replacement_version} must be smaller than"
-                    f" the removal major version {removal.version}"
+                    f"{prefix} redirect_replacement_major_version: Redirect removal major version"
+                    f" {removal.redirect_replacement_major_version} must be smaller than"
+                    f" the removal major version {removal.major_version}"
                 )
 
         if removal.reason == "renamed" and removal.new_name == collection:

--- a/src/antsibull/collection_meta_lint.py
+++ b/src/antsibull/collection_meta_lint.py
@@ -58,6 +58,28 @@ class _Validator:
                 f"{prefix} -> version: Must not be TBD if reason is not renamed"
             )
 
+    def _validate_reason_other(
+        self,
+        collection: str,  # pylint: disable=unused-argument
+        removal: RemovalInformation,
+        prefix: str,
+    ) -> None:
+        if removal.reason_text is None:
+            self.errors.append(
+                f"{prefix} -> reason_text: Must be provided if reason is other"
+            )
+
+    def _validate_reason_not_other(
+        self,
+        collection: str,  # pylint: disable=unused-argument
+        removal: RemovalInformation,
+        prefix: str,
+    ) -> None:
+        if removal.reason_text is not None:
+            self.errors.append(
+                f"{prefix} -> reason_text: Must not be provided if reason is not other"
+            )
+
     def _validate_removal(
         self, collection: str, removal: RemovalInformation, prefix: str
     ) -> None:
@@ -97,6 +119,11 @@ class _Validator:
             self._validate_reason_renamed(collection, removal, prefix)
         else:
             self._validate_reason_not_renamed(collection, removal, prefix)
+
+        if removal.reason == "other":
+            self._validate_reason_other(collection, removal, prefix)
+        else:
+            self._validate_reason_not_other(collection, removal, prefix)
 
     def _validate_collection(
         self, collection: str, meta: CollectionMetadata, prefix: str

--- a/src/antsibull/collection_meta_lint.py
+++ b/src/antsibull/collection_meta_lint.py
@@ -162,7 +162,7 @@ class _Validator:
 
         # Complain about remaining collections
         for collection in sorted(remaining_collections):
-            print(f"collections: No metadata present for {collection}")
+            self.errors.append(f"collections: No metadata present for {collection}")
 
 
 def lint_collection_meta() -> int:

--- a/src/antsibull/tagging.py
+++ b/src/antsibull/tagging.py
@@ -160,11 +160,11 @@ async def get_collections_tags(
 
     deps_filename = os.path.join(data_dir, deps_filename)
     deps_data = DepsFile(deps_filename).parse()
-    meta_data = CollectionsMetadata(data_dir)
+    meta_data = CollectionsMetadata.load_from(data_dir)
 
     async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
         collection_tags = {}
-        for name, data in meta_data.data.items():
+        for name, data in meta_data.collections.items():
             collection_tags[name] = pool.spawn_n(
                 _get_collection_tags(deps_data.deps[name], data, name)
             )


### PR DESCRIPTION
Ensures that collection-meta.yaml has the right order, the right structure, and that all kind of conditions are right.

Assumes the format from https://github.com/ansible-community/ansible-build-data/pull/450. That PR also fixes the order.

Note that this makes pydantic 2+ a required dependency, and thus also antsibull-core 3+.