### PR TITLE
Automatically generate changelog entries for deprecated collections

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -30,6 +30,7 @@ jobs:
             python: '3.9'
             antsibull_changelog_ref: 0.24.0
             antsibull_core_ref: main
+            antsibull_docs_parser_ref: 1.1.0
             antsibull_docutils_ref: 1.0.0  # isn't used by antsibull-changelog 0.24.0
             antsibull_fileutils_ref: main
           - name: Ansible 9
@@ -37,6 +38,7 @@ jobs:
             python: '3.11'
             antsibull_changelog_ref: main
             antsibull_core_ref: main
+            antsibull_docs_parser_ref: main
             antsibull_docutils_ref: main
             antsibull_fileutils_ref: main
           - name: Ansible 10
@@ -44,6 +46,7 @@ jobs:
             python: '3.12'
             antsibull_changelog_ref: main
             antsibull_core_ref: main
+            antsibull_docs_parser_ref: main
             antsibull_docutils_ref: main
             antsibull_fileutils_ref: main
           - name: Ansible 11
@@ -51,6 +54,7 @@ jobs:
             python: '3.12'
             antsibull_changelog_ref: main
             antsibull_core_ref: main
+            antsibull_docs_parser_ref: main
             antsibull_docutils_ref: main
             antsibull_fileutils_ref: main
 
@@ -73,6 +77,13 @@ jobs:
           repository: ansible-community/antsibull-core
           path: antsibull-core
           ref: ${{ matrix.antsibull_core_ref }}
+
+      - name: Check out dependent project antsibull-docs-parser
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-docs-parser
+          path: antsibull-docs-parser
+          ref: ${{ matrix.antsibull_docs_parser_ref }}
 
       - name: Check out dependent project antsibull-docutils
         uses: actions/checkout@v4

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           repository: ansible-community/antsibull-changelog
           path: antsibull-changelog
+      - name: Check out dependent project antsibull-docs-parser
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-docs-parser
+          path: antsibull-docs-parser
       - name: Check out dependent project antsibull-docutils
         uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -49,19 +49,20 @@ and install the requirements needed to run the tests there.
 ---
 
 antsibull depends on the sister antsibull-core, antsibull-changelog,
-antsibull-docutils, and antsibull-fileutils projects.
+antsibull-docs-parser, antsibull-docutils, and antsibull-fileutils projects.
 By default, `nox` will install development versions of these projects from
 Github.
-If you're hacking on antsibull-core, antsibull-changelog, antsibull-docutils and/or
-antsibull-fileutils alongside antsibull,
+If you're hacking on antsibull-core, antsibull-changelog, antsibull-docs-parser,
+antsibull-docutils and/or antsibull-fileutils alongside antsibull,
 nox will automatically install the projects from `../antsibull-core`,
-`../antsibull-changelog`, `../antsibull-docutils`, and `../antsibull-fileutils`
-when running tests if those paths exist.
+`../antsibull-changelog`, `../antsibull-docs-parser`, `../antsibull-docutils`,
+and `../antsibull-fileutils` when running tests if those paths exist.
 You can change this behavior through the `OTHER_ANTSIBULL_MODE` env var:
 
 - `OTHER_ANTSIBULL_MODE=auto` — the default behavior described above
 - `OTHER_ANTSIBULL_MODE=local` — install the projects from `../antsibull-core`,
-  `../antsibull-changelog`, `../antsibull-docutils`, and `../antsibull-fileutils`.
+  `../antsibull-changelog`, `../antsibull-docs-parser`, `../antsibull-docutils`,
+  and `../antsibull-fileutils`.
   Fail if those paths don't exist.
 - `OTHER_ANTSIBULL_MODE=git` — install the projects from the Github main branch
 - `OTHER_ANTSIBULL_MODE=pypi` — install the latest version from PyPI
