### PR TITLE
release role: also feature freeze by default for b10+

### DIFF
--- a/changelogs/fragments/669-betas.yml
+++ b/changelogs/fragments/669-betas.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "build-release role - also enable feature freeze by default for b10 and later beta releases, and not only for b2 to b9 beta releases (https://github.com/ansible-community/antsibull-build/pull/669)."

--- a/roles/build-release/tasks/build.yaml
+++ b/roles/build-release/tasks/build.yaml
@@ -44,7 +44,7 @@
     _feature_freeze: "--feature-frozen"
   when: 
     - not (antsibull_ignore_feature_freeze | bool)
-    - antsibull_ansible_version is regex("^\d+.\d+.\d+(b[2-9]|rc\d+)$")
+    - antsibull_ansible_version is regex("^\d+.\d+.\d+(b[2-9]|b[1-9]\d+|rc\d+)$")
 
 - name: Check whether the ansible deps file exists
   ansible.builtin.stat:


### PR DESCRIPTION
Right now feature freeze is only active for `b2` to `b9`, and for all release candidates, but not for `b10` etc.