### PR TITLE
announcements: fix link to ansible-core changelog

### DIFF
--- a/changelogs/fragments/621-forum-heading.yaml
+++ b/changelogs/fragments/621-forum-heading.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - announcements - fix link to ansible-core changelog in the Ansible package release announcement template
+    (https://github.com/ansible-community/antsibull/pull/621).

--- a/src/antsibull/data/ansible-forum-announcement.j2
+++ b/src/antsibull/data/ansible-forum-announcement.j2
@@ -59,7 +59,7 @@ and you can find a link to the source repository under the “Repository (Source
 
 The changelog for ansible-core {{ core_major_version }} installed by this release of Ansible {{ major_version }} can be found here:
 
-https://github.com/ansible/ansible/blob/v{{ core_major_version }}/changelogs/CHANGELOG-v{{ core_major_version }}.rst
+https://github.com/ansible/ansible/blob/v{{ core_version }}/changelogs/CHANGELOG-v{{ core_major_version }}.rst
 
 {{ ("What's the schedule for new Ansible releases after " ~ version ~ "?") | forum_heading }}
 

--- a/tests/test_data/announce-7.0.0/ansible-forum-announcement.md
+++ b/tests/test_data/announce-7.0.0/ansible-forum-announcement.md
@@ -53,7 +53,7 @@ and you can find a link to the source repository under the “Repository (Source
 
 The changelog for ansible-core 2.14 installed by this release of Ansible 7 can be found here:
 
-https://github.com/ansible/ansible/blob/v2.14/changelogs/CHANGELOG-v2.14.rst
+https://github.com/ansible/ansible/blob/v2.14.0/changelogs/CHANGELOG-v2.14.rst
 
 What's the schedule for new Ansible releases after 7.0.0?
 ---------------------------------------------------------

--- a/tests/test_data/announce-7.0.0b1/ansible-forum-announcement.md
+++ b/tests/test_data/announce-7.0.0b1/ansible-forum-announcement.md
@@ -53,7 +53,7 @@ and you can find a link to the source repository under the “Repository (Source
 
 The changelog for ansible-core 2.14 installed by this release of Ansible 7 can be found here:
 
-https://github.com/ansible/ansible/blob/v2.14/changelogs/CHANGELOG-v2.14.rst
+https://github.com/ansible/ansible/blob/v2.14.0/changelogs/CHANGELOG-v2.14.rst
 
 What's the schedule for new Ansible releases after 7.0.0b1?
 -----------------------------------------------------------

--- a/tests/test_data/announce-7.4.0/ansible-forum-announcement.md
+++ b/tests/test_data/announce-7.4.0/ansible-forum-announcement.md
@@ -53,7 +53,7 @@ and you can find a link to the source repository under the “Repository (Source
 
 The changelog for ansible-core 2.14 installed by this release of Ansible 7 can be found here:
 
-https://github.com/ansible/ansible/blob/v2.14/changelogs/CHANGELOG-v2.14.rst
+https://github.com/ansible/ansible/blob/v2.14.4/changelogs/CHANGELOG-v2.14.rst
 
 What's the schedule for new Ansible releases after 7.4.0?
 ---------------------------------------------------------


### PR DESCRIPTION
The link to the ansible-core changelog in the announcement template is incorrect.