@@ -89,12 +90,13 @@ To create a more complete local development env:
 ``` console
 git clone https://github.com/ansible-community/antsibull-changelog.git
 git clone https://github.com/ansible-community/antsibull-core.git
+git clone https://github.com/ansible-community/antsibull-docs-parser.git
 git clone https://github.com/ansible-community/antsibull-docutils.git
 git clone https://github.com/ansible-community/antsibull.git
 cd antsibull
 python3 -m venv venv
 . ./venv/bin/activate
-pip install -e '.[dev]' -e ../antsibull-changelog -e ../antsibull-core
+pip install -e '.[dev]' -e ../antsibull-changelog -e ../antsibull-core -e ../antsibull-docs-parser -e ../antsibull-docutils
 [...]
 nox
 ```

--- a/changelogs/fragments/623-changelog.yaml
+++ b/changelogs/fragments/623-changelog.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Automatically generate collection deprecation and removal changelog fragments from ``collection-meta.yaml`` information (https://github.com/ansible-community/antsibull/pull/623)."
+  - "Antsibull now depends on antsibull-docs-parser 1.x.y (https://github.com/ansible-community/antsibull/pull/623)."

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,7 @@ def other_antsibull(
     args = (
         "antsibull-core",
         "antsibull-changelog",
+        "antsibull-docs-parser",
         "antsibull-docutils",
         "antsibull-fileutils",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ requires-python = ">=3.9"
 dependencies = [
     "antsibull-changelog >= 0.24.0",
     "antsibull-core >= 3.1.0, < 4.0.0",
+    "antsibull-docs-parser >= 1.1.0, < 2.0.0",
     "antsibull-fileutils >= 1.0.0, < 2.0.0",
     "asyncio-pool",
     "build",

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -591,7 +591,8 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
         if removal.reason_text:
             sentences.append(_markup_to_rst(removal.reason_text))
         sentences.append(
-            "See `Collections Removal Process for collections not satisfying the collection requirements"
+            "See `Collections Removal Process for collections"
+            " not satisfying the collection requirements"
             " <https://docs.ansible.com/ansible/devel/community/collection_contributors/"
             "collection_package_removal.html#collections-not-satisfying-the-collection-requirements"
             f">`__ for more details, including for how this can be cancelled{link}."
@@ -678,7 +679,8 @@ def _get_removed_entry(  # noqa: C901, pylint:disable=too-many-branches
         if removal.reason_text:
             sentences.append(_markup_to_rst(removal.reason_text))
         sentences.append(
-            "See `Collections Removal Process for collections not satisfying the collection requirements"
+            "See `Collections Removal Process for collections"
+            " not satisfying the collection requirements"
             " <https://docs.ansible.com/ansible/devel/community/collection_contributors/"
             "collection_package_removal.html#collections-not-satisfying-the-collection-requirements"
             f">`__ for more details{link}."

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -498,7 +498,7 @@ class Changelog:
         self.collection_metadata = collection_metadata
 
 
-def _get_removal_entry(
+def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
     collection: str,
     removal: RemovalInformation,
 ) -> tuple[ChangelogFragment, str] | None:
@@ -517,10 +517,10 @@ def _get_removal_entry(
             " starts maintaining it again before Ansible {removal.major_version}."
         )
         sentences.append(
-            "See `the removal process for details on how this works"
+            "See `Collections Removal Process for unmaintained collections"
             " <https://docs.ansible.com/ansible/devel/community/collection_contributors/"
-            "collection_package_removal.html#canceling-removal-of-an-unmaintained-collection"
-            f">`__{link}."
+            "collection_package_removal.html#unmaintained-collections"
+            f">` for more details__{link}."
         )
 
     if removal.reason == "considered-unmaintained":

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -549,10 +549,10 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
             f" if no one starts maintaining it again before Ansible {removal.major_version}."
         )
         sentences.append(
-            "See `the removal process for details on how this works"
+            "See `Collections Removal Process for unmaintained collections"
             " <https://docs.ansible.com/ansible/devel/community/collection_contributors/"
-            "collection_package_removal.html#canceling-removal-of-an-unmaintained-collection"
-            f">`__{link}."
+            "collection_package_removal.html#unmaintained-collections"
+            f">`__ for more details, including for how this can be cancelled{link}."
         )
 
     if removal.reason == "renamed":
@@ -591,10 +591,10 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
         if removal.reason_text:
             sentences.append(_markup_to_rst(removal.reason_text))
         sentences.append(
-            "See `the removal process for details on how this works and can be cancelled"
+            "See `Collections Removal Process for collections not satisfying the collection requirements"
             " <https://docs.ansible.com/ansible/devel/community/collection_contributors/"
             "collection_package_removal.html#collections-not-satisfying-the-collection-requirements"
-            f">`__{link}."
+            f">`__ for more details, including for how this can be cancelled{link}."
         )
 
     if removal.reason == "other":
@@ -678,11 +678,9 @@ def _get_removed_entry(  # noqa: C901, pylint:disable=too-many-branches
         if removal.reason_text:
             sentences.append(_markup_to_rst(removal.reason_text))
         sentences.append(
-            "See `Collections Removal Process for"
-            " collections not satisfying the Collection requirements"
+            "See `Collections Removal Process for collections not satisfying the collection requirements"
             " <https://docs.ansible.com/ansible/devel/community/collection_contributors/"
-            "collection_package_removal.html"
-            "#collections-not-satisfying-the-collection-requirements"
+            "collection_package_removal.html#collections-not-satisfying-the-collection-requirements"
             f">`__ for more details{link}."
         )
 

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -538,7 +538,7 @@ def _get_removal_entry(
 
     if removal.reason == "renamed":
         sentences.append(
-            f"The collection ``{collection}`` has been renamed to ``{removal.new_name}``."
+            f"The collection ``{collection}`` was renamed to ``{removal.new_name}``."
         )
         sentences.append("For now both collections are included in Ansible.")
         if removal.redirect_replacement_major_version is not None:
@@ -563,7 +563,9 @@ def _get_removal_entry(
             sentences.append(
                 "The collection will be completely removed from Ansible eventually."
             )
-        sentences.append(f"Please update your FQCNs for ``{collection}``{link}.")
+        sentences.append(
+            f"Please update your FQCNs from ``{collection}`` to ``{removal.new_name}``{link}."
+        )
 
     if removal.reason == "guidelines-violation":
         sentences.append(

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -694,7 +694,7 @@ def _get_removed_entry(  # noqa: C901, pylint:disable=too-many-branches
             sentences.append(_markup_to_rst(removal.reason_text))
         if removal.discussion:
             sentences.append(
-                f"See `the removal discussion for details <{removal.discussion}>`__."
+                f"See `the removal discussion <{removal.discussion}>`__ for details."
             )
         else:
             sentences.append(

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -39,6 +39,10 @@ from antsibull_core.schemas.collection_meta import (
     RemovalInformation,
     RemovedRemovalInformation,
 )
+from antsibull_docs_parser.parser import Context as _AnsibleMarkupContext
+from antsibull_docs_parser.parser import Whitespace as _AnsibleMarkupWhitespace
+from antsibull_docs_parser.parser import parse as _parse_ansible_markup
+from antsibull_docs_parser.rst import to_rst_plain as _ansible_markup_to_rst
 from antsibull_fileutils.yaml import load_yaml_bytes
 from packaging.version import Version as PypiVer
 from semantic_version import Version as SemVer
@@ -499,6 +503,16 @@ class Changelog:
         self.collection_metadata = collection_metadata
 
 
+def _markup_to_rst(markup: str) -> str:
+    return _ansible_markup_to_rst(
+        _parse_ansible_markup(
+            markup,
+            _AnsibleMarkupContext(),
+            whitespace=_AnsibleMarkupWhitespace.KEEP_SINGLE_NEWLINES,
+        )
+    )
+
+
 def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
     collection: str,
     removal: RemovalInformation,
@@ -575,7 +589,7 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
             " due to violations of the Ansible inclusion requirements."
         )
         if removal.reason_text:
-            sentences.append(removal.reason_text)
+            sentences.append(_markup_to_rst(removal.reason_text))
         sentences.append(
             "See `the removal process for details on how this works and can be cancelled"
             " <https://docs.ansible.com/ansible/devel/community/collection_contributors/"
@@ -588,7 +602,7 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
             f"The {collection} collection will be removed from Ansible {removal.major_version}."
         )
         if removal.reason_text:
-            sentences.append(removal.reason_text)
+            sentences.append(_markup_to_rst(removal.reason_text))
         if removal.discussion:
             sentences.append(
                 f"See `the removal discussion for details <{removal.discussion}>`__."
@@ -662,7 +676,7 @@ def _get_removed_entry(  # noqa: C901, pylint:disable=too-many-branches
             " due to violations of the Ansible inclusion requirements."
         )
         if removal.reason_text:
-            sentences.append(removal.reason_text)
+            sentences.append(_markup_to_rst(removal.reason_text))
         sentences.append(
             "See `Collections Removal Process for"
             " collections not satisfying the Collection requirements"
@@ -677,7 +691,7 @@ def _get_removed_entry(  # noqa: C901, pylint:disable=too-many-branches
             f"The {collection} collection has been removed from Ansible {removal.version.major}."
         )
         if removal.reason_text:
-            sentences.append(removal.reason_text)
+            sentences.append(_markup_to_rst(removal.reason_text))
         if removal.discussion:
             sentences.append(
                 f"See `the removal discussion for details <{removal.discussion}>`__."

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -646,13 +646,13 @@ def _get_removed_entry(  # noqa: C901, pylint:disable=too-many-branches
             f"The deprecated ``{collection}`` collection has been removed{link}."
         )
 
-    if removal.reason == "considered-unmaintained":
+    elif removal.reason == "considered-unmaintained":
         sentences.append(
             f"The ``{collection}`` collection was considered unmaintained"
             f" and has been removed from Ansible {removal.version.major}{link}."
         )
 
-    if removal.reason == "renamed":
+    elif removal.reason == "renamed":
         sentences.append(
             f"The collection ``{collection}`` has been completely removed from Ansible."
         )
@@ -671,7 +671,7 @@ def _get_removed_entry(  # noqa: C901, pylint:disable=too-many-branches
             f"Please update your FQCNs from ``{collection}`` to ``{removal.new_name}``{link}."
         )
 
-    if removal.reason == "guidelines-violation":
+    elif removal.reason == "guidelines-violation":
         sentences.append(
             f"The {collection} collection has been removed from Ansible {removal.version.major}"
             " due to violations of the Ansible inclusion requirements."
@@ -686,7 +686,7 @@ def _get_removed_entry(  # noqa: C901, pylint:disable=too-many-branches
             f">`__ for more details{link}."
         )
 
-    if removal.reason == "other":
+    elif removal.reason == "other":
         sentences.append(
             f"The {collection} collection has been removed from Ansible {removal.version.major}."
         )

--- a/src/antsibull/changelog.py
+++ b/src/antsibull/changelog.py
@@ -542,7 +542,7 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
             f">`__ for more details{link}."
         )
 
-    if removal.reason == "considered-unmaintained":
+    elif removal.reason == "considered-unmaintained":
         sentences.append(
             f"The ``{collection}`` collection is considered unmaintained"
             f" and will be removed from Ansible {removal.major_version}"
@@ -555,7 +555,7 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
             f">`__ for more details, including for how this can be cancelled{link}."
         )
 
-    if removal.reason == "renamed":
+    elif removal.reason == "renamed":
         sentences.append(
             f"The collection ``{collection}`` was renamed to ``{removal.new_name}``."
         )
@@ -583,7 +583,7 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
             f"Please update your FQCNs from ``{collection}`` to ``{removal.new_name}``{link}."
         )
 
-    if removal.reason == "guidelines-violation":
+    elif removal.reason == "guidelines-violation":
         sentences.append(
             f"The {collection} collection will be removed from Ansible {removal.major_version}"
             " due to violations of the Ansible inclusion requirements."
@@ -598,7 +598,7 @@ def _get_removal_entry(  # noqa: C901, pylint:disable=too-many-branches
             f">`__ for more details, including for how this can be cancelled{link}."
         )
 
-    if removal.reason == "other":
+    elif removal.reason == "other":
         sentences.append(
             f"The {collection} collection will be removed from Ansible {removal.major_version}."
         )


### PR DESCRIPTION
Uses the data from https://github.com/ansible-community/ansible-build-data/pull/450 to automatically generate changelog fragments for deprecations.