### PR TITLE
Allow to announce a release as EOL

### DIFF
--- a/changelogs/fragments/626-announce-end-of-life.yml
+++ b/changelogs/fragments/626-announce-end-of-life.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add ``--end-of-life`` flag to the ``announcements`` subcommand to announce the last release of a major release train (https://github.com/ansible-community/antsibull/pull/626)."

--- a/src/antsibull/cli/antsibull_build.py
+++ b/src/antsibull/cli/antsibull_build.py
@@ -750,6 +750,12 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         type=Path,
     )
     announcements_parser.add_argument(
+        "--end-of-life",
+        action="store_true",
+        help="Report this version as the End of Life release for this"
+        " major release train",
+    )
+    announcements_parser.add_argument(
         "--send",
         action="store_true",
         help="Interactively send announcements using send-announcements command"

--- a/src/antsibull/data/ansible-forum-announcement.j2
+++ b/src/antsibull/data/ansible-forum-announcement.j2
@@ -67,7 +67,7 @@ https://github.com/ansible/ansible/blob/v{{ core_version }}/changelogs/CHANGELOG
 {{ ("What's the schedule for new Ansible releases after " ~ version ~ "?") | forum_heading }}
 
 {% if end_of_life %}
-This is the last release of Ansible version {{ major_version }}. Ansible {{ major_version }}.X.X will not receive any additional features, bugfixes, or security fixes. From now on we will only have {{ major_version + 1 }}.X.X releases.
+This is the last release of Ansible version {{ major_version }}. Ansible {{ major_version }}.X.X will not receive any additional features, bugfixes, or security fixes. From now on, only Ansible {{ major_version + 1 }}.X.X will receive updates.
 
 {% endif %}
 The next release roadmap can be found at

--- a/src/antsibull/data/ansible-forum-announcement.j2
+++ b/src/antsibull/data/ansible-forum-announcement.j2
@@ -67,7 +67,7 @@ https://github.com/ansible/ansible/blob/v{{ core_version }}/changelogs/CHANGELOG
 {{ ("What's the schedule for new Ansible releases after " ~ version ~ "?") | forum_heading }}
 
 {% if end_of_life %}
-This is the last release of Ansible version {{ major_version }}. No new feature or bugfixes will come for Ansible {{ major_version }}.X.X. From now on we will only have {{ major_version + 1 }}.X.X releases.
+This is the last release of Ansible version {{ major_version }}. Ansible {{ major_version }}.X.X will not receive any additional features, bugfixes, or security fixes. From now on we will only have {{ major_version + 1 }}.X.X releases.
 
 {% endif %}
 The next release roadmap can be found at

--- a/src/antsibull/data/ansible-forum-announcement.j2
+++ b/src/antsibull/data/ansible-forum-announcement.j2
@@ -9,7 +9,7 @@ Hello everyone,
 
 We're happy to announce the release of the Ansible {{ version }} package{% if is_prerelease %} pre-release{% endif %}!
 {% if end_of_life %}
-This is the final {{ major_version }}.X.X release.
+**This is the final {{ major_version }}.X.X release.**
 {% endif %}
 
 Ansible {{ version }} depends on ansible-core {{ core_version }} and includes a curated set of Ansible collections that provide a vast number of modules, plugins, and roles.{% if is_major_release and is_prerelease %} This is a pre-release of Ansible {{ major_version }}.{% elif is_major_release %} This is the first stable release of Ansible {{ major_version }}.{% elif is_prerelease %} This is a pre-release of Ansible.{% endif %}

--- a/src/antsibull/data/ansible-forum-announcement.j2
+++ b/src/antsibull/data/ansible-forum-announcement.j2
@@ -8,6 +8,9 @@
 Hello everyone,
 
 We're happy to announce the release of the Ansible {{ version }} package{% if is_prerelease %} pre-release{% endif %}!
+{% if end_of_life %}
+This is the final {{ major_version }}.X.X release.
+{% endif %}
 
 Ansible {{ version }} depends on ansible-core {{ core_version }} and includes a curated set of Ansible collections that provide a vast number of modules, plugins, and roles.{% if is_major_release and is_prerelease %} This is a pre-release of Ansible {{ major_version }}.{% elif is_major_release %} This is the first stable release of Ansible {{ major_version }}.{% elif is_prerelease %} This is a pre-release of Ansible.{% endif %}
 
@@ -63,6 +66,10 @@ https://github.com/ansible/ansible/blob/v{{ core_version }}/changelogs/CHANGELOG
 
 {{ ("What's the schedule for new Ansible releases after " ~ version ~ "?") | forum_heading }}
 
+{% if end_of_life %}
+This is the last release of Ansible version {{ major_version }}. No new feature or bugfixes will come for Ansible {{ major_version }}.X.X. From now on we will only have {{ major_version + 1 }}.X.X releases.
+
+{% endif %}
 The next release roadmap can be found at
 
 https://docs.ansible.com/ansible/devel/roadmap/ansible_roadmap_index.html

--- a/src/antsibull/data/ansible-matrix-announcement.j2
+++ b/src/antsibull/data/ansible-matrix-announcement.j2
@@ -13,4 +13,8 @@
 python3 -m pip install ansible=={{ version }} --user
 ```
 
+{% if end_of_life %}
+**This is the final {{ major_version }}.X.X release.**
+
+{% endif %}
 ➡️ Check [Release Notes 📦️🗒️]({{ build_data_path }}/CHANGELOG-v{{ major_version }}.md) and [Ansible {{ major_version }} Porting Guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_{{ major_version }}.html) for more details!

--- a/tests/test_data/announce-7.0.0/announcements.json
+++ b/tests/test_data/announce-7.0.0/announcements.json
@@ -42,7 +42,8 @@
       "yanked_reason": null
     },
     "is_major_release": true,
-    "is_prerelease": false
+    "is_prerelease": false,
+    "end_of_life": false
   },
   "outputs": [
     "ansible-forum-announcement.md",

--- a/tests/test_data/announce-7.0.0b1/announcements.json
+++ b/tests/test_data/announce-7.0.0b1/announcements.json
@@ -42,7 +42,8 @@
       "yanked_reason": null
     },
     "is_major_release": true,
-    "is_prerelease": true
+    "is_prerelease": true,
+    "end_of_life": false
   },
   "outputs": [
     "ansible-forum-announcement.md",

--- a/tests/test_data/announce-7.4.0/announcements.json
+++ b/tests/test_data/announce-7.4.0/announcements.json
@@ -42,7 +42,8 @@
       "yanked_reason": null
     },
     "is_major_release": false,
-    "is_prerelease": false
+    "is_prerelease": false,
+    "end_of_life": false
   },
   "outputs": [
     "ansible-forum-announcement.md",


### PR DESCRIPTION
Soon (once Ansible 11 is out) Ansible 9 and Ansible 10 will be End of Life. Right now the announcements are auto-generated and do not allow to mention this. This PR adds a `--end-of-life` option to the `announcements` subcommand that changes this.